### PR TITLE
[config] sonarqube, jacoco 세팅

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,6 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: Build and analyze
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # PR 정보를 가져오려면 필요합니다.
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew build sonar --info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: SonarQube
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'zulu' # Alternative distribution options are available
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonar --info

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.4'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
+    id "org.sonarqube" version "6.0.1.5171"
 }
 
 group = 'idle.table.eat.now'
@@ -19,4 +21,117 @@ repositories {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy 'jacocoTestReport'
+}
+
+
+ext {
+    excludePatterns = [
+        "**/*Application*",
+        "**/Q*",
+        "**/global/**",
+        "**/config/**",
+        "**/exception/**",
+        "**/dto/**",
+        "**/*Filter*",
+        "**/*Handler*",
+        "**/security/**",
+        "**/*Entity*",
+        "**/type/*",
+        "**/resources/**",
+        "**/infrastructure/**",
+        "**/projection/**",
+        "**/command/**",
+        "**/common/**"
+    ]
+
+    def Qdomains = []
+    for (qPattern in '**/QA'..'**/QZ') {
+        Qdomains.add(qPattern + '*')
+    }
+
+    excludePatterns += Qdomains
+}
+
+
+def jacocoDir = layout.buildDirectory.dir("reports/")
+
+jacocoTestReport {
+    dependsOn test
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(true)
+        html.destination jacocoDir.get().file("jacoco/index.html").asFile
+        xml.destination jacocoDir.get().file("jacoco/index.xml").asFile
+        csv.destination jacocoDir.get().file("jacoco/index.csv").asFile
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: rootProject.ext.excludePatterns)
+                })
+        )
+    }
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "HI-dle_table-eat-now"
+        property "sonar.organization", "hi-dle"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property 'sonar.sources', 'src'
+        property 'sonar.language', 'java'
+        property 'sonar.sourceEncoding', 'UTF-8'
+        property 'sonar.exclusions', rootProject.ext.excludePatterns.join(',')
+        property 'sonar.test.inclusions', '**/*Test*.java'
+        property 'sonar.java.coveragePlugin', 'jacoco'
+        property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/jacocoTestReport.xml"
+    }
+}
+
+
+subprojects {
+    apply plugin: 'org.sonarqube' // 플러그인
+
+    sonar {
+        properties {
+            property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/jacocoTestReport.xml"
+        }
+    }
+}
+
+subprojects {
+    group = 'com.sixheroes'
+    version = '0.0.1-SNAPSHOT'
+
+    java {
+        sourceCompatibility = '17'
+    }
+
+    apply plugin: 'java'
+    apply plugin: 'java-library'
+    apply plugin: 'io.spring.dependency-management'
+    apply plugin: 'org.springframework.boot'
+    apply plugin: 'jacoco' // 플러그인
+
+    test {
+        finalizedBy jacocoTestReport // test 후 jacoco 실행
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.required = true
+        }
+
+        afterEvaluate {
+            classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: rootProject.ext.excludePatterns)
+                })
+            )
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #36

## 변경 타입
- [x] 설정

## 변경 내용
- **to-be**
  - [x] sonarqube, jacoco 세팅

## 코멘트
- 각 모듈에서 test를 실행하면 build 파일에 아래와 같이 파일이 생깁니다.
  <img width="429" alt="image" src="https://github.com/user-attachments/assets/69801f56-2346-43e3-b9fd-d1732b16ca00" />

- sonarqube는 build/reports/jacoco/jacocoTestReport.xml를 사용하여 측정합니다.
- 위 사진의 index.html을 열어보면 아래와 같이 커버리지를 확인할 수 있습니다.
  ![image](https://github.com/user-attachments/assets/6df53061-ef31-4075-bc0a-627d96c5acb5)
  - 위의 사진은 아래와 같이 구성하였을때의 결과입니다. (Service파일은 테스트 용으로 만든 임시 파일입니다.)
    <img width="198" alt="image" src="https://github.com/user-attachments/assets/cb669884-20ee-47a3-ae34-5703973c062c" />
  - Application파일은 커버리지에서 제외된 것을 확인할 수 있습니다.
- 제외한 파일의 내용은 아래와 같습니다. 수정이 필요하다면 알려주세요!
   ```gradle
    ext {
        excludePatterns = [
            "**/*Application*",
            "**/Q*",
            "**/global/**",
            "**/config/**",
            "**/exception/**",
            "**/dto/**",
            "**/*Filter*",
            "**/*Handler*",
            "**/security/**",
            "**/*Entity*",
            "**/type/*",
            "**/resources/**",
            "**/infrastructure/**",
            "**/projection/**",
            "**/command/**",
            "**/common/**"
        ]
    
        def Qdomains = []
        for (qPattern in '**/QA'..'**/QZ') {
            Qdomains.add(qPattern + '*')
        }
    
        excludePatterns += Qdomains
    }
   ```
