### PR TITLE
Feat/#27 notification create 구현 및 테스트

### DIFF
--- a/notification/src/main/java/table/eat/now/notification/application/dto/request/CreateNotificationCommand.java
+++ b/notification/src/main/java/table/eat/now/notification/application/dto/request/CreateNotificationCommand.java
@@ -1,0 +1,32 @@
+package table.eat.now.notification.application.dto.request;
+
+import java.time.LocalDateTime;
+import table.eat.now.notification.domain.entity.Notification;
+import table.eat.now.notification.domain.entity.NotificationMethod;
+import table.eat.now.notification.domain.entity.NotificationStatus;
+import table.eat.now.notification.domain.entity.NotificationType;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+
+public record CreateNotificationCommand(Long userId,
+                                        String notificationType,
+                                        String message,
+                                        String status,
+                                        String notificationMethod,
+                                        LocalDateTime scheduledTime) {
+
+  public Notification toEntity() {
+    return Notification.of(
+        userId,
+        NotificationType.valueOf(notificationType),
+        message,
+        NotificationStatus.valueOf(status),
+        NotificationMethod.valueOf(notificationMethod),
+        scheduledTime
+    );
+  }
+
+}

--- a/notification/src/main/java/table/eat/now/notification/application/dto/response/CreateNotificationInfo.java
+++ b/notification/src/main/java/table/eat/now/notification/application/dto/response/CreateNotificationInfo.java
@@ -1,0 +1,33 @@
+package table.eat.now.notification.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import table.eat.now.notification.domain.entity.Notification;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+@Builder
+public record CreateNotificationInfo(UUID notificationUuid,
+                                     Long userId,
+                                     String notificationType,
+                                     String message,
+                                     String status,
+                                     String notificationMethod,
+                                     LocalDateTime scheduledTime) {
+
+  public static CreateNotificationInfo from(Notification notification) {
+    return CreateNotificationInfo.builder()
+        .notificationUuid(notification.getNotificationUuid())
+        .userId(notification.getUserId())
+        .notificationType(notification.getNotificationType().toString())
+        .message(notification.getMessage())
+        .status(notification.getStatus().toString())
+        .notificationMethod(notification.getNotificationMethod().toString())
+        .scheduledTime(notification.getScheduledTime())
+        .build();
+  }
+
+}

--- a/notification/src/main/java/table/eat/now/notification/application/service/NotificationService.java
+++ b/notification/src/main/java/table/eat/now/notification/application/service/NotificationService.java
@@ -1,0 +1,13 @@
+package table.eat.now.notification.application.service;
+
+import table.eat.now.notification.application.dto.request.CreateNotificationCommand;
+import table.eat.now.notification.application.dto.response.CreateNotificationInfo;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+public interface NotificationService {
+
+  CreateNotificationInfo createNotification(CreateNotificationCommand command);
+}

--- a/notification/src/main/java/table/eat/now/notification/application/service/NotificationServiceImpl.java
+++ b/notification/src/main/java/table/eat/now/notification/application/service/NotificationServiceImpl.java
@@ -1,0 +1,24 @@
+package table.eat.now.notification.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import table.eat.now.notification.application.dto.request.CreateNotificationCommand;
+import table.eat.now.notification.application.dto.response.CreateNotificationInfo;
+import table.eat.now.notification.domain.repository.NotificationRepository;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService{
+
+  private final NotificationRepository notificationRepository;
+
+  @Override
+  public CreateNotificationInfo createNotification(CreateNotificationCommand command) {
+    return CreateNotificationInfo
+        .from(notificationRepository.save(command.toEntity()));
+  }
+}

--- a/notification/src/main/java/table/eat/now/notification/domain/entity/Notification.java
+++ b/notification/src/main/java/table/eat/now/notification/domain/entity/Notification.java
@@ -1,0 +1,73 @@
+package table.eat.now.notification.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+@Entity
+@Table(name = "p_notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(100)")
+  private UUID notificationUuid;
+
+  @Column(nullable = false, name = "user_id")
+  private Long userId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, name = "notification_type")
+  private NotificationType notificationType;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String message;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationStatus status;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, name = "notification_method")
+  private NotificationMethod notificationMethod;
+
+  @Column(name = "scheduled_time")
+  private LocalDateTime scheduledTime;
+
+  private Notification(Long userId, NotificationType notificationType,
+      String message, NotificationStatus status, NotificationMethod notificationMethod,
+      LocalDateTime scheduledTime) {
+    this.notificationUuid = UUID.randomUUID();
+    this.userId = userId;
+    this.notificationType = notificationType;
+    this.message = message;
+    this.status = status;
+    this.notificationMethod = notificationMethod;
+    this.scheduledTime = scheduledTime;
+  }
+
+  public static Notification of(Long userId, NotificationType notificationType,
+      String message, NotificationStatus status, NotificationMethod notificationMethod,
+      LocalDateTime scheduledTime) {
+    return new Notification(
+        userId, notificationType, message, status,
+        notificationMethod, scheduledTime);
+  }
+}

--- a/notification/src/main/java/table/eat/now/notification/domain/entity/NotificationMethod.java
+++ b/notification/src/main/java/table/eat/now/notification/domain/entity/NotificationMethod.java
@@ -1,0 +1,11 @@
+package table.eat.now.notification.domain.entity;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+public enum NotificationMethod {
+  SLACK,
+  EMAIL,
+  MESSAGE
+}

--- a/notification/src/main/java/table/eat/now/notification/domain/entity/NotificationStatus.java
+++ b/notification/src/main/java/table/eat/now/notification/domain/entity/NotificationStatus.java
@@ -1,0 +1,11 @@
+package table.eat.now.notification.domain.entity;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+public enum NotificationStatus {
+  PENDING,
+  SENT,
+  FAILED
+}

--- a/notification/src/main/java/table/eat/now/notification/domain/entity/NotificationType.java
+++ b/notification/src/main/java/table/eat/now/notification/domain/entity/NotificationType.java
@@ -1,0 +1,14 @@
+package table.eat.now.notification.domain.entity;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+public enum NotificationType {
+  CONFIRM_OWNER,
+  CONFIRM_CUSTOMER,
+  REMINDER_9AM,
+  REMINDER_1HR,
+  COMPLETION,
+  NO_SHOW
+}

--- a/notification/src/main/java/table/eat/now/notification/domain/repository/NotificationRepository.java
+++ b/notification/src/main/java/table/eat/now/notification/domain/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package table.eat.now.notification.domain.repository;
+
+import table.eat.now.notification.domain.entity.Notification;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+public interface NotificationRepository {
+
+  Notification save(Notification notification);
+}

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/persistence/JpaNotificationRepository.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/persistence/JpaNotificationRepository.java
@@ -1,0 +1,14 @@
+package table.eat.now.notification.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import table.eat.now.notification.domain.entity.Notification;
+import table.eat.now.notification.domain.repository.NotificationRepository;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+public interface JpaNotificationRepository extends
+    JpaRepository<Notification, Long>, NotificationRepository {
+
+}

--- a/notification/src/main/java/table/eat/now/notification/presentation/NotificationAdminController.java
+++ b/notification/src/main/java/table/eat/now/notification/presentation/NotificationAdminController.java
@@ -1,0 +1,47 @@
+package table.eat.now.notification.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+import table.eat.now.common.aop.annotation.AuthCheck;
+import table.eat.now.common.resolver.annotation.CurrentUserInfo;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.notification.application.service.NotificationService;
+import table.eat.now.notification.presentation.dto.request.CreateNotificationRequest;
+import table.eat.now.notification.presentation.dto.response.CreateNotificationResponse;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+@RestController
+@RequestMapping("/admin/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationAdminController {
+
+  private final NotificationService notificationService;
+
+  @PostMapping
+  @AuthCheck(roles = {UserRole.MASTER, UserRole.OWNER, UserRole.STAFF})
+  public ResponseEntity<Void> createNotification(
+      @Valid @RequestBody CreateNotificationRequest request,
+      @CurrentUserInfo CurrentUserInfoDto userInfoDto
+  ) {
+
+    CreateNotificationResponse notificationResponse = CreateNotificationResponse
+        .from(notificationService
+            .createNotification(request.toApplication(userInfoDto)));
+
+    return ResponseEntity.created(UriComponentsBuilder.fromUriString("/admin/v1/notifications")
+            .buildAndExpand(notificationResponse.notificationUuid())
+            .toUri())
+        .build();
+  }
+
+}

--- a/notification/src/main/java/table/eat/now/notification/presentation/dto/request/CreateNotificationRequest.java
+++ b/notification/src/main/java/table/eat/now/notification/presentation/dto/request/CreateNotificationRequest.java
@@ -1,0 +1,41 @@
+package table.eat.now.notification.presentation.dto.request;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
+import table.eat.now.common.resolver.annotation.CurrentUserInfo;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.notification.application.dto.request.CreateNotificationCommand;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+public record CreateNotificationRequest(
+                                        @NotBlank(message = "알림 유형은 필수입니다.")
+                                        @Pattern(regexp = "CONFIRM_OWNER|CONFIRM_CUSTOMER|"
+                                            + "REMINDER_9AM|REMINDER_1HR|COMPLETION|NO_SHOW",
+                                            message = "유효하지 않은 프로모션 상태입니다.")
+                                        String notificationType,
+                                        @NotBlank(message = "메시지는 필수입니다.")
+                                        String message,
+                                        @NotBlank(message = "알림 상태는 필수입니다.")
+                                        @Pattern(regexp = "PENDING|SENT|FAILED", message = "유효하지 않은 프로모션 상태입니다.")
+                                        String status,
+                                        @NotBlank(message = "알림 방식은 필수입니다.")
+                                        @Pattern(regexp = "SLACK|EMAIL|MESSAGE", message = "유효하지 않은 프로모션 상태입니다.")
+                                        String notificationMethod,
+                                        @Future(message = "예약 시간은 현재 이후 시간이어야 합니다.")
+                                        LocalDateTime scheduledTime) {
+  public CreateNotificationCommand toApplication(CurrentUserInfoDto userInfoDto) {
+    return new CreateNotificationCommand(
+        userInfoDto.userId(),
+        notificationType,
+        message,
+        status,
+        notificationMethod,
+        scheduledTime
+    );
+  }
+}

--- a/notification/src/main/java/table/eat/now/notification/presentation/dto/request/CreateNotificationRequest.java
+++ b/notification/src/main/java/table/eat/now/notification/presentation/dto/request/CreateNotificationRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
-import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.notification.application.dto.request.CreateNotificationCommand;
 

--- a/notification/src/main/java/table/eat/now/notification/presentation/dto/response/CreateNotificationResponse.java
+++ b/notification/src/main/java/table/eat/now/notification/presentation/dto/response/CreateNotificationResponse.java
@@ -1,0 +1,32 @@
+package table.eat.now.notification.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import table.eat.now.notification.application.dto.response.CreateNotificationInfo;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+@Builder
+public record CreateNotificationResponse(UUID notificationUuid,
+                                         Long userId,
+                                         String notificationType,
+                                         String message,
+                                         String status,
+                                         String notificationMethod,
+                                         LocalDateTime scheduledTime) {
+  public static CreateNotificationResponse from(CreateNotificationInfo info) {
+    return CreateNotificationResponse.builder()
+        .notificationUuid(info.notificationUuid())
+        .userId(info.userId())
+        .notificationType(info.notificationType())
+        .message(info.message())
+        .status(info.status())
+        .notificationMethod(info.notificationMethod())
+        .scheduledTime(info.scheduledTime())
+        .build();
+  }
+
+}

--- a/notification/src/main/resources/application-test.yml
+++ b/notification/src/main/resources/application-test.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+    username: admin
+    password:
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        spring.jpa.open-in-view: false
+        format_sql: true
+        default_batch_fetch_size: 10
+
+eureka:
+  client:
+    register-with-eureka: false  # Eureka 서버에 등록
+    fetch-registry: false  # Eureka 서버로부터 레지스트리 정보 가져오기

--- a/notification/src/main/resources/application.properties
+++ b/notification/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=notification

--- a/notification/src/test/java/table/eat/now/notification/application/http/notification.http
+++ b/notification/src/test/java/table/eat/now/notification/application/http/notification.http
@@ -1,0 +1,11 @@
+###
+POST http://localhost:8089/admin/v1/notifications
+Content-Type: application/json
+
+{
+  "notificationType": "CONFIRM_OWNER",
+  "message": "예약이 확정되었습니다.",
+  "status": "PENDING",
+  "notificationMethod": "SLACK",
+  "scheduledTime": "2025-04-08T17:00:00"
+}

--- a/notification/src/test/java/table/eat/now/notification/application/service/NotificationServiceImplTest.java
+++ b/notification/src/test/java/table/eat/now/notification/application/service/NotificationServiceImplTest.java
@@ -1,0 +1,61 @@
+package table.eat.now.notification.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import table.eat.now.notification.application.dto.request.CreateNotificationCommand;
+import table.eat.now.notification.application.dto.response.CreateNotificationInfo;
+import table.eat.now.notification.domain.entity.Notification;
+import table.eat.now.notification.domain.repository.NotificationRepository;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+
+  @Mock
+  private NotificationRepository notificationRepository;
+
+  @InjectMocks
+  private NotificationServiceImpl notificationService;
+
+  @DisplayName("알림 생성 서비스 테스트")
+  @Test
+  void notification_create_service_test() {
+      // given
+    CreateNotificationCommand command = new CreateNotificationCommand(
+        1L,
+        "CONFIRM_OWNER",
+        "예약이 확정되었습니다.",
+        "PENDING",
+        "SLACK",
+        LocalDateTime.now().plusHours(1)
+    );
+
+    Notification entity = command.toEntity();
+
+    when(notificationRepository.save(any(Notification.class)))
+        .thenReturn(entity);
+
+    // when
+    CreateNotificationInfo result = notificationService.createNotification(command);
+
+    // then
+    assertThat(result.userId()).isEqualTo(command.userId());
+    assertThat(result.message()).isEqualTo(command.message());
+
+    verify(notificationRepository).save(any(Notification.class));
+  }
+
+}

--- a/notification/src/test/java/table/eat/now/notification/presentation/NotificationAdminControllerTest.java
+++ b/notification/src/test/java/table/eat/now/notification/presentation/NotificationAdminControllerTest.java
@@ -1,0 +1,82 @@
+package table.eat.now.notification.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
+import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.MediaType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.notification.application.dto.response.CreateNotificationInfo;
+import table.eat.now.notification.application.service.NotificationService;
+import table.eat.now.notification.domain.entity.Notification;
+import table.eat.now.notification.presentation.dto.request.CreateNotificationRequest;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 08.
+ */
+@AutoConfigureMockMvc
+@WebMvcTest(NotificationAdminController.class)
+@ActiveProfiles("test")
+class NotificationAdminControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private NotificationService notificationService;
+
+  @DisplayName("알림 생성 테스트")
+  @Test
+  void notification_create_test() throws Exception {
+      // given
+    CreateNotificationRequest request = new CreateNotificationRequest(
+        "CONFIRM_OWNER",
+        "예약이 확정되었습니다.",
+        "PENDING",
+        "SLACK",
+        LocalDateTime.now().plusHours(1)
+    );
+    CurrentUserInfoDto currentUserInfoDto = new CurrentUserInfoDto(1L, UserRole.MASTER);
+    Notification entity = request.toApplication(currentUserInfoDto).toEntity();
+
+    given(notificationService.createNotification(any()))
+        .willReturn(CreateNotificationInfo.from(entity));
+
+
+
+    // when
+    ResultActions resultActions = mockMvc.perform(post("/admin/v1/notifications")
+        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+        .header(USER_ID_HEADER, "1")
+        .header(USER_ROLE_HEADER, "MASTER")
+        .content(objectMapper.writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON));
+
+      // then
+    resultActions.andExpect(status().isCreated())
+        .andExpect(header().string("Location", "/admin/v1/notifications"))
+        .andDo(print());
+  }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #27 

## 변경 타입
- [x] 신규 기능 추가/수정


## 변경 내용


- **to-be**(변경 후 설명을 여기에 작성)

  - [x] notification create 구현 및 테스트


## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 알림 생성 기능이 추가되었습니다. 관리자는 새로운 API 엔드포인트를 통해 알림을 생성할 수 있습니다.
    - 다양한 알림 유형, 상태, 전송 방법(슬랙, 이메일, 메시지) 및 예약 시간을 지정할 수 있습니다.

- **버그 수정**
    - 해당 없음

- **테스트**
    - 알림 생성 서비스 및 관리자 API에 대한 단위 테스트와 통합 테스트가 추가되었습니다.

- **문서화**
    - 알림 생성 API 요청 예시가 추가되었습니다.

- **환경설정**
    - 테스트용 데이터베이스 및 JPA 설정이 추가되었습니다.
    - 불필요한 애플리케이션 이름 속성이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->