### PR TITLE
[payment] 결제정보 조회 구현, 성공 이벤트 발송 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       ALLOW_ANONYMOUS_LOGIN: "yes"
 
   kafka:
-    image: bitnami/kafka:latest
+    image: bitnami/kafka:3.8.1
     platform: linux/amd64
     ports:
       - "9092:9092"
@@ -85,7 +85,7 @@ services:
     image: provectuslabs/kafka-ui:latest
     platform: linux/amd64
     ports:
-      - "8079:8079"
+      - "8079:8080"
     environment:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 //	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 //	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    //KAFKA
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/payment/src/main/java/table/eat/now/payment/payment/application/PaymentService.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/PaymentService.java
@@ -1,10 +1,12 @@
 package table.eat.now.payment.payment.application;
 
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.payment.payment.application.dto.request.ConfirmPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
 import table.eat.now.payment.payment.application.dto.response.ConfirmPaymentInfo;
 import table.eat.now.payment.payment.application.dto.response.CreatePaymentInfo;
 import table.eat.now.payment.payment.application.dto.response.GetCheckoutDetailInfo;
+import table.eat.now.payment.payment.application.dto.response.GetPaymentInfo;
 
 public interface PaymentService {
 
@@ -13,4 +15,6 @@ public interface PaymentService {
   GetCheckoutDetailInfo getCheckoutDetail(String idempotencyKey);
 
   ConfirmPaymentInfo confirmPayment(ConfirmPaymentCommand command);
+
+  GetPaymentInfo getPayment(String paymentUuid, CurrentUserInfoDto userInfo);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/PaymentService.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/PaymentService.java
@@ -14,7 +14,7 @@ public interface PaymentService {
 
   GetCheckoutDetailInfo getCheckoutDetail(String idempotencyKey);
 
-  ConfirmPaymentInfo confirmPayment(ConfirmPaymentCommand command);
+  ConfirmPaymentInfo confirmPayment(ConfirmPaymentCommand command, CurrentUserInfoDto userInfo);
 
   GetPaymentInfo getPayment(String paymentUuid, CurrentUserInfoDto userInfo);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/PgClient.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/PgClient.java
@@ -2,8 +2,8 @@ package table.eat.now.payment.payment.application.client;
 
 import table.eat.now.payment.payment.application.dto.request.CancelPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.ConfirmPaymentCommand;
-import table.eat.now.payment.payment.application.dto.response.CancelPgPaymentInfo;
-import table.eat.now.payment.payment.application.dto.response.ConfirmPgPaymentInfo;
+import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentInfo;
+import table.eat.now.payment.payment.application.client.dto.ConfirmPgPaymentInfo;
 
 public interface PgClient {
 

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/ReservationClient.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/ReservationClient.java
@@ -1,6 +1,6 @@
 package table.eat.now.payment.payment.application.client;
 
-import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+import table.eat.now.payment.payment.application.client.dto.GetReservationInfo;
 
 public interface ReservationClient {
 

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/CancelPgPaymentInfo.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/CancelPgPaymentInfo.java
@@ -1,4 +1,4 @@
-package table.eat.now.payment.payment.application.dto.response;
+package table.eat.now.payment.payment.application.client.dto;
 
 import java.time.LocalDateTime;
 import table.eat.now.payment.payment.domain.entity.CancelPayment;

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/ConfirmPgPaymentInfo.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/ConfirmPgPaymentInfo.java
@@ -1,4 +1,4 @@
-package table.eat.now.payment.payment.application.dto.response;
+package table.eat.now.payment.payment.application.client.dto;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/GetReservationInfo.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/GetReservationInfo.java
@@ -1,4 +1,4 @@
-package table.eat.now.payment.payment.application.dto.response;
+package table.eat.now.payment.payment.application.client.dto;
 
 import java.math.BigDecimal;
 import lombok.Builder;

--- a/payment/src/main/java/table/eat/now/payment/payment/application/dto/response/GetPaymentInfo.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/dto/response/GetPaymentInfo.java
@@ -1,0 +1,39 @@
+package table.eat.now.payment.payment.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.payment.payment.domain.entity.Payment;
+
+@Builder
+public record GetPaymentInfo(
+    String paymentUuid,
+    Long customerId,
+    String reservationId,
+    String restaurantId,
+    String reservationName,
+    String paymentStatus,
+    BigDecimal originalAmount,
+    BigDecimal discountAmount,
+    BigDecimal totalAmount,
+    LocalDateTime createdAt,
+    LocalDateTime approvedAt,
+    LocalDateTime cancelledAt
+) {
+  public static GetPaymentInfo from(Payment payment){
+    return GetPaymentInfo.builder()
+        .paymentUuid(payment.getIdentifier().getPaymentUuid())
+        .customerId(payment.getReference().getCustomerId())
+        .reservationId(payment.getReference().getReservationId())
+        .restaurantId(payment.getReference().getRestaurantId())
+        .reservationName(payment.getReference().getReservationName())
+        .paymentStatus(payment.getPaymentStatus().name())
+        .originalAmount(payment.getAmount().getOriginalAmount())
+        .discountAmount(payment.getAmount().getDiscountAmount())
+        .totalAmount(payment.getAmount().getTotalAmount())
+        .createdAt(payment.getCreatedAt())
+        .approvedAt(payment.getApprovedAt())
+        .cancelledAt(payment.getCancelledAt())
+        .build();
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/EventType.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/EventType.java
@@ -1,0 +1,8 @@
+package table.eat.now.payment.payment.application.event;
+
+public enum EventType {
+  SUCCEED,
+  FAILED,
+  CANCEL_SUCCEED,
+  CANCEL_FAILED
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/MapperUtil.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/MapperUtil.java
@@ -1,0 +1,26 @@
+package table.eat.now.payment.payment.application.event;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+
+public class MapperUtil {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      .configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true)
+      .registerModule(new JavaTimeModule());
+
+  public static JsonNode toJsonNode(Object payload) {
+    try {
+      return objectMapper.valueToTree(payload);
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException("Failed to convert object to JsonNode", e);
+    }
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/MapperUtil.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/MapperUtil.java
@@ -1,20 +1,21 @@
 package table.eat.now.payment.payment.application.event;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
+import java.math.BigDecimal;
 
 public class MapperUtil {
 
   private static final ObjectMapper objectMapper = new ObjectMapper()
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
       .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-      .configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true)
-      .registerModule(new JavaTimeModule());
+      .registerModule(new JavaTimeModule())
+      .registerModule(new SimpleModule().addSerializer(BigDecimal.class, new ToStringSerializer()));
 
   public static JsonNode toJsonNode(Object payload) {
     try {

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/MapperUtil.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/MapperUtil.java
@@ -11,6 +11,10 @@ import java.math.BigDecimal;
 
 public class MapperUtil {
 
+  private MapperUtil() {
+    throw new AssertionError("Utility class should not be instantiated");
+  }
+
   private static final ObjectMapper objectMapper = new ObjectMapper()
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
       .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
@@ -21,7 +25,8 @@ public class MapperUtil {
     try {
       return objectMapper.valueToTree(payload);
     } catch (IllegalArgumentException e) {
-      throw new RuntimeException("Failed to convert object to JsonNode", e);
+      throw new IllegalArgumentException(
+          "Failed to convert object to JsonNode: " + e.getMessage(), e);
     }
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEvent.java
@@ -1,0 +1,8 @@
+package table.eat.now.payment.payment.application.event;
+
+public interface PaymentEvent {
+
+  EventType eventType();
+
+  String paymentUuid();
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEventPublisher.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEventPublisher.java
@@ -1,0 +1,6 @@
+package table.eat.now.payment.payment.application.event;
+
+public interface PaymentEventPublisher {
+
+  void publish(PaymentSuccessEvent createdEvent);
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentSuccessEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentSuccessEvent.java
@@ -1,0 +1,22 @@
+package table.eat.now.payment.payment.application.event;
+
+
+import static table.eat.now.payment.payment.application.event.EventType.SUCCEED;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+
+public record PaymentSuccessEvent(
+    EventType eventType,
+    String paymentUuid,
+    JsonNode payload,
+    CurrentUserInfoDto userInfo
+) implements PaymentEvent {
+
+  public static PaymentSuccessEvent of(
+      PaymentSuccessPayload payload, CurrentUserInfoDto userInfo) {
+
+    return new PaymentSuccessEvent(
+        SUCCEED, payload.paymentUuid(), MapperUtil.toJsonNode(payload), userInfo);
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentSuccessPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentSuccessPayload.java
@@ -1,0 +1,32 @@
+package table.eat.now.payment.payment.application.event;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.payment.payment.domain.entity.Payment;
+
+@Builder
+public record PaymentSuccessPayload(
+    String paymentUuid,
+    String idempotencyKey,
+    String paymentStatus,
+    BigDecimal originalAmount,
+    BigDecimal discountAmount,
+    BigDecimal totalAmount,
+    LocalDateTime createdAt,
+    LocalDateTime approvedAt
+) {
+
+  public static PaymentSuccessPayload from(Payment payment) {
+    return PaymentSuccessPayload.builder()
+        .paymentUuid(payment.getIdentifier().getPaymentUuid())
+        .idempotencyKey(payment.getIdentifier().getIdempotencyKey())
+        .paymentStatus(payment.getPaymentStatus().name())
+        .originalAmount(payment.getAmount().getOriginalAmount())
+        .discountAmount(payment.getAmount().getDiscountAmount())
+        .totalAmount(payment.getAmount().getTotalAmount())
+        .createdAt(payment.getCreatedAt())
+        .approvedAt(payment.getApprovedAt())
+        .build();
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/exception/PaymentErrorCode.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/exception/PaymentErrorCode.java
@@ -8,12 +8,11 @@ import table.eat.now.common.exception.type.ErrorCode;
 public enum PaymentErrorCode implements ErrorCode {
 
   PAYMENT_NOT_FOUND("해당 결제 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-
   RESERVATION_NOT_FOUND("존재하지 않는 예약입니다.", HttpStatus.NOT_FOUND),
   PAYMENT_AMOUNT_MISMATCH("결제 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
   RESERVATION_NOT_PENDING("결제 대기 상태의 예약만 결제할 수 있습니다.", HttpStatus.BAD_REQUEST),
-  PAYMENT_APPROVAL_FAILED("결제 승인에 실패했습니다.", HttpStatus.BAD_REQUEST)
-
+  PAYMENT_APPROVAL_FAILED("결제 승인에 실패했습니다.", HttpStatus.BAD_REQUEST),
+  PAYMENT_ACCESS_DENIED("해당 결제 정보를 조회할 권한이 없습니다.", HttpStatus.FORBIDDEN)
   ;
 
   private final String message;

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/repository/PaymentRepository.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/repository/PaymentRepository.java
@@ -10,4 +10,6 @@ public interface PaymentRepository {
   Optional<Payment> findByIdentifier_IdempotencyKeyAndDeletedAtNull(String idempotencyKey);
 
   Optional<Payment> findByReference_ReservationIdAndDeletedAtNull(String reservationId);
+
+  Optional<Payment> findByIdentifier_PaymentUuidAndDeletedAtNull(String paymentUuid);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/DummyReservationClientImpl.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/DummyReservationClientImpl.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.payment.payment.application.client.ReservationClient;
-import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+import table.eat.now.payment.payment.application.client.dto.GetReservationInfo;
 
 @Primary
 @Component

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/PgClientImpl.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/PgClientImpl.java
@@ -1,14 +1,13 @@
 package table.eat.now.payment.payment.infrastructure.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import table.eat.now.payment.payment.application.client.PgClient;
 import table.eat.now.payment.payment.application.dto.request.CancelPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.ConfirmPaymentCommand;
-import table.eat.now.payment.payment.application.dto.response.CancelPgPaymentInfo;
-import table.eat.now.payment.payment.application.dto.response.ConfirmPgPaymentInfo;
+import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentInfo;
+import table.eat.now.payment.payment.application.client.dto.ConfirmPgPaymentInfo;
 import table.eat.now.payment.payment.infrastructure.client.dto.request.CancelTossPayRequest;
 import table.eat.now.payment.payment.infrastructure.client.dto.request.ConfirmTossPayRequest;
 import table.eat.now.payment.payment.infrastructure.client.pg.TossPaymentClient;

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/ReservationClientImpl.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/ReservationClientImpl.java
@@ -3,7 +3,7 @@ package table.eat.now.payment.payment.infrastructure.client;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import table.eat.now.payment.payment.application.client.ReservationClient;
-import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+import table.eat.now.payment.payment.application.client.dto.GetReservationInfo;
 import table.eat.now.payment.payment.infrastructure.client.feign.ReservationFeignClient;
 
 @Component

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/response/CancelTossPayResponse.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/response/CancelTossPayResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDateTime;
 import java.util.List;
-import table.eat.now.payment.payment.application.dto.response.CancelPgPaymentInfo;
+import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentInfo;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record CancelTossPayResponse(

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/response/ConfirmTossPayResponse.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/response/ConfirmTossPayResponse.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import table.eat.now.payment.payment.application.dto.response.ConfirmPgPaymentInfo;
+import table.eat.now.payment.payment.application.client.dto.ConfirmPgPaymentInfo;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ConfirmTossPayResponse(

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/response/GetReservationResponse.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/response/GetReservationResponse.java
@@ -1,6 +1,6 @@
 package table.eat.now.payment.payment.infrastructure.client.dto.response;
 
-import table.eat.now.payment.payment.application.dto.response.GetReservationInfo;
+import table.eat.now.payment.payment.application.client.dto.GetReservationInfo;
 
 //Todo : internal 형식물어보기
 public record GetReservationResponse() {

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/KafkaPaymentProducer.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/KafkaPaymentProducer.java
@@ -1,0 +1,25 @@
+package table.eat.now.payment.payment.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import table.eat.now.payment.payment.application.event.PaymentEvent;
+import table.eat.now.payment.payment.application.event.PaymentEventPublisher;
+import table.eat.now.payment.payment.application.event.PaymentSuccessEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaPaymentProducer implements PaymentEventPublisher {
+
+  private final KafkaTemplate<String, PaymentEvent> kafkaTemplate;
+  private final String paymentTopic;
+
+  @Override
+  public void publish(PaymentSuccessEvent paymentEvent) {
+    kafkaTemplate.send(paymentTopic, paymentEvent.paymentUuid() ,paymentEvent);
+    log.info("payload is {} ", paymentEvent.payload().toString());
+    log.info("Published payment event {}", paymentEvent.eventType());
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaProducerConfig.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaProducerConfig.java
@@ -1,0 +1,40 @@
+package table.eat.now.payment.payment.infrastructure.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import table.eat.now.payment.payment.application.event.PaymentEvent;
+
+@Configuration
+public class PaymentKafkaProducerConfig {
+
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  @Bean
+  public ProducerFactory<String, PaymentEvent> producerFactory() {
+
+    Map<String, Object> props = new HashMap<>();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+    props.put(ProducerConfig.ACKS_CONFIG, "all");
+    props.put(ProducerConfig.RETRIES_CONFIG, 3);
+
+    return new DefaultKafkaProducerFactory<>(props);
+  }
+
+  @Bean
+  public KafkaTemplate<String, PaymentEvent> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaTopicConfig.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaTopicConfig.java
@@ -1,0 +1,26 @@
+package table.eat.now.payment.payment.infrastructure.kafka.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class PaymentKafkaTopicConfig {
+
+  private static final String PAYMENT_TOPIC_NAME = "payment-event";
+
+  @Bean
+  public NewTopic createTopic() {
+    return TopicBuilder.name(PAYMENT_TOPIC_NAME)
+        .partitions(3)
+        .replicas(3)
+        .config("min.insync.replicas", "2")
+        .build();
+  }
+
+  @Bean
+  public String paymentTopic() {
+    return PAYMENT_TOPIC_NAME;
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -10,4 +10,6 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, Long>, Paym
   Optional<Payment> findByIdentifier_IdempotencyKeyAndDeletedAtNull(String idempotencyKey);
 
   Optional<Payment> findByReference_ReservationIdAndDeletedAtNull(String reservationId);
+
+  Optional<Payment> findByIdentifier_PaymentUuidAndDeletedAtNull(String paymentUuid);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentApiController.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentApiController.java
@@ -41,10 +41,11 @@ public class PaymentApiController {
   @PatchMapping("/confirm")
   public ResponseEntity<ConfirmPaymentResponse> confirmPayment(
       @RequestParam UUID reservationUuid,
-      @RequestBody @Valid ConfirmPaymentRequest request) {
+      @RequestBody @Valid ConfirmPaymentRequest request,
+      @CurrentUserInfo CurrentUserInfoDto userInfo) {
 
     return ResponseEntity.ok(ConfirmPaymentResponse.from(
-        paymentService.confirmPayment(request.toCommand(reservationUuid.toString()))));
+        paymentService.confirmPayment(request.toCommand(reservationUuid.toString()), userInfo)));
   }
 
   @AuthCheck(roles = {CUSTOMER, MASTER})

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentApiController.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/PaymentApiController.java
@@ -1,19 +1,27 @@
 package table.eat.now.payment.payment.presentation;
 
+import static table.eat.now.common.resolver.dto.UserRole.CUSTOMER;
+import static table.eat.now.common.resolver.dto.UserRole.MASTER;
+
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import table.eat.now.common.aop.annotation.AuthCheck;
+import table.eat.now.common.resolver.annotation.CurrentUserInfo;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.payment.payment.application.PaymentService;
 import table.eat.now.payment.payment.presentation.dto.request.ConfirmPaymentRequest;
 import table.eat.now.payment.payment.presentation.dto.response.ConfirmPaymentResponse;
 import table.eat.now.payment.payment.presentation.dto.response.GetCheckoutDetailResponse;
+import table.eat.now.payment.payment.presentation.dto.response.GetPaymentResponse;
 
 @RestController
 @RequestMapping("/api/v1/payments")
@@ -27,7 +35,7 @@ public class PaymentApiController {
       @RequestParam UUID idempotencyKey) {
 
     return ResponseEntity.ok(GetCheckoutDetailResponse.from(
-            paymentService.getCheckoutDetail(idempotencyKey.toString())));
+        paymentService.getCheckoutDetail(idempotencyKey.toString())));
   }
 
   @PatchMapping("/confirm")
@@ -36,8 +44,16 @@ public class PaymentApiController {
       @RequestBody @Valid ConfirmPaymentRequest request) {
 
     return ResponseEntity.ok(ConfirmPaymentResponse.from(
-        paymentService.confirmPayment(
-            request.toCommand(reservationUuid.toString()))));
+        paymentService.confirmPayment(request.toCommand(reservationUuid.toString()))));
+  }
+
+  @AuthCheck(roles = {CUSTOMER, MASTER})
+  @GetMapping("/{paymentUuid}")
+  public ResponseEntity<GetPaymentResponse> getPayment(
+      @PathVariable UUID paymentUuid, @CurrentUserInfo CurrentUserInfoDto userInfo) {
+
+    return ResponseEntity.ok(
+        GetPaymentResponse.from(paymentService.getPayment(paymentUuid.toString(), userInfo)));
   }
 
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/presentation/dto/response/GetPaymentResponse.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/presentation/dto/response/GetPaymentResponse.java
@@ -1,0 +1,39 @@
+package table.eat.now.payment.payment.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.payment.payment.application.dto.response.GetPaymentInfo;
+
+@Builder
+public record GetPaymentResponse(
+    String paymentUuid,
+    Long customerId,
+    String reservationId,
+    String restaurantId,
+    String reservationName,
+    String paymentStatus,
+    BigDecimal originalAmount,
+    BigDecimal discountAmount,
+    BigDecimal totalAmount,
+    LocalDateTime createdAt,
+    LocalDateTime approvedAt,
+    LocalDateTime cancelledAt
+) {
+  public static GetPaymentResponse from(GetPaymentInfo info){
+    return GetPaymentResponse.builder()
+        .paymentUuid(info.paymentUuid())
+        .customerId(info.customerId())
+        .reservationId(info.reservationId())
+        .restaurantId(info.restaurantId())
+        .reservationName(info.reservationName())
+        .paymentStatus(info.paymentStatus())
+        .originalAmount(info.originalAmount())
+        .discountAmount(info.discountAmount())
+        .totalAmount(info.totalAmount())
+        .createdAt(info.createdAt())
+        .approvedAt(info.approvedAt())
+        .cancelledAt(info.cancelledAt())
+        .build();
+  }
+}

--- a/payment/src/test/http/api.http
+++ b/payment/src/test/http/api.http
@@ -3,7 +3,7 @@ POST localhost:8088/internal/v1/payments
 Content-Type: application/json
 
 {
-  "reservationUuid": "00000000-0000-0000-0000-000000000013",
+  "reservationUuid": "00000000-0000-0000-0000-000000000017",
   "restaurantUuid": "9882a539-0380-4a5d-bec4-da49d37f06e5",
   "customerId": 123,
   "reservationName": "하이들하신가",

--- a/payment/src/test/http/api.http
+++ b/payment/src/test/http/api.http
@@ -3,7 +3,7 @@ POST localhost:8088/internal/v1/payments
 Content-Type: application/json
 
 {
-  "reservationUuid": "00000000-0000-0000-0000-000000000017",
+  "reservationUuid": "00000000-0000-0000-0000-000000000018",
   "restaurantUuid": "9882a539-0380-4a5d-bec4-da49d37f06e5",
   "customerId": 123,
   "reservationName": "하이들하신가",
@@ -11,6 +11,7 @@ Content-Type: application/json
 }
 > {%
   client.global.set("idempotencyKey", response.body.idempotencyKey)
+  client.global.set("paymentUuid", response.body.paymentUuid)
 %}
 
 ### Checkout 상세 조회
@@ -26,7 +27,13 @@ Content-Type: application/json
   "totalAmount": 45000
 }
 
-###
+### 결제 조회
+GET localhost:8088/api/v1/payments/{{paymentUuid}}
+Content-Type: application/json
+X-User-Id: 123
+X-User-Role: CUSTOMER
+
+### 토스페이 거래내역 상세조회
 GET https://api.tosspayments.com/v1/payments/orders/00000000-0000-0000-0000-000000000011
 Authorization: Basic dGVzdF9za19BTG5RdkRkMlZKR2s0eUdLR1E5TnJNajdYNDFtOg
 Content-Type: application/json

--- a/payment/src/test/http/view.http
+++ b/payment/src/test/http/view.http
@@ -1,19 +1,17 @@
-### 결제 생성
+### 결제 생성 (현재 예약ID를 랜덤값으로 주고있지 않아서, 이미처리된 결제ID라는 알림이 올 수 있습니다! 끝수 +1해주세요!)
 POST localhost:8088/internal/v1/payments
 Content-Type: application/json
 
 {
-  "reservationUuid": "00000000-0000-0000-0000-000000000008",
-  "restaurantUuid": "00000",
+  "reservationUuid": "00000000-0000-0000-0000-000000000017",
+  "restaurantUuid": "9882a539-0380-4a5d-bec4-da49d37f06e5",
   "customerId": 123,
   "reservationName": "하이들하신가",
   "originalAmount": 45000
 }
-
 > {%
   client.global.set("idempotencyKey", response.body.idempotencyKey)
 %}
 
-
-### 브라우저에서 해보시면 됩니다!
+### 브라우저에서 해보시면 됩니다! (최상단의 GET요청 url을 복사붙여넣기하시면 됩니다.)
 GET http://localhost:8088/checkout?idempotencyKey={{idempotencyKey}}

--- a/payment/src/test/http/view.http
+++ b/payment/src/test/http/view.http
@@ -3,7 +3,7 @@ POST localhost:8088/internal/v1/payments
 Content-Type: application/json
 
 {
-  "reservationUuid": "00000000-0000-0000-0000-000000000017",
+  "reservationUuid": "00000000-0000-0000-0000-000000000018",
   "restaurantUuid": "9882a539-0380-4a5d-bec4-da49d37f06e5",
   "customerId": 123,
   "reservationName": "하이들하신가",

--- a/payment/src/test/java/table/eat/now/payment/payment/application/event/MapperUtilTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/application/event/MapperUtilTest.java
@@ -1,8 +1,10 @@
 package table.eat.now.payment.payment.application.event;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
@@ -42,21 +44,14 @@ class MapperUtilTest {
   @Test
   void toJsonNode_는_변환할수없는객체에_예외를던진다() {
     // given
-    Object invalidObject = new Object() {
-      private final Object circular = this;
-
-      @Override
-      public String toString() {
-        return "This object has a circular reference that cannot be serialized to JSON";
-      }
-    };
+    Object invalidObject = new Object();
 
     // when & then
-    RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+    Exception exception = assertThrows(RuntimeException.class, () -> {
       MapperUtil.toJsonNode(invalidObject);
     });
 
-    assertEquals("Failed to convert object to JsonNode", exception.getMessage());
+    assertThat(exception.getMessage()).contains("Failed to convert object to JsonNode");
   }
 
   static class TestPayload {

--- a/payment/src/test/java/table/eat/now/payment/payment/application/event/MapperUtilTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/application/event/MapperUtilTest.java
@@ -1,0 +1,83 @@
+package table.eat.now.payment.payment.application.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class MapperUtilTest {
+
+  @Test
+  void toJsonNode_는_BigDecimal을_일반숫자로_변환할_수_있다() {
+    // given
+    TestPayload dto = new TestPayload();
+    dto.setAmount(new BigDecimal("45000"));
+
+    // when
+    JsonNode jsonNode = MapperUtil.toJsonNode(dto);
+
+    // then
+    assertNotNull(jsonNode);
+    assertEquals("45000", jsonNode.get("amount").asText());
+  }
+
+  @Test
+  void toJsonNode_는_날짜를_ISO_문자열로_변환할_수_있다() {
+    // given
+    TestPayload dto = new TestPayload();
+    dto.setCreatedAt(LocalDateTime.of(2025, 4, 15, 1, 49, 51));
+
+    // when
+    JsonNode jsonNode = MapperUtil.toJsonNode(dto);
+
+    // then
+    assertNotNull(jsonNode);
+    assertEquals("2025-04-15T01:49:51", jsonNode.get("createdAt").asText());
+  }
+
+  @Test
+  void toJsonNode_는_변환할수없는객체에_예외를던진다() {
+    // given
+    Object invalidObject = new Object() {
+      private final Object circular = this;
+
+      @Override
+      public String toString() {
+        return "This object has a circular reference that cannot be serialized to JSON";
+      }
+    };
+
+    // when & then
+    RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+      MapperUtil.toJsonNode(invalidObject);
+    });
+
+    assertEquals("Failed to convert object to JsonNode", exception.getMessage());
+  }
+
+  static class TestPayload {
+
+    private BigDecimal amount;
+    private LocalDateTime createdAt;
+
+    public BigDecimal getAmount() {
+      return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+      this.amount = amount;
+    }
+
+    public LocalDateTime getCreatedAt() {
+      return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+      this.createdAt = createdAt;
+    }
+  }
+}

--- a/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentApiControllerTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentApiControllerTest.java
@@ -153,7 +153,7 @@ class PaymentApiControllerTest {
     @Test
     void 유효한_요청으로_결제_확인시_200_상태코드와_결제_정보를_반환한다() throws Exception {
       // given
-      when(paymentService.confirmPayment(any())).thenReturn(confirmPaymentInfo);
+      when(paymentService.confirmPayment(any(), any())).thenReturn(confirmPaymentInfo);
 
       // when
       ResultActions actions = mockMvc.perform(patch("/api/v1/payments/confirm")


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #113 

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용
- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 결제정보조회기능
  - [x] 성공 이벤트 발송 기능
  - [x] 테스트코드작성

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.

## 코멘트

- docker-compose.yml 을 수정했습니다 !
- 발송되는 메시지 예시입니다

<img width="1107" alt="스크린샷 2025-04-15 오전 2 37 48" src="https://github.com/user-attachments/assets/c628f879-d741-4602-baf0-ebd648b778ba" />
<img width="1090" alt="스크린샷 2025-04-15 오전 2 37 55" src="https://github.com/user-attachments/assets/0f0b7582-ce3a-42ad-aec6-5e87d68a86be" />
<img width="1095" alt="스크린샷 2025-04-15 오전 2 38 05" src="https://github.com/user-attachments/assets/b0256ed8-37a3-4e2f-8600-d8c6f714d5e7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 결제 단일 조회 API가 추가되어 사용자가 자신의 결제 정보를 확인할 수 있습니다.
  - 결제 단일 조회 시 사용자 권한(고객/마스터)에 따라 접근이 제한됩니다.
  - 결제 성공 시 이벤트가 Kafka로 발행됩니다.

- **버그 수정**
  - 결제 정보 조회 시 권한이 없을 경우 접근 거부(403) 오류가 반환됩니다.

- **테스트**
  - 결제 단일 조회, 권한 검증, 이벤트 발행 등에 대한 단위 테스트 및 통합 테스트가 추가되었습니다.

- **환경설정/운영**
  - Kafka 이미지 버전이 고정되었고, Kafka UI 포트 매핑이 변경되었습니다.
  - 결제 모듈에 Kafka 관련 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->