### PR TITLE
[payment] 결제 생성 구현

### DIFF
--- a/payment/src/main/java/table/eat/now/payment/PaymentApplication.java
+++ b/payment/src/main/java/table/eat/now/payment/PaymentApplication.java
@@ -2,7 +2,9 @@ package table.eat.now.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class PaymentApplication {
 

--- a/payment/src/main/java/table/eat/now/payment/payment/application/PaymentService.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/PaymentService.java
@@ -1,6 +1,9 @@
 package table.eat.now.payment.payment.application;
 
+import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
+import table.eat.now.payment.payment.application.dto.response.CreatePaymentInfo;
+
 public interface PaymentService {
 
-  void doNothing();
+  CreatePaymentInfo createPayment(CreatePaymentCommand command);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/PaymentServiceImpl.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/PaymentServiceImpl.java
@@ -1,10 +1,42 @@
 package table.eat.now.payment.payment.application;
 
+import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH;
+import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.RESERVATION_NOT_PENDING;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.payment.payment.application.client.ReservationClient;
+import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
+import table.eat.now.payment.payment.application.dto.response.CreatePaymentInfo;
+import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+import table.eat.now.payment.payment.domain.repository.PaymentRepository;
 
 @Service
+@RequiredArgsConstructor
 public class PaymentServiceImpl implements PaymentService {
 
-  public void doNothing() {
+  private final PaymentRepository paymentRepository;
+  private final ReservationClient reservationClient;
+
+  @Override
+  public CreatePaymentInfo createPayment(CreatePaymentCommand command) {
+    validateReservation(command);
+    return CreatePaymentInfo.from(paymentRepository.save(command.toEntity()));
+  }
+
+  private void validateReservation(CreatePaymentCommand command) {
+    GetReservationInfo reservationInfo = getReservationInfo(command);
+
+    if (reservationInfo.totalAmount().compareTo(command.originalAmount()) != 0) {
+      throw CustomException.from(PAYMENT_AMOUNT_MISMATCH);
+    }
+    if (!reservationInfo.status().equals("PENDING_PAYMENT")){
+      throw CustomException.from(RESERVATION_NOT_PENDING);
+    }
+  }
+
+  private GetReservationInfo getReservationInfo(CreatePaymentCommand command) {
+    return reservationClient.getReservation(command.reservationUuid());
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/ReservationClient.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/ReservationClient.java
@@ -1,0 +1,8 @@
+package table.eat.now.payment.payment.application.client;
+
+import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+
+public interface ReservationClient {
+
+  GetReservationInfo getReservation(String reservationUuid);
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/dto/request/CreatePaymentCommand.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/dto/request/CreatePaymentCommand.java
@@ -1,0 +1,28 @@
+package table.eat.now.payment.payment.application.dto.request;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import table.eat.now.payment.payment.domain.entity.Payment;
+import table.eat.now.payment.payment.domain.entity.PaymentAmount;
+import table.eat.now.payment.payment.domain.entity.PaymentReference;
+
+@Builder
+public record CreatePaymentCommand(
+    String reservationUuid,
+    String restaurantUuid,
+    Long customerId,
+    String reservationName,
+    BigDecimal originalAmount) {
+
+  public PaymentReference toReference() {
+    return PaymentReference.create(
+        reservationUuid, restaurantUuid, customerId, reservationName);
+  }
+
+  public Payment toEntity() {
+    return Payment.create(this.toReference(), PaymentAmount.create(originalAmount));
+  }
+}
+
+
+

--- a/payment/src/main/java/table/eat/now/payment/payment/application/dto/response/CreatePaymentInfo.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/dto/response/CreatePaymentInfo.java
@@ -1,0 +1,26 @@
+package table.eat.now.payment.payment.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.payment.payment.domain.entity.Payment;
+
+@Builder
+public record CreatePaymentInfo(
+    String paymentUuid,
+    String idempotencyKey,
+    String paymentStatus,
+    BigDecimal originalAmount,
+    LocalDateTime createdAt
+) {
+
+  public static CreatePaymentInfo from(Payment payment) {
+    return CreatePaymentInfo.builder()
+        .paymentUuid(payment.getIdentifier().getPaymentUuid())
+        .idempotencyKey(payment.getIdentifier().getIdempotencyKey())
+        .paymentStatus(payment.getPaymentStatus().name())
+        .originalAmount(payment.getAmount().getOriginalAmount())
+        .createdAt(payment.getCreatedAt())
+        .build();
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/dto/response/GetReservationInfo.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/dto/response/GetReservationInfo.java
@@ -1,0 +1,16 @@
+package table.eat.now.payment.payment.application.dto.response;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+
+@Builder
+public record GetReservationInfo(
+    String reservationUuid,
+    String restaurantUuid,
+    Long customerId,
+    String reservationName,
+    String status,
+    BigDecimal totalAmount
+) {
+
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/exception/PaymentErrorCode.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/exception/PaymentErrorCode.java
@@ -1,0 +1,25 @@
+package table.eat.now.payment.payment.application.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import table.eat.now.common.exception.type.ErrorCode;
+
+@Getter
+public enum PaymentErrorCode implements ErrorCode {
+
+  PAYMENT_NOT_FOUND("해당 결제 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+  RESERVATION_NOT_FOUND("존재하지 않는 예약입니다.", HttpStatus.NOT_FOUND),
+  PAYMENT_AMOUNT_MISMATCH("결제 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+  RESERVATION_NOT_PENDING("결제 대기 상태의 예약만 결제할 수 있습니다.", HttpStatus.BAD_REQUEST)
+
+  ;
+
+  private final String message;
+  private final HttpStatus status;
+
+  PaymentErrorCode(String message, HttpStatus status) {
+    this.message = message;
+    this.status = status;
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentAmount.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentAmount.java
@@ -1,0 +1,86 @@
+package table.eat.now.payment.payment.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import lombok.Getter;
+
+@Getter
+@Embeddable
+public class PaymentAmount {
+
+  @Column(name = "original_amount", nullable = false, precision = 8)
+  private BigDecimal originalAmount;
+
+  @Column(name = "discount_amount", precision = 8)
+  private BigDecimal discountAmount;
+
+  @Column(name = "total_amount", precision = 8)
+  private BigDecimal totalAmount;
+
+  public static PaymentAmount create(BigDecimal originalAmount) {
+    validateAmount(originalAmount);
+    return new PaymentAmount(originalAmount, null, null);
+  }
+
+  private static void validateAmount(BigDecimal amount) {
+    if (amount == null) {
+      throw new IllegalArgumentException("금액은 null이 될 수 없습니다");
+    }
+    if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new IllegalArgumentException("금액은 0보다 커야 합니다");
+    }
+    validatePrecision(amount);
+  }
+
+  private static void validatePrecision(BigDecimal amount) {
+    if (amount.precision() - amount.scale() > 8) {
+      throw new IllegalArgumentException("금액은 최대 8자리 정수를 초과할 수 없습니다");
+    }
+
+    if (amount.scale() > 0) {
+      throw new IllegalArgumentException("금액은 정수여야 합니다");
+    }
+  }
+
+  public PaymentAmount confirm(BigDecimal discountAmount, BigDecimal totalAmount) {
+    validateAmount(totalAmount);
+    discountAmount = discountAmount == null ? BigDecimal.ZERO : discountAmount;
+    validateDiscountAmount(discountAmount);
+    validateTotalAmount(discountAmount, totalAmount);
+
+    return new PaymentAmount(this.originalAmount, discountAmount, totalAmount);
+  }
+
+  private void validateDiscountAmount(BigDecimal discountAmount) {
+    if (discountAmount.compareTo(BigDecimal.ZERO) > 0) {
+      validatePrecision(discountAmount);
+      validateDiscountRange(discountAmount);
+    }
+  }
+
+  private void validateDiscountRange(BigDecimal discountAmount) {
+    if (discountAmount.compareTo(this.originalAmount) > 0) {
+      throw new IllegalArgumentException("할인 금액은 원래 금액보다 클 수 없습니다");
+    }
+  }
+
+  private void validateTotalAmount(BigDecimal discountAmount, BigDecimal totalAmount) {
+    BigDecimal expectedTotal = this.originalAmount.subtract(discountAmount);
+    if (!expectedTotal.equals(totalAmount)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "총 금액이 일치하지 않습니다. 예상: %s, 실제: %s", expectedTotal, totalAmount));
+    }
+  }
+
+  private PaymentAmount(
+      BigDecimal originalAmount, BigDecimal discountAmount, BigDecimal totalAmount) {
+    this.originalAmount = originalAmount;
+    this.discountAmount = discountAmount;
+    this.totalAmount = totalAmount;
+  }
+
+  protected PaymentAmount() {
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentIdentifier.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentIdentifier.java
@@ -9,11 +9,23 @@ import lombok.Getter;
 @Embeddable
 public class PaymentIdentifier {
 
-  @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(100)")
-  private UUID paymentUuid;
+  @Column(nullable = false, unique = true)
+  private String paymentUuid;
 
-  @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(100)")
-  private UUID idempotencyKey;
+  @Column(nullable = false, unique = true)
+  private String idempotencyKey;
+
+  public static PaymentIdentifier create() {
+    return new PaymentIdentifier(
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString()
+    );
+  }
+
+  private PaymentIdentifier(String paymentUuid, String idempotencyKey) {
+    this.paymentUuid = paymentUuid;
+    this.idempotencyKey = idempotencyKey;
+  }
 
   protected PaymentIdentifier() {
   }

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentReference.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentReference.java
@@ -9,14 +9,44 @@ import lombok.Getter;
 @Embeddable
 public class PaymentReference {
 
-  @Column(name = "restaurant_uuid", nullable = false, columnDefinition = "VARCHAR(100)")
-  private UUID restaurantId;
+  @Column(name = "restaurant_uuid", nullable = false)
+  private String restaurantId;
 
-  @Column(name = "reservation_uuid", nullable = false, columnDefinition = "VARCHAR(100)")
-  private UUID reservationId;
+  @Column(name = "reservation_uuid", nullable = false)
+  private String reservationId;
 
-  @Column(name = "customer_id", nullable = false, columnDefinition = "VARCHAR(100)")
+  @Column(name = "customer_id", nullable = false)
   private Long customerId;
+
+  @Column(name = "customer_key", nullable = false)
+  private String customerKey;
+
+  @Column(name = "reservation_name", nullable = false)
+  private String reservationName;
+
+  public static PaymentReference create(
+      String restaurantId, String reservationId, Long customerId, String reservationName) {
+
+    validateNull(restaurantId, reservationId, customerId, reservationName);
+    return new PaymentReference(restaurantId, reservationId, customerId, reservationName);
+  }
+
+  private static void validateNull(
+      String restaurantId, String reservationId, Long customerId, String reservationName) {
+
+    if(restaurantId == null || reservationId == null || customerId == null || reservationName == null) {
+      throw new IllegalArgumentException("null이 될 수 없습니다.");
+    }
+  }
+
+  private PaymentReference(
+      String restaurantId, String reservationId, Long customerId, String reservationName) {
+    this.restaurantId = restaurantId;
+    this.reservationId = reservationId;
+    this.customerId = customerId;
+    this.customerKey = UUID.randomUUID().toString();
+    this.reservationName = reservationName;
+  }
 
   protected PaymentReference() {
   }

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentStatus.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentStatus.java
@@ -2,7 +2,6 @@ package table.eat.now.payment.payment.domain.entity;
 
 public enum PaymentStatus {
   CREATED,
-  REQUESTED,
   APPROVED,
   CANCELED,
   REFUNDED,

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/repository/PaymentRepository.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/repository/PaymentRepository.java
@@ -1,5 +1,8 @@
 package table.eat.now.payment.payment.domain.repository;
 
+import table.eat.now.payment.payment.domain.entity.Payment;
+
 public interface PaymentRepository {
 
+  Payment save(Payment entity);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/DummyReservationClientImpl.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/DummyReservationClientImpl.java
@@ -1,0 +1,34 @@
+package table.eat.now.payment.payment.infrastructure.client;
+
+import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.RESERVATION_NOT_FOUND;
+
+import java.math.BigDecimal;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.payment.payment.application.client.ReservationClient;
+import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+
+@Primary
+@Component
+public class DummyReservationClientImpl implements ReservationClient {
+
+  @Override
+  public GetReservationInfo getReservation(String reservationUuid) {
+    String nonValidUUID  = "00000000-0000-0000-0000-000000000000";
+    String validUUID = "00000000-0000-0000-0000-000000000001";
+
+    if (nonValidUUID.equals(reservationUuid)) {
+      throw CustomException.from(RESERVATION_NOT_FOUND);
+    }
+
+    return GetReservationInfo.builder()
+        .reservationUuid(reservationUuid)
+        .restaurantUuid(validUUID)
+        .customerId(123L)
+        .reservationName("하이들하신가")
+        .status("PENDING_PAYMENT")
+        .totalAmount(new BigDecimal("45000"))
+        .build();
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/ReservationClientImpl.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/ReservationClientImpl.java
@@ -1,0 +1,19 @@
+package table.eat.now.payment.payment.infrastructure.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import table.eat.now.payment.payment.application.client.ReservationClient;
+import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+import table.eat.now.payment.payment.infrastructure.client.feign.ReservationFeignClient;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationClientImpl implements ReservationClient {
+
+  private final ReservationFeignClient reservationFeignClient;
+
+  @Override
+  public GetReservationInfo getReservation(String reservationUuid) {
+    return reservationFeignClient.getReservation(reservationUuid).toInfo();
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/config/FeignConfig.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/config/FeignConfig.java
@@ -1,0 +1,26 @@
+package table.eat.now.payment.payment.infrastructure.client.config;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignConfig {
+  @Bean
+  public RequestInterceptor requestInterceptor() {
+    return requestTemplate -> {
+      ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+      if (attrs != null) {
+        HttpServletRequest request = attrs.getRequest();
+        String userId = request.getHeader("X-User-Id");
+        String role = request.getHeader("X-User-Role");
+
+        if (userId != null) requestTemplate.header("X-User-Id", userId);
+        if (role != null) requestTemplate.header("X-User-Role", role);
+      }
+    };
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/GetReservationResponse.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/GetReservationResponse.java
@@ -1,0 +1,12 @@
+package table.eat.now.payment.payment.infrastructure.client.dto;
+
+import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+
+//Todo : internal 형식물어보기
+public record GetReservationResponse() {
+
+  public GetReservationInfo toInfo(){
+    return null;
+  }
+
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/feign/ReservationFeignClient.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/feign/ReservationFeignClient.java
@@ -1,0 +1,14 @@
+package table.eat.now.payment.payment.infrastructure.client.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import table.eat.now.payment.payment.infrastructure.client.config.FeignConfig;
+import table.eat.now.payment.payment.infrastructure.client.dto.GetReservationResponse;
+
+@FeignClient(name = "reservation", configuration = FeignConfig.class)
+public interface ReservationFeignClient {
+
+  @GetMapping("/api/v1/reservations/{reservationUuid}")
+  GetReservationResponse getReservation(@PathVariable String reservationUuid);
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -1,0 +1,9 @@
+package table.eat.now.payment.payment.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import table.eat.now.payment.payment.domain.entity.Payment;
+import table.eat.now.payment.payment.domain.repository.PaymentRepository;
+
+public interface JpaPaymentRepository extends JpaRepository<Payment, Long>, PaymentRepository {
+
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/persistence/config/QuerydslConfig.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/persistence/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package table.eat.now.payment.payment.infrastructure.persistence.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @Bean
+  JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentController.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentController.java
@@ -20,8 +20,8 @@ public class PaymentController {
   public ResponseEntity<GetCheckoutDetailResponse> getCheckoutDetail(
       @PathVariable UUID idempotencyKey) {
     GetCheckoutDetailResponse response = new GetCheckoutDetailResponse(
-        idempotencyKey,
-        1L,
+        idempotencyKey.toString(),
+        idempotencyKey.toString(),
         BigDecimal.valueOf(3000),
         "테스트 결제입니다.");
     return ResponseEntity.ok(response);

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentInternalController.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentInternalController.java
@@ -1,0 +1,29 @@
+package table.eat.now.payment.payment.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import table.eat.now.payment.payment.application.PaymentService;
+import table.eat.now.payment.payment.presentation.dto.request.CreatePaymentRequest;
+import table.eat.now.payment.payment.presentation.dto.response.CreatePaymentResponse;
+
+@RestController
+@RequestMapping("/internal/v1/payments")
+@RequiredArgsConstructor
+public class PaymentInternalController {
+
+  private final PaymentService paymentService;
+
+  @PostMapping
+  public ResponseEntity<CreatePaymentResponse> createPayment(
+      @RequestBody @Valid CreatePaymentRequest request) {
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        CreatePaymentResponse.from(paymentService.createPayment(request.toCommand())));
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentViewController.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentViewController.java
@@ -1,6 +1,5 @@
 package table.eat.now.payment.payment.presentation;
 
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class PaymentViewController {
 
   @GetMapping("/checkout")
-  public String getPage(@RequestParam UUID idempotencyKey) {
+  public String getPage(@RequestParam String idempotencyKey) {
     return "checkout";
   }
 

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/dto/request/CreatePaymentRequest.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/dto/request/CreatePaymentRequest.java
@@ -1,0 +1,25 @@
+package table.eat.now.payment.payment.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
+
+public record CreatePaymentRequest(
+    @NotNull String reservationUuid,
+    @NotNull String restaurantUuid,
+    @NotNull Long customerId,
+    @NotNull String reservationName,
+    @NotNull BigDecimal originalAmount
+) {
+
+  public CreatePaymentCommand toCommand() {
+    return CreatePaymentCommand.builder()
+        .reservationUuid(reservationUuid)
+        .restaurantUuid(restaurantUuid)
+        .customerId(customerId)
+        .reservationName(reservationName)
+        .originalAmount(originalAmount)
+        .build();
+  }
+
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/dto/response/CreatePaymentResponse.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/dto/response/CreatePaymentResponse.java
@@ -1,0 +1,26 @@
+package table.eat.now.payment.payment.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.payment.payment.application.dto.response.CreatePaymentInfo;
+
+@Builder
+public record CreatePaymentResponse(
+    String paymentUuid,
+    String idempotencyKey,
+    String paymentStatus,
+    BigDecimal originalAmount,
+    LocalDateTime createdAt
+) {
+
+  public static CreatePaymentResponse from(CreatePaymentInfo info) {
+    return CreatePaymentResponse.builder()
+        .paymentUuid(info.paymentUuid())
+        .idempotencyKey(info.idempotencyKey())
+        .paymentStatus(info.paymentStatus())
+        .originalAmount(info.originalAmount())
+        .createdAt(info.createdAt())
+        .build();
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/dto/response/GetCheckoutDetailResponse.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/dto/response/GetCheckoutDetailResponse.java
@@ -1,9 +1,11 @@
 package table.eat.now.payment.payment.presentation.dto.response;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 public record GetCheckoutDetailResponse(
-    UUID idempotencyKey, Long customerId, BigDecimal amount, String orderName) {
+    String idempotencyKey,
+    String customerKey,
+    BigDecimal amount,
+    String orderName) {
 
 }

--- a/payment/src/main/resources/templates/checkout.html
+++ b/payment/src/main/resources/templates/checkout.html
@@ -40,7 +40,7 @@
     const tossPayments = TossPayments(clientKey);
 
     // 회원 결제 - API에서 받은 customerId 사용
-    const customerKey = paymentData.customerId;
+    const customerKey = paymentData.customerKey;
     const widgets = tossPayments.widgets({
       customerKey,
     });

--- a/payment/src/test/http/internal.http
+++ b/payment/src/test/http/internal.http
@@ -1,0 +1,23 @@
+### 결제 생성
+POST localhost:8088/internal/v1/payments
+Content-Type: application/json
+
+{
+  "reservationUuid": "00000000-0000-0000-0000-000000000001",
+  "restaurantUuid": "00000",
+  "customerId": 123,
+  "reservationName": "하이들하신가",
+  "originalAmount": 45000
+}
+
+### 결제 생성 (검증실패)
+POST localhost:8088/internal/v1/payments
+Content-Type: application/json
+
+{
+  "reservationUuid": "00000000-0000-0000-0000-000000000000",
+  "restaurantUuid": "00000",
+  "customerId": 123,
+  "reservationName": "하이들하신가",
+  "originalAmount": 45000
+}

--- a/payment/src/test/java/table/eat/now/payment/payment/application/PaymentServiceImplTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/application/PaymentServiceImplTest.java
@@ -1,21 +1,139 @@
 package table.eat.now.payment.payment.application;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH;
+import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.RESERVATION_NOT_PENDING;
 
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.payment.payment.application.client.ReservationClient;
+import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
+import table.eat.now.payment.payment.application.dto.response.CreatePaymentInfo;
+import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+import table.eat.now.payment.payment.domain.entity.Payment;
+import table.eat.now.payment.payment.domain.entity.PaymentStatus;
+import table.eat.now.payment.payment.domain.repository.PaymentRepository;
 
 @SpringBootTest
+@Transactional
 @ActiveProfiles("test")
 class PaymentServiceImplTest {
 
   @Autowired
   private PaymentService paymentService;
 
-  @Test
-  public void 아무것도_안한다() {
-    assertDoesNotThrow(() -> paymentService.doNothing());
+  @MockitoBean
+  private PaymentRepository paymentRepository;
+
+  @MockitoBean
+  private ReservationClient reservationClient;
+
+  @Nested
+  class createPayment_는 {
+
+    private String reservationUuid;
+    private String restaurantUuid;
+    private Long customerId;
+    private String reservationName;
+    private BigDecimal originalAmount;
+    private CreatePaymentCommand command;
+    private Payment savedPayment;
+
+    @BeforeEach
+    void setUp() {
+      reservationUuid = UUID.randomUUID().toString();
+      restaurantUuid = UUID.randomUUID().toString();
+      customerId = 123L;
+      reservationName = "고객님의 예약";
+      originalAmount = BigDecimal.valueOf(50000);
+
+      command = CreatePaymentCommand.builder()
+          .reservationUuid(reservationUuid)
+          .restaurantUuid(restaurantUuid)
+          .customerId(customerId)
+          .reservationName(reservationName)
+          .originalAmount(originalAmount)
+          .build();
+
+      GetReservationInfo reservationInfo = GetReservationInfo.builder()
+          .reservationUuid(reservationUuid)
+          .restaurantUuid(restaurantUuid)
+          .customerId(customerId)
+          .status("PENDING_PAYMENT")
+          .totalAmount(originalAmount)
+          .build();
+
+      savedPayment = command.toEntity();
+      when(reservationClient.getReservation(reservationUuid)).thenReturn(reservationInfo);
+      when(paymentRepository.save(any(Payment.class))).thenReturn(savedPayment);
+    }
+
+    @Test
+    void 유효한_요청으로_결제를_생성하면_저장된_결제_정보를_반환한다() {
+      // when
+      CreatePaymentInfo result = paymentService.createPayment(command);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.paymentUuid()).isEqualTo(savedPayment.getIdentifier().getPaymentUuid());
+      assertThat(result.idempotencyKey()).isEqualTo(savedPayment.getIdentifier().getIdempotencyKey());
+      assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.CREATED.name());
+      assertThat(result.originalAmount()).isEqualTo(originalAmount);
+
+      verify(reservationClient).getReservation(reservationUuid);
+      verify(paymentRepository).save(any(Payment.class));
+    }
+
+    @Test
+    void 결제_금액이_예약_금액과_일치하지_않으면_예외를_발생시킨다() {
+      // given
+      BigDecimal differentAmount = BigDecimal.valueOf(60000);
+      CreatePaymentCommand invalidCommand = CreatePaymentCommand.builder()
+          .reservationUuid(reservationUuid)
+          .restaurantUuid(restaurantUuid)
+          .customerId(customerId)
+          .reservationName(reservationName)
+          .originalAmount(differentAmount)
+          .build();
+
+      // when & then
+      CustomException exception = assertThrows(CustomException.class, () ->
+          paymentService.createPayment(invalidCommand));
+
+      assertThat(exception.getMessage()).isEqualTo(PAYMENT_AMOUNT_MISMATCH.getMessage());
+    }
+
+    @Test
+    void 예약_상태가_결제_대기_상태가_아니면_예외를_발생시킨다() {
+      // given
+      GetReservationInfo invalidStatusInfo = GetReservationInfo.builder()
+          .reservationUuid(reservationUuid)
+          .restaurantUuid(restaurantUuid)
+          .customerId(customerId)
+          .status("CONFIRMED") // 결제 대기 상태가 아님
+          .totalAmount(originalAmount)
+          .build();
+
+      when(reservationClient.getReservation(reservationUuid)).thenReturn(invalidStatusInfo);
+
+      // when & then
+      CustomException exception = assertThrows(CustomException.class, () ->
+          paymentService.createPayment(command));
+
+      assertThat(exception.getMessage()).isEqualTo(RESERVATION_NOT_PENDING.getMessage());
+    }
   }
 }

--- a/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentAmountTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentAmountTest.java
@@ -1,0 +1,196 @@
+package table.eat.now.payment.payment.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PaymentAmountTest {
+
+  @Nested
+  class create_는 {
+
+    @Test
+    void 유효한_금액으로_PaymentAmount를_생성할_수_있다() {
+      //given
+      BigDecimal validAmount = BigDecimal.valueOf(10000);
+
+      //when & then
+      PaymentAmount paymentAmount = assertDoesNotThrow(() -> PaymentAmount.create(validAmount));
+
+      assertThat(paymentAmount).isNotNull();
+      assertThat(paymentAmount.getOriginalAmount()).isEqualTo(validAmount);
+      assertThat(paymentAmount.getDiscountAmount()).isNull();
+      assertThat(paymentAmount.getTotalAmount()).isNull();
+    }
+
+    @Test
+    void 금액이_null이면_IllegalArgumentException을_던진다() {
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> PaymentAmount.create(null));
+
+      assertThat(exception.getMessage()).contains("금액은 null이 될 수 없습니다");
+    }
+
+    @Test
+    void 금액이_0이하이면_IllegalArgumentException을_던진다() {
+      //given
+      BigDecimal zeroAmount = BigDecimal.ZERO;
+      BigDecimal negativeAmount = BigDecimal.valueOf(-1000);
+
+      //when & then
+      IllegalArgumentException exception1 = assertThrows(
+          IllegalArgumentException.class, () -> PaymentAmount.create(zeroAmount));
+      IllegalArgumentException exception2 = assertThrows(
+          IllegalArgumentException.class, () -> PaymentAmount.create(negativeAmount));
+
+      assertThat(exception1.getMessage()).contains("금액은 0보다 커야 합니다");
+      assertThat(exception2.getMessage()).contains("금액은 0보다 커야 합니다");
+    }
+
+    @Test
+    void 금액이_8자리를_초과하면_IllegalArgumentException을_던진다() {
+      //given
+      BigDecimal tooLargeAmount = BigDecimal.valueOf(100000000); // 9자리
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> PaymentAmount.create(tooLargeAmount));
+
+      assertThat(exception.getMessage()).contains("금액은 최대 8자리 정수를 초과할 수 없습니다");
+    }
+
+    @Test
+    void 금액이_소수점을_포함하면_IllegalArgumentException을_던진다() {
+      //given
+      BigDecimal decimalAmount = BigDecimal.valueOf(1000.5);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> PaymentAmount.create(decimalAmount));
+
+      assertThat(exception.getMessage()).contains("금액은 정수여야 합니다");
+    }
+  }
+
+  @Nested
+  class confirm_은 {
+
+    @Test
+    void 유효한_할인금액과_총액으로_확정된_PaymentAmount를_생성할_수_있다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount);
+
+      //when
+      PaymentAmount confirmedAmount = assertDoesNotThrow(() ->
+          paymentAmount.confirm(discountAmount, totalAmount));
+
+      //then
+      assertThat(confirmedAmount).isNotNull();
+      assertThat(confirmedAmount.getOriginalAmount()).isEqualTo(originalAmount);
+      assertThat(confirmedAmount.getDiscountAmount()).isEqualTo(discountAmount);
+      assertThat(confirmedAmount.getTotalAmount()).isEqualTo(totalAmount);
+    }
+
+    @Test
+    void 할인금액이_null이면_0으로_처리한다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal totalAmount = BigDecimal.valueOf(10000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount);
+
+      //when
+      PaymentAmount confirmedAmount = assertDoesNotThrow(() ->
+          paymentAmount.confirm(null, totalAmount));
+
+      //then
+      assertThat(confirmedAmount.getDiscountAmount()).isEqualTo(BigDecimal.ZERO);
+      assertThat(confirmedAmount.getTotalAmount()).isEqualTo(totalAmount);
+    }
+
+    @Test
+    void 총액이_null이면_IllegalArgumentException을_던진다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> paymentAmount.confirm(discountAmount, null));
+
+      assertThat(exception.getMessage()).contains("금액은 null이 될 수 없습니다");
+    }
+
+    @Test
+    void 할인금액이_원금보다_크면_IllegalArgumentException을_던진다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(11000);
+      BigDecimal totalAmount = BigDecimal.valueOf(1000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              paymentAmount.confirm(discountAmount, totalAmount));
+
+      assertThat(exception.getMessage()).contains("할인 금액은 원래 금액보다 클 수 없습니다");
+    }
+
+    @Test
+    void 총액이_원금과_할인금액의_차이와_일치하지_않으면_IllegalArgumentException을_던진다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal wrongTotalAmount = BigDecimal.valueOf(8000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              paymentAmount.confirm(discountAmount, wrongTotalAmount));
+
+      assertThat(exception.getMessage()).contains("총 금액이 일치하지 않습니다");
+    }
+
+    @Test
+    void 할인금액이_소수점을_포함하면_IllegalArgumentException을_던진다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(1000.5);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              paymentAmount.confirm(discountAmount, totalAmount));
+
+      assertThat(exception.getMessage()).contains("금액은 정수여야 합니다");
+    }
+
+    @Test
+    void 총액이_소수점을_포함하면_IllegalArgumentException을_던진다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000.5);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              paymentAmount.confirm(discountAmount, totalAmount));
+
+      assertThat(exception.getMessage()).contains("금액은 정수여야 합니다");
+    }
+  }
+}

--- a/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentIdentifierTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentIdentifierTest.java
@@ -1,0 +1,53 @@
+package table.eat.now.payment.payment.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PaymentIdentifierTest {
+
+  @Nested
+  class create_는 {
+
+    @Test
+    void 유효한_PaymentIdentifier_를_생성_할_수_있다() {
+      // when
+      PaymentIdentifier identifier = assertDoesNotThrow(PaymentIdentifier::create);
+
+      // then
+      assertThat(identifier).isNotNull();
+      assertThat(identifier.getPaymentUuid()).isNotNull();
+      assertThat(identifier.getIdempotencyKey()).isNotNull();
+      assertThat(identifier.getPaymentUuid()).isNotEmpty();
+      assertThat(identifier.getIdempotencyKey()).isNotEmpty();
+    }
+
+    @Test
+    void 서로_다른_UUID_값을_가진_PaymentIdentifier_를_생성한다() {
+      // when
+      PaymentIdentifier identifier1 = PaymentIdentifier.create();
+      PaymentIdentifier identifier2 = PaymentIdentifier.create();
+
+      // then
+      assertThat(identifier1.getPaymentUuid()).isNotEqualTo(identifier2.getPaymentUuid());
+      assertThat(identifier1.getIdempotencyKey()).isNotEqualTo(identifier2.getIdempotencyKey());
+    }
+
+    @Test
+    void UUID_형식의_문자열을_생성한다() {
+      // when
+      PaymentIdentifier identifier = PaymentIdentifier.create();
+
+      // then
+      assertThat(identifier.getIdempotencyKey()).isNotNull();
+      assertThat(identifier.getIdempotencyKey()).isInstanceOf(String.class);
+      assertThat(UUID.fromString(identifier.getIdempotencyKey())).isNotNull();
+      assertThat(identifier.getPaymentUuid()).isNotNull();
+      assertThat(identifier.getPaymentUuid()).isInstanceOf(String.class);
+      assertThat(UUID.fromString(identifier.getPaymentUuid())).isNotNull();
+    }
+  }
+}

--- a/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentReferenceTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentReferenceTest.java
@@ -1,0 +1,113 @@
+package table.eat.now.payment.payment.domain.entity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PaymentReferenceTest {
+
+  @Nested
+  class create_는 {
+
+    @Test
+    void 유효한_입력값으로_ReviewReference_를_생성_할_수_있다() {
+      //given
+      String validRestaurantId = UUID.randomUUID().toString();
+      String validReservationId = UUID.randomUUID().toString();
+      Long validCustomerId = 123L;
+      String validReservationName = "멋진 이름을 가진 주문명";
+
+      //when & then
+      PaymentReference reference = assertDoesNotThrow(() -> PaymentReference.create(
+          validRestaurantId, validReservationId, validCustomerId, validReservationName));
+
+      assertThat(reference).isNotNull();
+      assertThat(reference.getRestaurantId()).isEqualTo(validRestaurantId);
+      assertThat(reference.getReservationId()).isEqualTo(validReservationId);
+      assertThat(reference.getCustomerId()).isEqualTo(validCustomerId);
+      assertThat(reference.getReservationName()).isEqualTo(validReservationName);
+    }
+
+    @Test
+    void restaurantId가_null_이면_IllegalArgumentException_을_던진다() {
+      //given
+      String validReservationId = UUID.randomUUID().toString();
+      Long validCustomerId = 123L;
+      String validReservationName = "멋진 이름을 가진 주문명";
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> PaymentReference.create(
+              null, validReservationId, validCustomerId, validReservationName));
+
+      assertThat(exception.getMessage()).contains("null이 될 수 없습니다");
+    }
+
+    @Test
+    void reservationId가_null_이면_IllegalArgumentException_을_던진다() {
+      //given
+      String validRestaurantId = UUID.randomUUID().toString();
+      Long validCustomerId = 123L;
+      String validReservationName = "멋진 이름을 가진 주문명";
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> PaymentReference.create(
+              validRestaurantId, null, validCustomerId, validReservationName));
+
+      assertThat(exception.getMessage()).contains("null이 될 수 없습니다");
+    }
+
+    @Test
+    void customerId가_null_이면_IllegalArgumentException_을_던진다() {
+      //given
+      String validRestaurantId = UUID.randomUUID().toString();
+      String validReservationId = UUID.randomUUID().toString();
+      String validReservationName = "멋진 이름을 가진 주문명";
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> PaymentReference.create(
+              validRestaurantId, validReservationId, null, validReservationName));
+
+      assertThat(exception.getMessage()).contains("null이 될 수 없습니다");
+    }
+
+    @Test
+    void reservationName이_null_이면_IllegalArgumentException_을_던진다() {
+      //given
+      String validRestaurantId = UUID.randomUUID().toString();
+      String validReservationId = UUID.randomUUID().toString();
+      Long validCustomerId = 123L;
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> PaymentReference.create(
+              validRestaurantId, validReservationId, validCustomerId, null));
+
+      assertThat(exception.getMessage()).contains("null이 될 수 없습니다");
+    }
+
+    @Test
+    void 생성된_Review는_UUID_형식의_문자열의_customerKey를_갖는다() {
+      // given
+      String validRestaurantId = UUID.randomUUID().toString();
+      String validReservationId = UUID.randomUUID().toString();
+      Long validCustomerId = 123L;
+      String validReservationName = "멋진 이름을 가진 주문명";
+
+      //when & then
+      PaymentReference reference = assertDoesNotThrow(() -> PaymentReference.create(
+          validRestaurantId, validReservationId, validCustomerId, validReservationName));
+
+      assertThat(reference.getCustomerKey()).isNotNull();
+      assertThat(reference.getCustomerKey()).isInstanceOf(String.class);
+      assertThat(UUID.fromString(reference.getCustomerKey())).isNotNull();
+    }
+  }
+
+}

--- a/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentTest.java
@@ -1,0 +1,144 @@
+package table.eat.now.payment.payment.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PaymentTest {
+
+  @Nested
+  class create_는 {
+
+    @Test
+    void 유효한_입력값으로_Payment를_생성할_수_있다() {
+      //given
+      PaymentReference validReference = PaymentReference.create(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          123L,
+          "예약 이름");
+      PaymentAmount validAmount = PaymentAmount.create(BigDecimal.valueOf(10000));
+
+      //when & then
+      Payment payment = assertDoesNotThrow(() -> Payment.create(validReference, validAmount));
+
+      assertThat(payment).isNotNull();
+      assertThat(payment.getReference()).isEqualTo(validReference);
+      assertThat(payment.getAmount()).isEqualTo(validAmount);
+      assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CREATED);
+      assertThat(payment.getIdentifier()).isNotNull();
+      assertThat(payment.getPaymentKey()).isNull();
+      assertThat(payment.getApprovedAt()).isNull();
+    }
+
+    @Test
+    void reference가_null이면_IllegalArgumentException을_던진다() {
+      //given
+      PaymentAmount validAmount = PaymentAmount.create(BigDecimal.valueOf(10000));
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> Payment.create(null, validAmount));
+
+      assertThat(exception.getMessage()).contains("null일 수 없습니다");
+    }
+
+    @Test
+    void amount가_null이면_IllegalArgumentException을_던진다() {
+      //given
+      PaymentReference validReference = PaymentReference.create(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          123L,
+          "예약 이름");
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> Payment.create(validReference, null));
+
+      assertThat(exception.getMessage()).contains("null일 수 없습니다");
+    }
+  }
+
+  @Nested
+  class confirm_은 {
+
+    @Test
+    void 유효한_입력값으로_결제를_확정할_수_있다() {
+      //given
+      Payment payment = createValidPayment();
+      String paymentKey = "payment_key_123456";
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000);
+
+      //when
+      assertDoesNotThrow(() -> payment.confirm(paymentKey, discountAmount, totalAmount));
+
+      //then
+      assertThat(payment.getPaymentKey()).isEqualTo(paymentKey);
+      assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.APPROVED);
+      assertThat(payment.getApprovedAt()).isNotNull();
+    }
+
+    @Test
+    void paymentKey가_null이면_IllegalArgumentException을_던진다() {
+      //given
+      Payment payment = createValidPayment();
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              payment.confirm(null, discountAmount, totalAmount));
+
+      assertThat(exception.getMessage()).contains("null이거나 빈 값일 수 없습니다");
+    }
+
+    @Test
+    void paymentKey가_빈_문자열이면_IllegalArgumentException을_던진다() {
+      //given
+      Payment payment = createValidPayment();
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              payment.confirm("", discountAmount, totalAmount));
+
+      assertThat(exception.getMessage()).contains("null이거나 빈 값일 수 없습니다");
+    }
+
+    @Test
+    void 할인금액과_총액이_PaymentAmount에서_검증된다() {
+      //given
+      Payment payment = createValidPayment();
+      String paymentKey = "payment_key_123456";
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(8000);
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              payment.confirm(paymentKey, discountAmount, totalAmount));
+
+      assertThat(exception.getMessage()).contains("총 금액이 일치하지 않습니다.");
+    }
+  }
+
+  private Payment createValidPayment() {
+    PaymentReference validReference = PaymentReference.create(
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        123L,
+        "예약 이름");
+    PaymentAmount validAmount = PaymentAmount.create(BigDecimal.valueOf(10000));
+    return Payment.create(validReference, validAmount);
+  }
+}

--- a/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentInternalControllerTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentInternalControllerTest.java
@@ -1,0 +1,192 @@
+package table.eat.now.payment.payment.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH;
+import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.RESERVATION_NOT_PENDING;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.common.aop.AuthCheckAspect;
+import table.eat.now.common.config.WebConfig;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.common.exception.GlobalErrorHandler;
+import table.eat.now.common.resolver.CurrentUserInfoResolver;
+import table.eat.now.common.resolver.CustomPageableArgumentResolver;
+import table.eat.now.payment.payment.application.PaymentService;
+import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
+import table.eat.now.payment.payment.application.dto.response.CreatePaymentInfo;
+import table.eat.now.payment.payment.presentation.dto.request.CreatePaymentRequest;
+
+@ActiveProfiles("test")
+@Import({
+    WebConfig.class,
+    CustomPageableArgumentResolver.class,
+    CurrentUserInfoResolver.class,
+    GlobalErrorHandler.class,
+    AuthCheckAspect.class
+})
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@WebMvcTest(PaymentInternalController.class)
+class PaymentInternalControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private PaymentService paymentService;
+
+  @Nested
+  class 결제_생성_요청시 {
+
+    private UUID reservationUuid;
+    private UUID restaurantUuid;
+    private Long customerId;
+    private String reservationName;
+    private BigDecimal originalAmount;
+    private CreatePaymentRequest request;
+    private CreatePaymentInfo paymentInfo;
+
+    @BeforeEach
+    void setUp() {
+      reservationUuid = UUID.randomUUID();
+      restaurantUuid = UUID.randomUUID();
+      customerId = 123L;
+      reservationName = "고객님의 예약";
+      originalAmount = BigDecimal.valueOf(50000);
+
+      request = new CreatePaymentRequest(
+          reservationUuid.toString(),
+          restaurantUuid.toString(),
+          customerId,
+          reservationName,
+          originalAmount
+      );
+
+      paymentInfo = CreatePaymentInfo.builder()
+          .paymentUuid(UUID.randomUUID().toString())
+          .idempotencyKey(UUID.randomUUID().toString())
+          .paymentStatus("CREATED")
+          .originalAmount(originalAmount)
+          .createdAt(LocalDateTime.now())
+          .build();
+    }
+
+    @Test
+    void 유효한_요청으로_결제를_생성하면_201_상태_코드와_생성된_결제_정보를_반환한다() throws Exception {
+      // given
+      when(paymentService.createPayment(any(CreatePaymentCommand.class))).thenReturn(paymentInfo);
+
+      // when
+      ResultActions actions = mockMvc.perform(post("/internal/v1/payments")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)));
+
+      // then
+      actions
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.paymentUuid").value(paymentInfo.paymentUuid()))
+          .andExpect(jsonPath("$.idempotencyKey").value(paymentInfo.idempotencyKey()))
+          .andExpect(jsonPath("$.paymentStatus").value(paymentInfo.paymentStatus()))
+          .andExpect(jsonPath("$.originalAmount").value(originalAmount.intValue()))
+          .andExpect(jsonPath("$.createdAt").exists());
+
+      verify(paymentService).createPayment(any(CreatePaymentCommand.class));
+    }
+
+    @Test
+    void 결제_금액_불일치_예외가_발생하면_400_상태_코드를_반환한다() throws Exception {
+      // given
+      when(paymentService.createPayment(any(CreatePaymentCommand.class)))
+          .thenThrow(CustomException.from(PAYMENT_AMOUNT_MISMATCH));
+
+      // when
+      ResultActions actions = mockMvc.perform(post("/internal/v1/payments")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)));
+
+      // then
+      actions
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(PAYMENT_AMOUNT_MISMATCH.getMessage()));
+    }
+
+    @Test
+    void 예약_상태_예외가_발생하면_400_상태_코드를_반환한다() throws Exception {
+      // given
+      when(paymentService.createPayment(any(CreatePaymentCommand.class)))
+          .thenThrow(CustomException.from(RESERVATION_NOT_PENDING));
+
+      // when
+      ResultActions actions = mockMvc.perform(post("/internal/v1/payments")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)));
+
+      // then
+      actions
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(RESERVATION_NOT_PENDING.getMessage()));
+    }
+
+    @Test
+    void 필수_값이_null이면_400_상태_코드를_반환한다() throws Exception {
+      // given
+      CreatePaymentRequest invalidRequest = new CreatePaymentRequest(
+          null, // reservationUuid is null
+          restaurantUuid.toString(),
+          customerId,
+          reservationName,
+          originalAmount
+      );
+
+      // when
+      ResultActions actions = mockMvc.perform(post("/internal/v1/payments")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(invalidRequest)));
+
+      // then
+      actions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 결제_금액이_null이면_400_상태_코드를_반환한다() throws Exception {
+      // given
+      CreatePaymentRequest invalidRequest = new CreatePaymentRequest(
+          reservationUuid.toString(),
+          restaurantUuid.toString(),
+          customerId,
+          reservationName,
+          null // originalAmount is null
+      );
+
+      // when
+      ResultActions actions = mockMvc.perform(post("/internal/v1/payments")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(invalidRequest)));
+
+      // then
+      actions.andExpect(status().isBadRequest());
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #103

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용
  - [x] customerId -> customerkey (토스페이먼츠 요구사항 , 문자열입니다 !) 
  - [x] 결제 생성 기능을 구현했습니다. (검증부분은 현재 더미로 진행한 상태입니다!) 
  - [x] 결제 생성 기능의 테스트를 수행했습니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.

## 코멘트
- dto에서 customerId -> customerkey (토스페이먼츠 요구사항 , 문자열입니다 !) 로 변경했는데, 해당부분이 토스 요구사항 (2자이상의 문자열 형식) 이라서, 주문 생성시점에 랜덤한 uuid 를 만들어 함께 저장하는 형식으로 구현해뒀습니다!
