### PR TITLE
[reviews] 관리자용 리뷰 검색 기능 추가 및 코드 리팩토링

### DIFF
--- a/review/src/main/java/table/eat/now/review/application/client/RestaurantClient.java
+++ b/review/src/main/java/table/eat/now/review/application/client/RestaurantClient.java
@@ -1,9 +1,12 @@
 package table.eat.now.review.application.client;
 
+import table.eat.now.review.application.service.dto.response.GetRestaurantInfo;
 import table.eat.now.review.application.service.dto.response.GetRestaurantStaffInfo;
 
 public interface RestaurantClient {
 
   GetRestaurantStaffInfo getRestaurantStaffInfo(String restaurantId);
+
+  GetRestaurantInfo getRestaurantInfo(Long userId);
 
 }

--- a/review/src/main/java/table/eat/now/review/application/exception/ReviewErrorCode.java
+++ b/review/src/main/java/table/eat/now/review/application/exception/ReviewErrorCode.java
@@ -11,6 +11,7 @@ public enum ReviewErrorCode implements ErrorCode {
   SERVICE_USER_MISMATCH("서비스 정보와 사용자 정보가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
   REVIEW_IS_INVISIBLE("비공개 처리된 리뷰입니다.", HttpStatus.FORBIDDEN),
   MODIFY_PERMISSION_DENIED("수정 요청에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  REVIEW_ALREADY_EXISTS("이미 해당 서비스에 대한 리뷰가 존재합니다.", HttpStatus.CONFLICT)
   ;
 
   private final String message;

--- a/review/src/main/java/table/eat/now/review/application/service/ReviewService.java
+++ b/review/src/main/java/table/eat/now/review/application/service/ReviewService.java
@@ -2,11 +2,13 @@ package table.eat.now.review.application.service;
 
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.review.application.service.dto.request.CreateReviewCommand;
+import table.eat.now.review.application.service.dto.request.SearchAdminReviewQuery;
 import table.eat.now.review.application.service.dto.request.SearchReviewQuery;
 import table.eat.now.review.application.service.dto.request.UpdateReviewCommand;
 import table.eat.now.review.application.service.dto.response.CreateReviewInfo;
 import table.eat.now.review.application.service.dto.response.GetReviewInfo;
 import table.eat.now.review.application.service.dto.response.PaginatedInfo;
+import table.eat.now.review.application.service.dto.response.SearchAdminReviewInfo;
 import table.eat.now.review.application.service.dto.response.SearchReviewInfo;
 
 public interface ReviewService {
@@ -21,7 +23,9 @@ public interface ReviewService {
 
   GetReviewInfo updateReview(String reviewId, UpdateReviewCommand command);
 
-  PaginatedInfo<SearchReviewInfo> getReviews(SearchReviewQuery query, CurrentUserInfoDto userInfo);
+  PaginatedInfo<SearchReviewInfo> searchReviews(SearchReviewQuery query, CurrentUserInfoDto userInfo);
 
   void deleteReview(String reviewId, CurrentUserInfoDto userInfo);
+
+  PaginatedInfo<SearchAdminReviewInfo> searchAdminReviews(SearchAdminReviewQuery query, CurrentUserInfoDto userInfo);
 }

--- a/review/src/main/java/table/eat/now/review/application/service/dto/request/CreateReviewCommand.java
+++ b/review/src/main/java/table/eat/now/review/application/service/dto/request/CreateReviewCommand.java
@@ -14,8 +14,22 @@ public record CreateReviewCommand(
 
   public Review toEntity() {
     return Review.create(
-        ReviewReference.create(restaurantId, serviceId, customerId, ServiceType.from(serviceType)),
-        ReviewContent.create(content, rating),
-        ReviewVisibility.create(isVisible, customerId, role.name()));
+        this.toReviewReference(),
+        this.toReviewContent(),
+        this.toReviewVisibility()
+    );
+  }
+
+  public ReviewReference toReviewReference() {
+    return ReviewReference
+        .create(restaurantId, serviceId, customerId, ServiceType.from(serviceType));
+  }
+
+  public ReviewContent toReviewContent() {
+    return ReviewContent.create(content, rating);
+  }
+
+  public ReviewVisibility toReviewVisibility() {
+    return ReviewVisibility.create(isVisible, customerId, role.name());
   }
 }

--- a/review/src/main/java/table/eat/now/review/application/service/dto/request/SearchAdminReviewQuery.java
+++ b/review/src/main/java/table/eat/now/review/application/service/dto/request/SearchAdminReviewQuery.java
@@ -3,10 +3,10 @@ package table.eat.now.review.application.service.dto.request;
 import java.time.LocalDate;
 import lombok.Builder;
 import table.eat.now.review.domain.entity.ServiceType;
-import table.eat.now.review.domain.repository.search.SearchReviewCriteria;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewCriteria;
 
 @Builder
-public record SearchReviewQuery(
+public record SearchAdminReviewQuery(
     String orderBy,
     String sort,
     LocalDate startDate,
@@ -19,8 +19,8 @@ public record SearchReviewQuery(
     Boolean isVisible,
     int page, int size) {
 
-  public SearchReviewCriteria toCriteria(Long currentUserId) {
-    return SearchReviewCriteria.builder()
+  public SearchAdminReviewCriteria toCriteria(String accessibleRestaurantId) {
+    return SearchAdminReviewCriteria.builder()
         .orderBy(orderBy)
         .sort(sort)
         .startDate(startDate)
@@ -31,9 +31,10 @@ public record SearchReviewQuery(
         .restaurantId(restaurantId)
         .userId(userId)
         .isVisible(isVisible)
-        .currentUserId(currentUserId)
+        .accessibleRestaurantId(accessibleRestaurantId)
         .page(page)
         .size(size)
         .build();
   }
+
 }

--- a/review/src/main/java/table/eat/now/review/application/service/dto/request/SearchAdminReviewQuery.java
+++ b/review/src/main/java/table/eat/now/review/application/service/dto/request/SearchAdminReviewQuery.java
@@ -19,7 +19,7 @@ public record SearchAdminReviewQuery(
     Boolean isVisible,
     int page, int size) {
 
-  public SearchAdminReviewCriteria toCriteria(String accessibleRestaurantId) {
+  public SearchAdminReviewCriteria toCriteria(String accessibleRestaurantId, boolean isMaster) {
     return SearchAdminReviewCriteria.builder()
         .orderBy(orderBy)
         .sort(sort)
@@ -32,6 +32,7 @@ public record SearchAdminReviewQuery(
         .userId(userId)
         .isVisible(isVisible)
         .accessibleRestaurantId(accessibleRestaurantId)
+        .isMaster(isMaster)
         .page(page)
         .size(size)
         .build();

--- a/review/src/main/java/table/eat/now/review/application/service/dto/response/PaginatedInfo.java
+++ b/review/src/main/java/table/eat/now/review/application/service/dto/response/PaginatedInfo.java
@@ -2,6 +2,7 @@ package table.eat.now.review.application.service.dto.response;
 
 import java.util.List;
 import table.eat.now.review.domain.repository.search.PaginatedResult;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewResult;
 import table.eat.now.review.domain.repository.search.SearchReviewResult;
 
 public record PaginatedInfo<T>(
@@ -11,12 +12,26 @@ public record PaginatedInfo<T>(
     Long totalElements,
     int totalPages) {
 
-  public static PaginatedInfo<SearchReviewInfo> from(
+  public static PaginatedInfo<SearchReviewInfo> fromResult(
       PaginatedResult<SearchReviewResult> result) {
 
     return new PaginatedInfo<>(
         result.content().stream()
             .map(SearchReviewInfo::from)
+            .toList(),
+        result.page(),
+        result.size(),
+        result.totalElements(),
+        result.totalPages()
+    );
+  }
+
+  public static PaginatedInfo<SearchAdminReviewInfo> fromAdminResult(
+      PaginatedResult<SearchAdminReviewResult> result) {
+
+    return new PaginatedInfo<>(
+        result.content().stream()
+            .map(SearchAdminReviewInfo::from)
             .toList(),
         result.page(),
         result.size(),

--- a/review/src/main/java/table/eat/now/review/application/service/dto/response/SearchAdminReviewInfo.java
+++ b/review/src/main/java/table/eat/now/review/application/service/dto/response/SearchAdminReviewInfo.java
@@ -1,0 +1,39 @@
+package table.eat.now.review.application.service.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewResult;
+
+@Builder
+public record SearchAdminReviewInfo(
+    String reviewUuid,
+    Long customerId,
+    String restaurantId,
+    String serviceId,
+    String serviceType,
+    Integer rating,
+    String content,
+    boolean isVisible,
+    Long hiddenBy,
+    String hiddenByRole,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt) {
+
+  public static SearchAdminReviewInfo from(SearchAdminReviewResult result) {
+    return SearchAdminReviewInfo.builder()
+        .reviewUuid(result.reviewUuid())
+        .customerId(result.customerId())
+        .restaurantId(result.restaurantId())
+        .serviceId(result.serviceId())
+        .serviceType(result.serviceType())
+        .rating(result.rating())
+        .content(result.content())
+        .isVisible(result.isVisible())
+        .hiddenBy(result.hiddenBy())
+        .hiddenByRole(result.hiddenByRole())
+        .createdAt(result.createdAt())
+        .updatedAt(result.updatedAt())
+        .build();
+  }
+
+}

--- a/review/src/main/java/table/eat/now/review/domain/entity/Review.java
+++ b/review/src/main/java/table/eat/now/review/domain/entity/Review.java
@@ -82,6 +82,10 @@ public class Review extends BaseEntity {
     super.delete(deletedBy);
   }
 
+  public String getRestaurantId(){
+    return this.getReference().getRestaurantId();
+  }
+
   private Review(ReviewReference reference, ReviewContent content, ReviewVisibility visibility) {
     this.reviewId = UUID.randomUUID().toString();
     this.reference = reference;

--- a/review/src/main/java/table/eat/now/review/domain/entity/ReviewReference.java
+++ b/review/src/main/java/table/eat/now/review/domain/entity/ReviewReference.java
@@ -4,10 +4,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @Embeddable
+@EqualsAndHashCode
 public class ReviewReference {
 
   @Column(name = "restaurant_uuid", nullable = false)
@@ -25,12 +27,14 @@ public class ReviewReference {
 
   public static ReviewReference create(
       String restaurantId, String serviceId, Long customerId, ServiceType serviceType) {
+
     validateNull(restaurantId, serviceId, customerId, serviceType);
     return new ReviewReference(restaurantId, serviceId, customerId, serviceType);
   }
 
   private static void validateNull(
       String restaurantId, String serviceId, Long customerId, ServiceType serviceType) {
+
     if (restaurantId == null || serviceId == null || customerId == null || serviceType == null) {
       throw new IllegalArgumentException("null이 될 수 없습니다.");
     }
@@ -38,6 +42,7 @@ public class ReviewReference {
 
   private ReviewReference(
       String restaurantId, String serviceId, Long customerId, ServiceType serviceType) {
+
     this.restaurantId = restaurantId;
     this.serviceId = serviceId;
     this.customerId = customerId;

--- a/review/src/main/java/table/eat/now/review/domain/entity/ReviewVisibility.java
+++ b/review/src/main/java/table/eat/now/review/domain/entity/ReviewVisibility.java
@@ -30,7 +30,8 @@ public class ReviewVisibility {
 
   public static ReviewVisibility create(Boolean isVisible, Long hiddenBy, String hiddenByRole) {
     validateVisibility(isVisible);
-    return isVisible ? createVisible() : createHidden(hiddenBy, hiddenByRole);
+    return isVisible ?
+        createVisible() : createHidden(hiddenBy, hiddenByRole);
   }
 
   private static void validateVisibility(Boolean isVisible) {
@@ -55,7 +56,8 @@ public class ReviewVisibility {
   }
 
   public ReviewVisibility hide(Long hiddenBy, String hiddenByRole) {
-    return this.isVisible ? createHidden(hiddenBy, hiddenByRole) : this;
+    return this.isVisible ?
+        createHidden(hiddenBy, hiddenByRole) : this;
   }
 
   public ReviewVisibility show(String hiddenByRole) {

--- a/review/src/main/java/table/eat/now/review/domain/repository/ReviewRepository.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/ReviewRepository.java
@@ -2,6 +2,7 @@ package table.eat.now.review.domain.repository;
 
 import java.util.Optional;
 import table.eat.now.review.domain.entity.Review;
+import table.eat.now.review.domain.entity.ReviewReference;
 import table.eat.now.review.domain.repository.search.PaginatedResult;
 import table.eat.now.review.domain.repository.search.SearchAdminReviewCriteria;
 import table.eat.now.review.domain.repository.search.SearchAdminReviewResult;
@@ -17,4 +18,6 @@ public interface ReviewRepository {
   PaginatedResult<SearchReviewResult> searchReviews(SearchReviewCriteria criteria);
 
 	PaginatedResult<SearchAdminReviewResult> searchAdminReviews(SearchAdminReviewCriteria criteria);
+
+  boolean existsByReferenceAndDeletedAtIsNull(ReviewReference reference);
 }

--- a/review/src/main/java/table/eat/now/review/domain/repository/ReviewRepository.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/ReviewRepository.java
@@ -3,6 +3,8 @@ package table.eat.now.review.domain.repository;
 import java.util.Optional;
 import table.eat.now.review.domain.entity.Review;
 import table.eat.now.review.domain.repository.search.PaginatedResult;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewCriteria;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewResult;
 import table.eat.now.review.domain.repository.search.SearchReviewCriteria;
 import table.eat.now.review.domain.repository.search.SearchReviewResult;
 
@@ -13,4 +15,6 @@ public interface ReviewRepository {
   Optional<Review> findByReviewIdAndDeletedAtIsNull(String reviewId);
 
   PaginatedResult<SearchReviewResult> searchReviews(SearchReviewCriteria criteria);
+
+	PaginatedResult<SearchAdminReviewResult> searchAdminReviews(SearchAdminReviewCriteria criteria);
 }

--- a/review/src/main/java/table/eat/now/review/domain/repository/ReviewRepository.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/ReviewRepository.java
@@ -17,7 +17,7 @@ public interface ReviewRepository {
 
   PaginatedResult<SearchReviewResult> searchReviews(SearchReviewCriteria criteria);
 
-	PaginatedResult<SearchAdminReviewResult> searchAdminReviews(SearchAdminReviewCriteria criteria);
+  PaginatedResult<SearchAdminReviewResult> searchAdminReviews(SearchAdminReviewCriteria criteria);
 
   boolean existsByReferenceAndDeletedAtIsNull(ReviewReference reference);
 }

--- a/review/src/main/java/table/eat/now/review/domain/repository/search/SearchAdminReviewCriteria.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/search/SearchAdminReviewCriteria.java
@@ -1,0 +1,24 @@
+package table.eat.now.review.domain.repository.search;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import table.eat.now.review.domain.entity.ServiceType;
+
+@Builder
+public record SearchAdminReviewCriteria(
+    String orderBy,
+    String sort,
+    LocalDate startDate,
+    LocalDate endDate,
+    Integer minRating,
+    Integer maxRating,
+    ServiceType serviceType,
+    String restaurantId,
+    Long userId,
+    Boolean isVisible,
+    String accessibleRestaurantId,
+    int page,
+    int size
+) {
+
+}

--- a/review/src/main/java/table/eat/now/review/domain/repository/search/SearchAdminReviewCriteria.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/search/SearchAdminReviewCriteria.java
@@ -17,6 +17,7 @@ public record SearchAdminReviewCriteria(
     Long userId,
     Boolean isVisible,
     String accessibleRestaurantId,
+    boolean isMaster,
     int page,
     int size
 ) {

--- a/review/src/main/java/table/eat/now/review/domain/repository/search/SearchAdminReviewResult.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/search/SearchAdminReviewResult.java
@@ -1,0 +1,20 @@
+package table.eat.now.review.domain.repository.search;
+
+import java.time.LocalDateTime;
+
+public record SearchAdminReviewResult(
+    String reviewUuid,
+    Long customerId,
+    String restaurantId,
+    String serviceId,
+    String serviceType,
+    Integer rating,
+    String content,
+    Boolean isVisible,
+    Long hiddenBy,
+    String hiddenByRole,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+}

--- a/review/src/main/java/table/eat/now/review/infrastructure/client/feign/DummyRestaurantClientImpl.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/client/feign/DummyRestaurantClientImpl.java
@@ -1,7 +1,9 @@
 package table.eat.now.review.infrastructure.client.feign;
 
+import java.util.UUID;
 import org.springframework.stereotype.Component;
 import table.eat.now.review.application.client.RestaurantClient;
+import table.eat.now.review.application.service.dto.response.GetRestaurantInfo;
 import table.eat.now.review.application.service.dto.response.GetRestaurantStaffInfo;
 
 @Component
@@ -10,5 +12,10 @@ public class DummyRestaurantClientImpl implements RestaurantClient {
   @Override
   public GetRestaurantStaffInfo getRestaurantStaffInfo(String restaurantId) {
     return new GetRestaurantStaffInfo(1L, 2L);
+  }
+
+  @Override
+  public GetRestaurantInfo getRestaurantInfo(Long userId) {
+    return new GetRestaurantInfo(UUID.randomUUID().toString());
   }
 }

--- a/review/src/main/java/table/eat/now/review/infrastructure/persistence/JpaReviewRepository.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/persistence/JpaReviewRepository.java
@@ -3,10 +3,13 @@ package table.eat.now.review.infrastructure.persistence;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import table.eat.now.review.domain.entity.Review;
+import table.eat.now.review.domain.entity.ReviewReference;
 import table.eat.now.review.domain.repository.ReviewRepository;
 
 public interface JpaReviewRepository extends
     JpaRepository<Review, Long>, ReviewRepository, JpaReviewRepositoryCustom {
 
   Optional<Review> findByReviewIdAndDeletedAtIsNull(String reviewId);
+
+  boolean existsByReferenceAndDeletedAtIsNull(ReviewReference reference);
 }

--- a/review/src/main/java/table/eat/now/review/infrastructure/persistence/JpaReviewRepositoryCustom.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/persistence/JpaReviewRepositoryCustom.java
@@ -1,10 +1,14 @@
 package table.eat.now.review.infrastructure.persistence;
 
 import table.eat.now.review.domain.repository.search.PaginatedResult;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewCriteria;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewResult;
 import table.eat.now.review.domain.repository.search.SearchReviewCriteria;
 import table.eat.now.review.domain.repository.search.SearchReviewResult;
 
 public interface JpaReviewRepositoryCustom {
 
   PaginatedResult<SearchReviewResult> searchReviews(SearchReviewCriteria criteria);
+
+  PaginatedResult<SearchAdminReviewResult> searchAdminReviews(SearchAdminReviewCriteria criteria);
 }

--- a/review/src/main/java/table/eat/now/review/infrastructure/persistence/JpaReviewRepositoryCustomImpl.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/persistence/JpaReviewRepositoryCustomImpl.java
@@ -163,7 +163,7 @@ public class JpaReviewRepositoryCustomImpl implements JpaReviewRepositoryCustom 
     }
 
     if(targetUserId != null) {
-      return optionalVisibility == null ? null :
+      return optionalVisibility == null ? isVisible :
           optionalVisibility ? isVisible : Expressions.FALSE;
     }
 

--- a/review/src/main/java/table/eat/now/review/presentation/ReviewAdminController.java
+++ b/review/src/main/java/table/eat/now/review/presentation/ReviewAdminController.java
@@ -1,0 +1,41 @@
+package table.eat.now.review.presentation;
+
+import static table.eat.now.common.resolver.dto.UserRole.MASTER;
+import static table.eat.now.common.resolver.dto.UserRole.OWNER;
+import static table.eat.now.common.resolver.dto.UserRole.STAFF;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import table.eat.now.common.aop.annotation.AuthCheck;
+import table.eat.now.common.resolver.annotation.CurrentUserInfo;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.review.application.service.ReviewService;
+import table.eat.now.review.presentation.dto.request.SearchAdminReviewRequest;
+import table.eat.now.review.presentation.dto.response.PaginatedResponse;
+import table.eat.now.review.presentation.dto.response.SearchAdminReviewResponse;
+
+@RestController
+@RequestMapping("/admin/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewAdminController {
+
+  private final ReviewService reviewService;
+
+  @GetMapping
+  @AuthCheck(roles = {MASTER, OWNER, STAFF})
+  public ResponseEntity<PaginatedResponse<SearchAdminReviewResponse>> searchAdminReviews(
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @Valid SearchAdminReviewRequest request, Pageable pageable) {
+
+    return ResponseEntity.status(HttpStatus.OK).body(
+        PaginatedResponse.fromAdminInfo(
+            reviewService.searchAdminReviews(request.toQuery(pageable), userInfo)));
+
+  }
+}

--- a/review/src/main/java/table/eat/now/review/presentation/ReviewAdminController.java
+++ b/review/src/main/java/table/eat/now/review/presentation/ReviewAdminController.java
@@ -36,6 +36,5 @@ public class ReviewAdminController {
     return ResponseEntity.status(HttpStatus.OK).body(
         PaginatedResponse.fromAdminInfo(
             reviewService.searchAdminReviews(request.toQuery(pageable), userInfo)));
-
   }
 }

--- a/review/src/main/java/table/eat/now/review/presentation/ReviewApiController.java
+++ b/review/src/main/java/table/eat/now/review/presentation/ReviewApiController.java
@@ -1,5 +1,8 @@
 package table.eat.now.review.presentation;
 
+import static table.eat.now.common.resolver.dto.UserRole.CUSTOMER;
+import static table.eat.now.common.resolver.dto.UserRole.MASTER;
+
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 import table.eat.now.common.aop.annotation.AuthCheck;
 import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
-import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.review.application.service.ReviewService;
 import table.eat.now.review.presentation.dto.request.CreateReviewRequest;
 import table.eat.now.review.presentation.dto.request.SearchReviewRequest;
@@ -30,7 +32,7 @@ import table.eat.now.review.presentation.dto.response.SearchReviewResponse;
 @RestController
 @RequestMapping("/api/v1/reviews")
 @RequiredArgsConstructor
-public class ReviewController {
+public class ReviewApiController {
 
   private final ReviewService reviewService;
 
@@ -79,17 +81,17 @@ public class ReviewController {
   }
 
   @GetMapping
-  public ResponseEntity<PaginatedResponse<SearchReviewResponse>> getReviews(
+  public ResponseEntity<PaginatedResponse<SearchReviewResponse>> searchReviews(
       @CurrentUserInfo CurrentUserInfoDto userInfo,
       @Valid SearchReviewRequest request, Pageable pageable) {
 
     return ResponseEntity.status(HttpStatus.OK).body(
-        PaginatedResponse.from(
-            reviewService.getReviews(request.toQuery(pageable), userInfo)));
+        PaginatedResponse.fromInfo(
+            reviewService.searchReviews(request.toQuery(pageable), userInfo)));
   }
 
   @DeleteMapping("/{reviewId}")
-  @AuthCheck(roles = {UserRole.MASTER, UserRole.CUSTOMER})
+  @AuthCheck(roles = {MASTER,CUSTOMER})
   public ResponseEntity<Void> deleteReview(
       @PathVariable UUID reviewId, @CurrentUserInfo CurrentUserInfoDto userInfo) {
 

--- a/review/src/main/java/table/eat/now/review/presentation/dto/request/SearchAdminReviewRequest.java
+++ b/review/src/main/java/table/eat/now/review/presentation/dto/request/SearchAdminReviewRequest.java
@@ -1,0 +1,48 @@
+package table.eat.now.review.presentation.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import table.eat.now.review.application.service.dto.request.SearchAdminReviewQuery;
+import table.eat.now.review.application.service.dto.request.SearchReviewQuery;
+
+public record SearchAdminReviewRequest(
+    @Pattern(regexp = "^(WAITING|RESERVATION)$") String serviceType,
+    @Pattern(regexp = "^(createdAt|rating)$") String orderBy,
+    @Pattern(regexp = "^(desc|asc)$") String sort,
+    @PastOrPresent LocalDate startDate,
+    @PastOrPresent LocalDate endDate,
+    @Max(4) Integer minRating,
+    @Min(1) Integer maxRating,
+    UUID restaurantId,
+    Long userId,
+    Boolean isVisible
+) {
+
+  public SearchAdminReviewRequest {
+    orderBy = orderBy != null ? orderBy : "createdAt";
+    sort = sort != null ? sort : "desc";
+  }
+
+  public SearchAdminReviewQuery toQuery(Pageable pageable) {
+    return SearchAdminReviewQuery.builder()
+        .orderBy(orderBy)
+        .sort(sort)
+        .startDate(startDate)
+        .endDate(endDate)
+        .minRating(minRating)
+        .maxRating(maxRating)
+        .serviceType(serviceType)
+        .restaurantId(restaurantId != null ? restaurantId.toString() : null)
+        .userId(userId)
+        .isVisible(isVisible)
+        .page(pageable.getPageNumber())
+        .size(pageable.getPageSize())
+        .build();
+  }
+
+}

--- a/review/src/main/java/table/eat/now/review/presentation/dto/request/SearchAdminReviewRequest.java
+++ b/review/src/main/java/table/eat/now/review/presentation/dto/request/SearchAdminReviewRequest.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import table.eat.now.review.application.service.dto.request.SearchAdminReviewQuery;
-import table.eat.now.review.application.service.dto.request.SearchReviewQuery;
 
 public record SearchAdminReviewRequest(
     @Pattern(regexp = "^(WAITING|RESERVATION)$") String serviceType,

--- a/review/src/main/java/table/eat/now/review/presentation/dto/response/PaginatedResponse.java
+++ b/review/src/main/java/table/eat/now/review/presentation/dto/response/PaginatedResponse.java
@@ -2,6 +2,7 @@ package table.eat.now.review.presentation.dto.response;
 
 import java.util.List;
 import table.eat.now.review.application.service.dto.response.PaginatedInfo;
+import table.eat.now.review.application.service.dto.response.SearchAdminReviewInfo;
 import table.eat.now.review.application.service.dto.response.SearchReviewInfo;
 
 public record PaginatedResponse<T>(
@@ -11,12 +12,26 @@ public record PaginatedResponse<T>(
     Long totalElements,
     int totalPages) {
 
-  public static PaginatedResponse<SearchReviewResponse> from(
+  public static PaginatedResponse<SearchReviewResponse> fromInfo(
       PaginatedInfo<SearchReviewInfo> info) {
 
     return new PaginatedResponse<>(
         info.content().stream()
             .map(SearchReviewResponse::from)
+            .toList(),
+        info.page(),
+        info.size(),
+        info.totalElements(),
+        info.totalPages()
+    );
+  }
+
+  public static PaginatedResponse<SearchAdminReviewResponse> fromAdminInfo(
+      PaginatedInfo<SearchAdminReviewInfo> info) {
+
+    return new PaginatedResponse<>(
+        info.content().stream()
+            .map(SearchAdminReviewResponse::from)
             .toList(),
         info.page(),
         info.size(),

--- a/review/src/main/java/table/eat/now/review/presentation/dto/response/SearchAdminReviewResponse.java
+++ b/review/src/main/java/table/eat/now/review/presentation/dto/response/SearchAdminReviewResponse.java
@@ -1,0 +1,39 @@
+package table.eat.now.review.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.review.application.service.dto.response.SearchAdminReviewInfo;
+
+@Builder
+public record SearchAdminReviewResponse(
+    String reviewUuid,
+    Long customerId,
+    String restaurantId,
+    String serviceId,
+    String serviceType,
+    Integer rating,
+    String content,
+    boolean isVisible,
+    Long hiddenBy,
+    String hiddenByRole,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt) {
+
+  public static SearchAdminReviewResponse from(SearchAdminReviewInfo info) {
+    return SearchAdminReviewResponse.builder()
+        .reviewUuid(info.reviewUuid())
+        .customerId(info.customerId())
+        .restaurantId(info.restaurantId())
+        .serviceId(info.serviceId())
+        .serviceType(info.serviceType())
+        .rating(info.rating())
+        .content(info.content())
+        .isVisible(info.isVisible())
+        .hiddenBy(info.hiddenBy())
+        .hiddenByRole(info.hiddenByRole())
+        .createdAt(info.createdAt())
+        .updatedAt(info.updatedAt())
+        .build();
+  }
+
+}

--- a/review/src/test/admin-search-review.http
+++ b/review/src/test/admin-search-review.http
@@ -1,0 +1,86 @@
+ ### 1. 리뷰 생성 (사용자 1)
+POST localhost:8087/api/v1/reviews
+Content-Type: application/json
+X-User-Id: 1
+X-User-Role: CUSTOMER
+
+{
+  "serviceType": "RESERVATION",
+  "restaurantId": "123e4567-e89b-12d3-a456-426614174000",
+  "serviceId": "123e4567-e89b-12d3-a456-426614174001",
+  "rating": 4,
+  "content": "리뷰를~~~~공개합니다!11",
+  "isVisible": true
+}
+
+### 2. 비공개 리뷰 생성 (사용자 1)
+POST localhost:8087/api/v1/reviews
+Content-Type: application/json
+X-User-Id: 1
+X-User-Role: CUSTOMER
+
+{
+  "serviceType": "RESERVATION",
+  "restaurantId": "123e4567-e89b-12d3-a456-426614174000",
+  "serviceId": "123e4567-e89b-12d3-a456-426614174002",
+  "rating": 2,
+  "content": "내가쓴비밀일기",
+  "isVisible": false
+}
+
+
+### 3. 다른 사용자의 리뷰 생성 (사용자 2)
+POST localhost:8087/api/v1/reviews
+Content-Type: application/json
+X-User-Id: 2
+X-User-Role: CUSTOMER
+
+{
+  "serviceType": "WAITING",
+  "restaurantId": "123e4567-e89b-12d3-a456-426614174000",
+  "serviceId": "123e4567-e89b-12d3-a456-426614174003",
+  "rating": 5,
+  "content": "절봐주세요",
+  "isVisible": true
+}
+
+### 4. 다른 사용자의 비공개 리뷰 생성 (사용자 2)
+POST localhost:8087/api/v1/reviews
+Content-Type: application/json
+X-User-Id: 2
+X-User-Role: CUSTOMER
+
+{
+  "serviceType": "WAITING",
+  "restaurantId": "123e4567-e89b-12d3-a456-426614174000",
+  "serviceId": "123e4567-e89b-12d3-a456-426614174004",
+  "rating": 1,
+  "content": "제가 보이시나요..?",
+  "isVisible": false
+}
+
+
+### 시나리오 1: 마스터의 검색테스트
+# 결과: 모든 공개, 비공개 리뷰를 조회할 수 있어야 한다
+GET localhost:8087/admin/v1/reviews?restaurantId=123e4567-e89b-12d3-a456-426614174000
+X-User-Id: 1
+X-User-Role: MASTER
+
+### 시나리오 2: 마스터의 검색테스트 (공개리뷰)
+# 결과: 모든 공개리뷰를 조회할 수 있어야 한다
+GET localhost:8087/admin/v1/reviews?isVisible=true
+X-User-Id: 1
+X-User-Role: MASTER
+
+### 시나리오 3: 마스터의 검색테스트 (바공개리뷰)
+# 결과: 모든 비공개리뷰를 조회할 수 있어야 한다
+GET localhost:8087/admin/v1/reviews?isVisible=true
+X-User-Id: 1
+X-User-Role: MASTER
+
+
+### 시나리오 4: 식당 직원의 검색테스트
+# 결과: 모든 공개, 비공개 리뷰를 조회할 수 있어야 한다
+GET localhost:8087/admin/v1/reviews?isVisible=false
+X-User-Id: 1
+X-User-Role: STAFF

--- a/review/src/test/admin-search-review.http
+++ b/review/src/test/admin-search-review.http
@@ -62,7 +62,7 @@ X-User-Role: CUSTOMER
 
 ### 시나리오 1: 마스터의 검색테스트
 # 결과: 모든 공개, 비공개 리뷰를 조회할 수 있어야 한다
-GET localhost:8087/admin/v1/reviews?restaurantId=123e4567-e89b-12d3-a456-426614174000
+GET localhost:8087/admin/v1/reviews?restaurantId=123e4567-e89b-12d3-a456-426614174000&size=30
 X-User-Id: 1
 X-User-Role: MASTER
 
@@ -74,13 +74,13 @@ X-User-Role: MASTER
 
 ### 시나리오 3: 마스터의 검색테스트 (바공개리뷰)
 # 결과: 모든 비공개리뷰를 조회할 수 있어야 한다
-GET localhost:8087/admin/v1/reviews?isVisible=true
+GET localhost:8087/admin/v1/reviews?isVisible=false
 X-User-Id: 1
 X-User-Role: MASTER
 
 
 ### 시나리오 4: 식당 직원의 검색테스트
 # 결과: 모든 공개, 비공개 리뷰를 조회할 수 있어야 한다
-GET localhost:8087/admin/v1/reviews?isVisible=false
+GET localhost:8087/admin/v1/reviews?isVisible=true
 X-User-Id: 1
 X-User-Role: STAFF

--- a/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
+++ b/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
@@ -811,7 +811,8 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchReviewInfo> result = reviewService.searchReviews(myReviewsQuery, userInfo);
+      PaginatedInfo<SearchReviewInfo> result =
+          reviewService.searchReviews(myReviewsQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(2);
@@ -1019,7 +1020,6 @@ class ReviewServiceImplTest {
       otherRestaurantId = UUID.randomUUID().toString();
 
       GetRestaurantInfo restaurantInfo = new GetRestaurantInfo(restaurantId);
-      restaurantInfo = new GetRestaurantInfo(restaurantId);
 
       when(restaurantClient.getRestaurantInfo(ownerId)).thenReturn(restaurantInfo);
       when(restaurantClient.getRestaurantInfo(staffId)).thenReturn(restaurantInfo);
@@ -1059,7 +1059,8 @@ class ReviewServiceImplTest {
     @Test
     void 마스터_권한으로_조회시_모든_리뷰를_반환한다() {
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(query, masterUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result =
+          reviewService.searchAdminReviews(query, masterUserInfo);
 
       // then
       assertThat(result.content()).hasSize(4);
@@ -1076,7 +1077,8 @@ class ReviewServiceImplTest {
     @Test
     void 식당_주인_권한으로_조회시_자신의_식당_리뷰와_다른_공개_리뷰를_반환한다() {
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(query, ownerUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result =
+          reviewService.searchAdminReviews(query, ownerUserInfo);
 
       // then
       assertThat(result.content()).hasSize(3);
@@ -1095,7 +1097,8 @@ class ReviewServiceImplTest {
     @Test
     void 직원_권한으로_조회시_자신의_식당_리뷰와_다른_공개_리뷰를_반환한다() {
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(query, staffUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result =
+          reviewService.searchAdminReviews(query, staffUserInfo);
 
       // then
       assertThat(result.content()).hasSize(3);
@@ -1123,7 +1126,8 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(visibleQuery, masterUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result =
+          reviewService.searchAdminReviews(visibleQuery, masterUserInfo);
 
       // then
       assertThat(result.content()).hasSize(2);
@@ -1149,7 +1153,8 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(invisibleQuery, masterUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result =
+          reviewService.searchAdminReviews(invisibleQuery, masterUserInfo);
 
       // then
       assertThat(result.content()).hasSize(2);
@@ -1197,7 +1202,8 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(userQuery, masterUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result =
+          reviewService.searchAdminReviews(userQuery, masterUserInfo);
 
       // then
       assertThat(result.content()).hasSize(2);
@@ -1214,8 +1220,9 @@ class ReviewServiceImplTest {
     @Test
     void restaurantId로_필터링시_해당_식당의_리뷰만_반환한다() {
       // given
+      String theOtherRestaurantId = UUID.randomUUID().toString();
       SearchAdminReviewQuery restaurantQuery = SearchAdminReviewQuery.builder()
-          .restaurantId(otherRestaurantId)
+          .restaurantId(theOtherRestaurantId)
           .orderBy("createdAt")
           .sort("desc")
           .page(0)
@@ -1225,18 +1232,20 @@ class ReviewServiceImplTest {
       // 다른 식당의 리뷰 추가
       String serviceId = UUID.randomUUID().toString();
       CreateReviewCommand otherRestaurantReview = new CreateReviewCommand(
-          otherRestaurantId, serviceId, customerId, "RESERVATION",
+          theOtherRestaurantId, serviceId, customerId, "RESERVATION",
           "다른 식당 리뷰입니다.", 3, true, CUSTOMER
       );
       Review savedOtherRestaurantReview = reviewRepository.save(otherRestaurantReview.toEntity());
 
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(restaurantQuery, masterUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result = reviewService
+          .searchAdminReviews(restaurantQuery, masterUserInfo);
 
       // then
       assertThat(result.content()).hasSize(1);
-      assertThat(result.content().get(0).reviewUuid()).isEqualTo(savedOtherRestaurantReview.getReviewId());
-      assertThat(result.content().get(0).restaurantId()).isEqualTo(otherRestaurantId);
+      assertThat(result.content().get(0).reviewUuid())
+          .isEqualTo(savedOtherRestaurantReview.getReviewId());
+      assertThat(result.content().get(0).restaurantId()).isEqualTo(theOtherRestaurantId);
     }
 
     @Test
@@ -1251,7 +1260,8 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(waitingQuery, masterUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(waitingQuery,
+          masterUserInfo);
 
       // then
       assertThat(result.content()).hasSize(2);
@@ -1278,7 +1288,8 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(ratingQuery, masterUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(ratingQuery,
+          masterUserInfo);
 
       // then
       assertThat(result.content()).hasSize(2);
@@ -1309,7 +1320,8 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(complexQuery, masterUserInfo);
+      PaginatedInfo<SearchAdminReviewInfo> result = reviewService.searchAdminReviews(complexQuery,
+          masterUserInfo);
 
       // then
       assertThat(result.content()).hasSize(1);

--- a/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
+++ b/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
@@ -714,7 +714,7 @@ class ReviewServiceImplTest {
   }
 
   @Nested
-  class getReviews_는 {
+  class searchReviews_는 {
 
     private String restaurantId;
     private Long customerId;
@@ -769,7 +769,7 @@ class ReviewServiceImplTest {
     @Test
     void 자신의_모든_리뷰와_타인의_공개_리뷰를_반환한다() {
       // when
-      PaginatedInfo<SearchReviewInfo> result = reviewService.getReviews(query, userInfo);
+      PaginatedInfo<SearchReviewInfo> result = reviewService.searchReviews(query, userInfo);
 
       // then
       assertThat(result.content()).hasSize(3);
@@ -795,7 +795,7 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchReviewInfo> result = reviewService.getReviews(myReviewsQuery, userInfo);
+      PaginatedInfo<SearchReviewInfo> result = reviewService.searchReviews(myReviewsQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(2);
@@ -821,7 +821,7 @@ class ReviewServiceImplTest {
 
       // when
       PaginatedInfo<SearchReviewInfo> result =
-          reviewService.getReviews(myPublicReviewsQuery, userInfo);
+          reviewService.searchReviews(myPublicReviewsQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(1);
@@ -843,7 +843,7 @@ class ReviewServiceImplTest {
 
       // when
       PaginatedInfo<SearchReviewInfo> result =
-          reviewService.getReviews(myPrivateReviewsQuery, userInfo);
+          reviewService.searchReviews(myPrivateReviewsQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(1);
@@ -864,7 +864,7 @@ class ReviewServiceImplTest {
 
       // when
       PaginatedInfo<SearchReviewInfo> result =
-          reviewService.getReviews(otherUserReviewsQuery, userInfo);
+          reviewService.searchReviews(otherUserReviewsQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(1);
@@ -885,7 +885,7 @@ class ReviewServiceImplTest {
 
       // when
       PaginatedInfo<SearchReviewInfo> result =
-          reviewService.getReviews(restaurantReviewsQuery, userInfo);
+          reviewService.searchReviews(restaurantReviewsQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(3);
@@ -912,7 +912,7 @@ class ReviewServiceImplTest {
 
       // when
       PaginatedInfo<SearchReviewInfo> result =
-          reviewService.getReviews(waitingReviewsQuery, userInfo);
+          reviewService.searchReviews(waitingReviewsQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(1);
@@ -934,7 +934,7 @@ class ReviewServiceImplTest {
 
       // when
       PaginatedInfo<SearchReviewInfo> result =
-          reviewService.getReviews(highRatingReviewsQuery, userInfo);
+          reviewService.searchReviews(highRatingReviewsQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(2);
@@ -962,7 +962,7 @@ class ReviewServiceImplTest {
           .build();
 
       // when
-      PaginatedInfo<SearchReviewInfo> result = reviewService.getReviews(complexQuery, userInfo);
+      PaginatedInfo<SearchReviewInfo> result = reviewService.searchReviews(complexQuery, userInfo);
 
       // then
       assertThat(result.content()).hasSize(1);

--- a/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
+++ b/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
@@ -157,7 +157,6 @@ class ReviewServiceImplTest {
     private CurrentUserInfoDto otherUserInfo;
     private CurrentUserInfoDto staffInfo;
     private CurrentUserInfoDto ownerInfo;
-    private Review review;
 
     @BeforeEach
     void setUp() {
@@ -183,7 +182,7 @@ class ReviewServiceImplTest {
       );
 
       when(reservationClient.getReservation(serviceId, customerId)).thenReturn(serviceInfo);
-      review = reviewRepository.save(command.toEntity());
+      Review review = reviewRepository.save(command.toEntity());
       reviewId = review.getReviewId();
     }
 
@@ -439,7 +438,6 @@ class ReviewServiceImplTest {
 
     private String reviewId;
     private String restaurantId;
-    private String serviceId;
     private Long staffId;
     private Long ownerId;
     private CurrentUserInfoDto customerInfo;
@@ -450,7 +448,7 @@ class ReviewServiceImplTest {
 
     @BeforeEach
     void setUp() {
-      serviceId = UUID.randomUUID().toString();
+      String serviceId = UUID.randomUUID().toString();
       Long customerId = 123L;
       Long otherUserId = 456L;
       reviewId = UUID.randomUUID().toString();
@@ -993,14 +991,10 @@ class ReviewServiceImplTest {
   @Nested
   class searchAdminReviews_는 {
 
-    private String restaurantId;
-    private String otherRestaurantId;
     private Long customerId;
-    private Long otherUserId;
     private Long staffId;
     private Long ownerId;
     private CurrentUserInfoDto masterUserInfo;
-    private CurrentUserInfoDto customerUserInfo;
     private CurrentUserInfoDto ownerUserInfo;
     private CurrentUserInfoDto staffUserInfo;
     private SearchAdminReviewQuery query;
@@ -1008,24 +1002,23 @@ class ReviewServiceImplTest {
     private Review myPrivateReview;
     private Review otherPublicReview;
     private Review otherPrivateReview;
-    private GetRestaurantInfo restaurantInfo;
+    private String otherRestaurantId;
 
     @BeforeEach
     void setUp() {
       String serviceId = UUID.randomUUID().toString();
-      restaurantId = UUID.randomUUID().toString();
-      otherRestaurantId = UUID.randomUUID().toString();
+      String restaurantId = UUID.randomUUID().toString();
       customerId = 123L;
-      otherUserId = 456L;
+      Long otherUserId = 456L;
       staffId = 789L;
       ownerId = 999L;
 
       masterUserInfo = new CurrentUserInfoDto(otherUserId, MASTER);
-      customerUserInfo = new CurrentUserInfoDto(customerId, CUSTOMER);
       ownerUserInfo = new CurrentUserInfoDto(ownerId, OWNER);
       staffUserInfo = new CurrentUserInfoDto(staffId, STAFF);
+      otherRestaurantId = UUID.randomUUID().toString();
 
-      restaurantInfo = new GetRestaurantInfo(restaurantId);
+      GetRestaurantInfo restaurantInfo = new GetRestaurantInfo(restaurantId);
       restaurantInfo = new GetRestaurantInfo(restaurantId);
 
       when(restaurantClient.getRestaurantInfo(ownerId)).thenReturn(restaurantInfo);
@@ -1221,7 +1214,6 @@ class ReviewServiceImplTest {
     @Test
     void restaurantId로_필터링시_해당_식당의_리뷰만_반환한다() {
       // given
-      String otherRestaurantId = UUID.randomUUID().toString();
       SearchAdminReviewQuery restaurantQuery = SearchAdminReviewQuery.builder()
           .restaurantId(otherRestaurantId)
           .orderBy("createdAt")

--- a/review/src/test/java/table/eat/now/review/presentation/ReviewAdminControllerTest.java
+++ b/review/src/test/java/table/eat/now/review/presentation/ReviewAdminControllerTest.java
@@ -1,0 +1,300 @@
+package table.eat.now.review.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
+import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
+import static table.eat.now.common.resolver.dto.UserRole.CUSTOMER;
+import static table.eat.now.common.resolver.dto.UserRole.MASTER;
+import static table.eat.now.common.resolver.dto.UserRole.OWNER;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.common.aop.AuthCheckAspect;
+import table.eat.now.common.config.WebConfig;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.common.exception.GlobalErrorHandler;
+import table.eat.now.common.exception.type.ApiErrorCode;
+import table.eat.now.common.resolver.CurrentUserInfoResolver;
+import table.eat.now.common.resolver.CustomPageableArgumentResolver;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.review.application.service.ReviewService;
+import table.eat.now.review.application.service.dto.request.SearchAdminReviewQuery;
+import table.eat.now.review.application.service.dto.response.PaginatedInfo;
+import table.eat.now.review.application.service.dto.response.SearchAdminReviewInfo;
+
+@ActiveProfiles("test")
+@Import({
+    WebConfig.class,
+    CustomPageableArgumentResolver.class,
+    CurrentUserInfoResolver.class,
+    GlobalErrorHandler.class,
+    AuthCheckAspect.class
+})
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@WebMvcTest(ReviewAdminController.class)
+class ReviewAdminControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private ReviewService reviewService;
+
+  @Nested
+  class 관리자_리뷰_검색_요청시 {
+
+    private SearchAdminReviewInfo createSearchAdminReviewInfo(
+        String reviewUuid,
+        Long customerId,
+        String restaurantId,
+        String serviceId,
+        String serviceType,
+        int rating,
+        String content,
+        boolean isVisible,
+        Long hiddenBy,
+        String hiddenByRole) {
+
+      return SearchAdminReviewInfo.builder()
+          .reviewUuid(reviewUuid)
+          .customerId(customerId)
+          .restaurantId(restaurantId)
+          .serviceId(serviceId)
+          .serviceType(serviceType)
+          .rating(rating)
+          .content(content)
+          .isVisible(isVisible)
+          .hiddenBy(hiddenBy)
+          .hiddenByRole(hiddenByRole)
+          .createdAt(LocalDateTime.now())
+          .updatedAt(LocalDateTime.now())
+          .build();
+    }
+
+    private UUID restaurantId;
+    private Long userId;
+    private CurrentUserInfoDto masterUserInfo;
+    private CurrentUserInfoDto ownerUserInfo;
+
+    @BeforeEach
+    void setUp() {
+      restaurantId = UUID.randomUUID();
+      userId = 1L;
+      masterUserInfo = new CurrentUserInfoDto(userId, MASTER);
+      ownerUserInfo = new CurrentUserInfoDto(userId, OWNER);
+    }
+
+    @Test
+    void 마스터_권한으로_리뷰목록_조회시_200_상태코드와_페이징된_리뷰목록을_반환한다() throws Exception {
+      // given
+      SearchAdminReviewInfo userReview = createSearchAdminReviewInfo(
+          "review-uuid-1",
+          2L,
+          restaurantId.toString(),
+          "service-1",
+          "RESERVATION",
+          4,
+          "좋은 식당이었습니다.",
+          true,
+          null,
+          null
+      );
+
+      SearchAdminReviewInfo hiddenReview = createSearchAdminReviewInfo(
+          "review-uuid-2",
+          3L,
+          restaurantId.toString(),
+          "service-2",
+          "WAITING",
+          2,
+          "실망스러웠습니다.",
+          false,
+          1L,
+          "MASTER"
+      );
+
+      PaginatedInfo<SearchAdminReviewInfo> paginatedInfo = new PaginatedInfo<>(
+          List.of(userReview, hiddenReview), 0, 10, 2L, 1);
+
+      when(
+          reviewService.searchAdminReviews(any(SearchAdminReviewQuery.class),
+              any(CurrentUserInfoDto.class)))
+          .thenReturn(paginatedInfo);
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/admin/v1/reviews")
+          .header(USER_ID_HEADER, masterUserInfo.userId())
+          .header(USER_ROLE_HEADER, masterUserInfo.role())
+          .param("page", "0")
+          .param("size", "10"));
+
+      // then
+      actions
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content").isArray())
+          .andExpect(jsonPath("$.content.length()").value(2))
+          .andExpect(jsonPath("$.content[0].reviewUuid").value("review-uuid-1"))
+          .andExpect(jsonPath("$.content[0].isVisible").value(true))
+          .andExpect(jsonPath("$.content[1].reviewUuid").value("review-uuid-2"))
+          .andExpect(jsonPath("$.content[1].isVisible").value(false))
+          .andExpect(jsonPath("$.content[1].hiddenBy").value(1))
+          .andExpect(jsonPath("$.content[1].hiddenByRole").value("MASTER"))
+          .andExpect(jsonPath("$.page").value(0))
+          .andExpect(jsonPath("$.size").value(10))
+          .andExpect(jsonPath("$.totalElements").value(2))
+          .andExpect(jsonPath("$.totalPages").value(1));
+    }
+
+    @Test
+    void 식당_주인_권한으로_리뷰목록_조회시_200_상태코드와_페이징된_리뷰목록을_반환한다() throws Exception {
+      // given
+      SearchAdminReviewInfo userReview = createSearchAdminReviewInfo(
+          "review-uuid-1",
+          2L,
+          restaurantId.toString(),
+          "service-1",
+          "RESERVATION",
+          4,
+          "좋은 식당이었습니다.",
+          true,
+          null,
+          null
+      );
+
+      PaginatedInfo<SearchAdminReviewInfo> paginatedInfo = new PaginatedInfo<>(
+          List.of(userReview), 0, 10, 1L, 1);
+
+      when(
+          reviewService.searchAdminReviews(any(SearchAdminReviewQuery.class),
+              any(CurrentUserInfoDto.class)))
+          .thenReturn(paginatedInfo);
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/admin/v1/reviews")
+          .header(USER_ID_HEADER, ownerUserInfo.userId())
+          .header(USER_ROLE_HEADER, ownerUserInfo.role())
+          .param("page", "0")
+          .param("size", "10"));
+
+      // then
+      actions
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content").isArray())
+          .andExpect(jsonPath("$.content.length()").value(1))
+          .andExpect(jsonPath("$.content[0].reviewUuid").value("review-uuid-1"))
+          .andExpect(jsonPath("$.content[0].isVisible").value(true))
+          .andExpect(jsonPath("$.page").value(0))
+          .andExpect(jsonPath("$.size").value(10))
+          .andExpect(jsonPath("$.totalElements").value(1))
+          .andExpect(jsonPath("$.totalPages").value(1));
+    }
+
+    @Test
+    void 필터링_파라미터를_포함한_요청시_200_상태코드와_필터링된_리뷰목록을_반환한다() throws Exception {
+      // given
+      SearchAdminReviewInfo filteredReview = createSearchAdminReviewInfo(
+          "review-uuid-1",
+          2L,
+          restaurantId.toString(),
+          "service-1",
+          "RESERVATION",
+          4,
+          "좋은 식당이었습니다.",
+          true,
+          null,
+          null
+      );
+
+      PaginatedInfo<SearchAdminReviewInfo> paginatedInfo = new PaginatedInfo<>(
+          List.of(filteredReview), 0, 10, 1L, 1);
+
+      when(
+          reviewService.searchAdminReviews(any(SearchAdminReviewQuery.class),
+              any(CurrentUserInfoDto.class)))
+          .thenReturn(paginatedInfo);
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/admin/v1/reviews")
+          .header(USER_ID_HEADER, masterUserInfo.userId())
+          .header(USER_ROLE_HEADER, masterUserInfo.role())
+          .param("serviceType", "RESERVATION")
+          .param("minRating", "4")
+          .param("maxRating", "5")
+          .param("userId", "2")
+          .param("isVisible", "true")
+          .param("page", "0")
+          .param("size", "10"));
+
+      // then
+      actions
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content").isArray())
+          .andExpect(jsonPath("$.content.length()").value(1))
+          .andExpect(jsonPath("$.content[0].reviewUuid").value("review-uuid-1"))
+          .andExpect(jsonPath("$.content[0].serviceType").value("RESERVATION"))
+          .andExpect(jsonPath("$.content[0].rating").value(4))
+          .andExpect(jsonPath("$.content[0].isVisible").value(true));
+    }
+
+    @Test
+    void 권한이_없는_사용자가_접근시_403_상태코드를_반환한다() throws Exception {
+      // given
+      CurrentUserInfoDto customerUserInfo = new CurrentUserInfoDto(userId, CUSTOMER);
+      doThrow(CustomException.from(ApiErrorCode.FORBIDDEN))
+          .when(reviewService).searchAdminReviews(any(SearchAdminReviewQuery.class), any(CurrentUserInfoDto.class));
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/admin/v1/reviews")
+          .header(USER_ID_HEADER, customerUserInfo.userId())
+          .header(USER_ROLE_HEADER, customerUserInfo.role())
+          .param("page", "0")
+          .param("size", "10"));
+
+      // then
+      actions.andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 잘못된_서비스_타입으로_요청시_400_상태코드를_반환한다() throws Exception {
+      // when
+      ResultActions actions = mockMvc.perform(get("/admin/v1/reviews")
+          .header(USER_ID_HEADER, masterUserInfo.userId())
+          .header(USER_ROLE_HEADER, masterUserInfo.role())
+          .param("serviceType", "INVALID_TYPE")
+          .param("page", "0")
+          .param("size", "10"));
+
+      // then
+      actions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 잘못된_정렬_필드로_요청시_400_상태코드를_반환한다() throws Exception {
+      // when
+      ResultActions actions = mockMvc.perform(get("/admin/v1/reviews")
+          .header(USER_ID_HEADER, masterUserInfo.userId())
+          .header(USER_ROLE_HEADER, masterUserInfo.role())
+          .param("orderBy", "invalidField"));
+
+      // then
+      actions.andExpect(status().isBadRequest());
+    }
+  }
+}

--- a/review/src/test/java/table/eat/now/review/presentation/ReviewApiControllerTest.java
+++ b/review/src/test/java/table/eat/now/review/presentation/ReviewApiControllerTest.java
@@ -64,7 +64,7 @@ import table.eat.now.review.presentation.dto.request.UpdateReviewRequest;
 })
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 @WebMvcTest(ReviewApiController.class)
-class ReviewControllerTest {
+class ReviewApiControllerTest {
 
   @Autowired
   private MockMvc mockMvc;

--- a/review/src/test/java/table/eat/now/review/presentation/ReviewControllerTest.java
+++ b/review/src/test/java/table/eat/now/review/presentation/ReviewControllerTest.java
@@ -63,7 +63,7 @@ import table.eat.now.review.presentation.dto.request.UpdateReviewRequest;
     AuthCheckAspect.class
 })
 @EnableAspectJAutoProxy(proxyTargetClass = true)
-@WebMvcTest(ReviewController.class)
+@WebMvcTest(ReviewApiController.class)
 class ReviewControllerTest {
 
   @Autowired
@@ -734,7 +734,7 @@ class ReviewControllerTest {
           List.of(myReview, otherReview), 0, 10, 2L, 1);
 
       when(
-          reviewService.getReviews(any(SearchReviewQuery.class),
+          reviewService.searchReviews(any(SearchReviewQuery.class),
               any(CurrentUserInfoDto.class)))
           .thenReturn(paginatedInfo);
 
@@ -776,7 +776,7 @@ class ReviewControllerTest {
           List.of(myReview), 0, 10, 1L, 1);
 
       when(
-          reviewService.getReviews(any(SearchReviewQuery.class),
+          reviewService.searchReviews(any(SearchReviewQuery.class),
               any(CurrentUserInfoDto.class)))
           .thenReturn(paginatedInfo);
 

--- a/review/src/test/search-review.http
+++ b/review/src/test/search-review.http
@@ -128,27 +128,20 @@ X-User-Id: 1
 X-User-Role: CUSTOMER
 
 
-### 시나리오 13: 마스터의 검색테스트
-# 결과: 모든 공개, 비공개 리뷰를 조회할 수 있어야 한다
-GET localhost:8087/admin/v1/reviews?restaurantId=123e4567-e89b-12d3-a456-426614174000
+### 시나리오 13: 가시성 테스트 (다른 유저에 대한 조회에 가시성필터 적용되는지)
+# 결과 : 아무것도 보이지 않아야 함
+GET localhost:8087/api/v1/reviews?userId=1&isVisible=false
 X-User-Id: 1
-X-User-Role: MASTER
+X-User-Role: CUSTOMER
 
-### 시나리오 13: 마스터의 검색테스트 (공개리뷰)
-# 결과: 모든 공개리뷰를 조회할 수 있어야 한다
-GET localhost:8087/admin/v1/reviews?isVisible=true
+### 시나리오 14: 가시성 테스트 (다른 유저에 대한 조회에 가시성필터 적용되는지)
+# 결과 : 공개리뷰만 보여야함
+GET localhost:8087/api/v1/reviews?userId=2&isVisible=true
 X-User-Id: 1
-X-User-Role: MASTER
+X-User-Role: CUSTOMER
 
-### 시나리오 13: 마스터의 검색테스트 (바공개리뷰)
-# 결과: 모든 비공개리뷰를 조회할 수 있어야 한다
-GET localhost:8087/admin/v1/reviews?isVisible=false
+### 시나리오 15: 가시성 테스트 (다른 유저에 대한 조회에 가시성필터 적용되는지)
+# 결과 : 공개리뷰만 보여야함
+GET localhost:8087/api/v1/reviews?userId=2
 X-User-Id: 1
-X-User-Role: MASTER
-
-
-### 시나리오 14: 식당 직원의 검색테스트
-# 결과: 모든 공개, 비공개 리뷰를 조회할 수 있어야 한다
-GET localhost:8087/admin/v1/reviews?isVisible=false
-X-User-Id: 1
-X-User-Role: STAFF
+X-User-Role: CUSTOMER

--- a/review/src/test/search-review.http
+++ b/review/src/test/search-review.http
@@ -130,7 +130,7 @@ X-User-Role: CUSTOMER
 
 ### 시나리오 13: 가시성 테스트 (다른 유저에 대한 조회에 가시성필터 적용되는지)
 # 결과 : 아무것도 보이지 않아야 함
-GET localhost:8087/api/v1/reviews?userId=1&isVisible=false
+GET localhost:8087/api/v1/reviews?userId=2&isVisible=false
 X-User-Id: 1
 X-User-Role: CUSTOMER
 

--- a/review/src/test/search-review.http
+++ b/review/src/test/search-review.http
@@ -126,3 +126,29 @@ X-User-Role: CUSTOMER
 GET localhost:8087/api/v1/reviews?serviceType=RESERVATION&minRating=3&maxRating=5&orderBy=rating&sort=desc
 X-User-Id: 1
 X-User-Role: CUSTOMER
+
+
+### 시나리오 13: 마스터의 검색테스트
+# 결과: 모든 공개, 비공개 리뷰를 조회할 수 있어야 한다
+GET localhost:8087/admin/v1/reviews?restaurantId=123e4567-e89b-12d3-a456-426614174000
+X-User-Id: 1
+X-User-Role: MASTER
+
+### 시나리오 13: 마스터의 검색테스트 (공개리뷰)
+# 결과: 모든 공개리뷰를 조회할 수 있어야 한다
+GET localhost:8087/admin/v1/reviews?isVisible=true
+X-User-Id: 1
+X-User-Role: MASTER
+
+### 시나리오 13: 마스터의 검색테스트 (바공개리뷰)
+# 결과: 모든 비공개리뷰를 조회할 수 있어야 한다
+GET localhost:8087/admin/v1/reviews?isVisible=false
+X-User-Id: 1
+X-User-Role: MASTER
+
+
+### 시나리오 14: 식당 직원의 검색테스트
+# 결과: 모든 공개, 비공개 리뷰를 조회할 수 있어야 한다
+GET localhost:8087/admin/v1/reviews?isVisible=false
+X-User-Id: 1
+X-User-Role: STAFF


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #93 

## 변경 타입
- [x] 신규 기능 추가/수정
- [x] 리팩토링

## 변경 내용
  - [x] 관리자용 리뷰 검색기능 구현
  - [x] 관리자용 리뷰 검색기능 테스트
  - [x] 리뷰 생성 중복 검증 추가
  - [x] 리뷰 중복검증 테스트
  - [x] 코드 리팩토링

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 관리자용 리뷰 검색 API 및 화면이 추가되어, MASTER, OWNER, STAFF 역할의 사용자가 다양한 조건(서비스 유형, 평점, 기간, 가시성 등)으로 리뷰를 조회할 수 있습니다.
  - 관리자 리뷰 검색을 위한 요청/응답 DTO, 검색 조건, 결과 구조가 도입되었습니다.
  - 리뷰 중복 작성 시 에러 메시지가 제공됩니다.

- **버그 수정**
  - 리뷰 생성 시 중복 여부 및 서비스 사용자 일치 여부에 대한 검증이 강화되었습니다.

- **리팩터**
  - 기존 리뷰 검색 API, 서비스, 컨트롤러, 테스트의 명칭 및 구조가 일관성 있게 변경되었습니다.

- **테스트**
  - 관리자 리뷰 검색 API 및 기능에 대한 단위/통합 테스트, HTTP 시나리오 테스트가 추가되었습니다.
  - 기존 리뷰 검색 테스트가 최신 구조에 맞게 개선되었습니다.

- **문서화**
  - 관리자 및 사용자 리뷰 검색 관련 HTTP 테스트 시나리오가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->