### PR TITLE
[waiting] 대기 정보 도메인 및 조회 기능 구현, 대기 요청 리팩토링

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -36,7 +36,11 @@ spring:
         - id: waiting
           uri: lb://waiting
           predicates:
-            - Path=/api/v1/waitings/**,/admin/v1/waitings/**,/api/v1/waiting-requests/**,/admin/v1/waiting-requests
+            - Path=/api/v1/waitings/**,/admin/v1/waitings/**
+        - id: waiting-request
+          uri: lb://waiting
+          predicates:
+            - Path=/api/v1/waiting-requests/**,/admin/v1/waiting-requests/**
         - id: coupon
           uri: lb://coupon
           predicates:

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/application/service/WaitingService.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/application/service/WaitingService.java
@@ -1,0 +1,8 @@
+package table.eat.now.waiting.waiting.application.service;
+
+import table.eat.now.waiting.waiting.application.service.dto.response.GetDailyWaitingInfo;
+
+public interface WaitingService {
+
+  GetDailyWaitingInfo getDailyWaitingInfo(String dailyWaitingUuid);
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/application/service/WaitingServiceImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/application/service/WaitingServiceImpl.java
@@ -1,0 +1,20 @@
+package table.eat.now.waiting.waiting.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import table.eat.now.waiting.waiting.application.service.dto.response.GetDailyWaitingInfo;
+import table.eat.now.waiting.waiting.domain.entity.DailyWaiting;
+import table.eat.now.waiting.waiting.domain.repository.WaitingRepository;
+
+@RequiredArgsConstructor
+@Service
+public class WaitingServiceImpl implements WaitingService {
+  private final WaitingRepository waitingRepository;
+
+  @Override
+  public GetDailyWaitingInfo getDailyWaitingInfo(String dailyWaitingUuid) {
+
+    DailyWaiting dailyWaiting = waitingRepository.getDailyWaitingBy(dailyWaitingUuid);
+    return GetDailyWaitingInfo.from(dailyWaiting);
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/application/service/dto/response/GetDailyWaitingInfo.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/application/service/dto/response/GetDailyWaitingInfo.java
@@ -1,0 +1,29 @@
+package table.eat.now.waiting.waiting.application.service.dto.response;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import table.eat.now.waiting.waiting.domain.entity.DailyWaiting;
+
+@Builder
+public record GetDailyWaitingInfo(
+    String dailyWaitingUuid,
+    String restaurantUuid,
+    String restaurantName,
+    String status,
+    long avgWaitingSec,
+    LocalDate waitingDate,
+    Long totalSequence
+) {
+
+  public static GetDailyWaitingInfo from(DailyWaiting dailyWaiting) {
+    return GetDailyWaitingInfo.builder()
+        .dailyWaitingUuid(dailyWaiting.getDailyWaitingUuid())
+        .restaurantUuid(dailyWaiting.getRestaurantUuid())
+        .restaurantName(dailyWaiting.getRestaurantName())
+        .status(dailyWaiting.getStatus().toString())
+        .avgWaitingSec(dailyWaiting.getAvgWaitingSec())
+        .waitingDate(dailyWaiting.getWaitingDate())
+        .totalSequence(dailyWaiting.getTotalSequence())
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/domain/entity/DailyWaiting.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/domain/entity/DailyWaiting.java
@@ -1,0 +1,68 @@
+package table.eat.now.waiting.waiting.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import table.eat.now.common.domain.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class DailyWaiting extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Column(nullable = false, length = 100, unique = true)
+  private String dailyWaitingUuid;
+
+  @Column(nullable = false, length = 100)
+  private String restaurantUuid;
+
+  @Column(nullable = false, length = 200)
+  private String restaurantName;
+
+  @Enumerated(value = EnumType.STRING)
+  @Column(nullable = false)
+  private WaitingStatus status;
+
+  @Column(nullable = false)
+  private LocalDate waitingDate;
+
+  @Column(nullable = false)
+  private long avgWaitingSec;
+
+  private Long totalSequence;
+
+  private DailyWaiting(String restaurantUuid, String restaurantName, WaitingStatus status,
+      LocalDate waitingDate, long avgWaitingSec) {
+    this.dailyWaitingUuid = UUID.randomUUID().toString();
+    this.restaurantUuid = restaurantUuid;
+    this.restaurantName = restaurantName;
+    this.status = status;
+    this.waitingDate = waitingDate;
+    this.avgWaitingSec = avgWaitingSec;
+  }
+
+  public static DailyWaiting of(String restaurantUuid, String restaurantName, String status,
+      LocalDate waitingDate, long avgWaitingSec) {
+    return new DailyWaiting(restaurantUuid, restaurantName, WaitingStatus.valueOf(status), waitingDate, avgWaitingSec);
+  }
+
+  @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+  public enum WaitingStatus {
+    AVAILABLE,
+    UNAVAILABLE,
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/domain/repository/WaitingRepository.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/domain/repository/WaitingRepository.java
@@ -1,0 +1,10 @@
+package table.eat.now.waiting.waiting.domain.repository;
+
+import table.eat.now.waiting.waiting.domain.entity.DailyWaiting;
+
+public interface WaitingRepository {
+
+  DailyWaiting getDailyWaitingBy(String dailyWaitingUuid);
+
+  DailyWaiting save(DailyWaiting dailyWaiting);
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/infrastructure/exception/WaitingInfraErrorCode.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/infrastructure/exception/WaitingInfraErrorCode.java
@@ -1,0 +1,18 @@
+package table.eat.now.waiting.waiting.infrastructure.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import table.eat.now.common.exception.type.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum WaitingInfraErrorCode implements ErrorCode {
+
+  INVALID_DAILY_WAITING_UUID(
+      "유효하지 않은 일간 대기 정보 아이디입니다.", HttpStatus.NOT_FOUND);
+
+  private final String message;
+  private final HttpStatus status;
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/infrastructure/persistence/WaitingRepositoryImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/infrastructure/persistence/WaitingRepositoryImpl.java
@@ -1,0 +1,26 @@
+package table.eat.now.waiting.waiting.infrastructure.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.waiting.waiting.domain.entity.DailyWaiting;
+import table.eat.now.waiting.waiting.domain.repository.WaitingRepository;
+import table.eat.now.waiting.waiting.infrastructure.exception.WaitingInfraErrorCode;
+import table.eat.now.waiting.waiting.infrastructure.persistence.jpa.JpaWaitingRepository;
+
+@RequiredArgsConstructor
+@Repository
+public class WaitingRepositoryImpl implements WaitingRepository {
+  private final JpaWaitingRepository jpaRepository;
+
+  @Override
+  public DailyWaiting getDailyWaitingBy(String dailyWaitingUuid) {
+    return jpaRepository.findByDailyWaitingUuidAndDeletedAtIsNull(dailyWaitingUuid)
+        .orElseThrow(() -> CustomException.from(WaitingInfraErrorCode.INVALID_DAILY_WAITING_UUID));
+  }
+
+  @Override
+  public DailyWaiting save(DailyWaiting dailyWaiting) {
+    return jpaRepository.save(dailyWaiting);
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/infrastructure/persistence/jpa/JpaWaitingRepository.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/infrastructure/persistence/jpa/JpaWaitingRepository.java
@@ -1,0 +1,10 @@
+package table.eat.now.waiting.waiting.infrastructure.persistence.jpa;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import table.eat.now.waiting.waiting.domain.entity.DailyWaiting;
+
+public interface JpaWaitingRepository extends JpaRepository<DailyWaiting, Long> {
+
+  Optional<DailyWaiting> findByDailyWaitingUuidAndDeletedAtIsNull(String dailyWaitingUuid);
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/presentation/WaitingInternalController.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/presentation/WaitingInternalController.java
@@ -1,0 +1,27 @@
+package table.eat.now.waiting.waiting.presentation;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import table.eat.now.waiting.waiting.application.service.WaitingService;
+import table.eat.now.waiting.waiting.application.service.dto.response.GetDailyWaitingInfo;
+import table.eat.now.waiting.waiting.presentation.dto.response.GetDailyWaitingResponse;
+
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/waitings")
+@RestController
+public class WaitingInternalController {
+  private final WaitingService waitingService;
+
+  @GetMapping("/{dailyWaitingUuid}")
+  public ResponseEntity<GetDailyWaitingResponse> getDailyWaitingInfo(
+      @PathVariable UUID dailyWaitingUuid
+  ) {
+    GetDailyWaitingInfo info = waitingService.getDailyWaitingInfo(dailyWaitingUuid.toString());
+    return ResponseEntity.ok().body(GetDailyWaitingResponse.from(info));
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/presentation/dto/response/GetDailyWaitingResponse.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/presentation/dto/response/GetDailyWaitingResponse.java
@@ -1,0 +1,29 @@
+package table.eat.now.waiting.waiting.presentation.dto.response;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import table.eat.now.waiting.waiting.application.service.dto.response.GetDailyWaitingInfo;
+
+@Builder
+public record GetDailyWaitingResponse(
+    String dailyWaitingUuid,
+    String restaurantUuid,
+    String restaurantName,
+    String status,
+    long avgWaitingSec,
+    LocalDate waitingDate,
+    Long totalSequence
+) {
+
+  public static GetDailyWaitingResponse from(GetDailyWaitingInfo info) {
+    return GetDailyWaitingResponse.builder()
+        .dailyWaitingUuid(info.dailyWaitingUuid())
+        .restaurantUuid(info.restaurantUuid())
+        .restaurantName(info.restaurantName())
+        .status(info.status())
+        .avgWaitingSec(info.avgWaitingSec())
+        .waitingDate(info.waitingDate())
+        .totalSequence(info.totalSequence())
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/client/WaitingClient.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/client/WaitingClient.java
@@ -1,0 +1,9 @@
+package table.eat.now.waiting.waiting_request.application.client;
+
+
+import table.eat.now.waiting.waiting_request.application.dto.response.GetDailyWaitingInfo;
+
+public interface WaitingClient {
+
+  GetDailyWaitingInfo getDailyWaitingInfo(String dailyWaitingUuid);
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/response/GetDailyWaitingInfo.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/response/GetDailyWaitingInfo.java
@@ -1,0 +1,25 @@
+package table.eat.now.waiting.waiting_request.application.dto.response;
+
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record GetDailyWaitingInfo(
+    String dailyWaitingUuid,
+    String restaurantUuid,
+    String restaurantName,
+    String status,
+    long avgWaitingSec,
+    LocalDate waitingDate,
+    Long totalSequence
+) {
+
+  public boolean isAvailable() {
+    return status.equals(WaitingStatus.AVAILABLE.toString());
+  }
+
+  enum WaitingStatus {
+    AVAILABLE,
+    UNAVAILABLE
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/exception/WaitingRequestErrorCode.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/exception/WaitingRequestErrorCode.java
@@ -16,7 +16,8 @@ public enum WaitingRequestErrorCode implements ErrorCode {
       "유효하지 않은 대기 요청 아이디입니다.", HttpStatus.NOT_FOUND),
   UNAUTH_REQUEST(
       "권한이 없는 요청입니다.", HttpStatus.FORBIDDEN),
-  ;
+  UNAVAILABLE_WAITING(
+      "현재 대기가 불가능한 식당입니다.", HttpStatus.UNPROCESSABLE_ENTITY),;
 
   private final String message;
   private final HttpStatus status;

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingStatus.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingStatus.java
@@ -8,10 +8,10 @@ public enum WaitingStatus {
 
   WAITING("대기중"),
   POSTPONED("입장연기"),
-  SEATED("착석"),
   CANCELED("취소"),
-  LEAVED("식사종료"),
   NO_SHOW("노쇼"),
+  SEATED("착석"),
+  LEAVED("식사종료"),
   ;
 
   private final String description;

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/client/WaitingClientImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/client/WaitingClientImpl.java
@@ -1,0 +1,18 @@
+package table.eat.now.waiting.waiting_request.infrastructure.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
+import table.eat.now.waiting.waiting_request.application.dto.response.GetDailyWaitingInfo;
+import table.eat.now.waiting.waiting_request.infrastructure.client.feign.WaitingFeignClient;
+
+@RequiredArgsConstructor
+@Component
+public class WaitingClientImpl implements WaitingClient {
+  private final WaitingFeignClient feignClient;
+
+  @Override
+  public GetDailyWaitingInfo getDailyWaitingInfo(String dailyWaitingUuid) {
+    return feignClient.getDailyWaitingInfo(dailyWaitingUuid).getBody().toInfo();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/client/dto/response/GetDailyWaitingResponse.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/client/dto/response/GetDailyWaitingResponse.java
@@ -1,0 +1,29 @@
+package table.eat.now.waiting.waiting_request.infrastructure.client.dto.response;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import table.eat.now.waiting.waiting_request.application.dto.response.GetDailyWaitingInfo;
+
+@Builder
+public record GetDailyWaitingResponse(
+    String dailyWaitingUuid,
+    String restaurantUuid,
+    String restaurantName,
+    String status,
+    long avgWaitingSec,
+    LocalDate waitingDate,
+    Long totalSequence
+) {
+
+  public GetDailyWaitingInfo toInfo() {
+    return GetDailyWaitingInfo.builder()
+        .dailyWaitingUuid(dailyWaitingUuid)
+        .restaurantUuid(restaurantUuid)
+        .restaurantName(restaurantName)
+        .status(status)
+        .avgWaitingSec(avgWaitingSec)
+        .waitingDate(waitingDate)
+        .totalSequence(totalSequence)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/client/feign/WaitingFeignClient.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/client/feign/WaitingFeignClient.java
@@ -1,0 +1,15 @@
+package table.eat.now.waiting.waiting_request.infrastructure.client.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import table.eat.now.waiting.waiting_request.infrastructure.client.dto.response.GetDailyWaitingResponse;
+import table.eat.now.waiting.waiting_request.infrastructure.client.feign.config.InternalFeignConfig;
+
+@FeignClient(name="waiting", configuration = InternalFeignConfig.class)
+public interface WaitingFeignClient {
+
+  @GetMapping("/internal/v1/waiting/{dailyWaitingUuid}")
+  ResponseEntity<GetDailyWaitingResponse> getDailyWaitingInfo(@PathVariable String dailyWaitingUuid);
+}

--- a/waiting/src/test/java/table/eat/now/waiting/waiting/application/service/WaitingServiceImplTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting/application/service/WaitingServiceImplTest.java
@@ -1,0 +1,43 @@
+package table.eat.now.waiting.waiting.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import table.eat.now.waiting.helper.IntegrationTestSupport;
+import table.eat.now.waiting.waiting.application.service.dto.response.GetDailyWaitingInfo;
+import table.eat.now.waiting.waiting.domain.entity.DailyWaiting;
+import table.eat.now.waiting.waiting.domain.repository.WaitingRepository;
+
+class WaitingServiceImplTest extends IntegrationTestSupport {
+
+  @Autowired
+  private WaitingService waitingService;
+  @Autowired
+  private WaitingRepository waitingRepository;
+  private DailyWaiting dailyWaiting;
+
+  @BeforeEach
+  void setUp() {
+    dailyWaiting = DailyWaiting.of(UUID.randomUUID().toString(), "지훈이네 식당",
+        "AVAILABLE", LocalDate.now(), 600L);
+    waitingRepository.save(dailyWaiting);
+  }
+
+  @DisplayName("일간 대기 정보 단건 조회 검증 - 성공")
+  @Test
+  void getDailyWaitingInfo() {
+    // given
+    // when
+    GetDailyWaitingInfo dailyWaitingInfo = waitingService.getDailyWaitingInfo(
+        dailyWaiting.getDailyWaitingUuid());
+
+    // then
+    assertThat(dailyWaitingInfo.status()).isEqualTo(dailyWaiting.getStatus().toString());
+    assertThat(dailyWaitingInfo.waitingDate()).isEqualTo(dailyWaiting.getWaitingDate());
+  }
+}

--- a/waiting/src/test/java/table/eat/now/waiting/waiting/presentation/WaitingInternalControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting/presentation/WaitingInternalControllerTest.java
@@ -1,0 +1,55 @@
+package table.eat.now.waiting.waiting.presentation;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.waiting.helper.ControllerTestSupport;
+import table.eat.now.waiting.waiting.application.service.WaitingService;
+import table.eat.now.waiting.waiting.application.service.dto.response.GetDailyWaitingInfo;
+
+@WebMvcTest(WaitingInternalController.class)
+class WaitingInternalControllerTest extends ControllerTestSupport {
+
+  @MockitoBean
+  private WaitingService waitingService;
+
+  @DisplayName("일간 대기 정보 내부 조회 검증 - 200 성공")
+  @Test
+  void getDailyWaitingInfo() throws Exception {
+    // given
+    var info = GetDailyWaitingInfo.builder()
+        .dailyWaitingUuid(UUID.randomUUID().toString())
+        .restaurantUuid(UUID.randomUUID().toString())
+        .restaurantName("혜주네 식당")
+        .waitingDate(LocalDate.now())
+        .avgWaitingSec(600L)
+        .status("AVAILABLE")
+        .totalSequence(null)
+        .build();
+
+    given(waitingService.getDailyWaitingInfo(eq(info.dailyWaitingUuid()))).willReturn(info);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        get("/internal/v1/waitings/{dailyWaitingUuid}", info.dailyWaitingUuid()));
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andExpect(jsonPath("$.dailyWaitingUuid").value(info.dailyWaitingUuid()))
+        .andExpect(jsonPath("$.restaurantUuid").value(info.restaurantUuid()))
+        .andExpect(jsonPath("$.restaurantName").value(info.restaurantName()))
+        .andExpect(jsonPath("$.status").value(info.status()))
+        .andDo(print());
+  }
+}

--- a/waiting/src/test/waiting.http
+++ b/waiting/src/test/waiting.http
@@ -1,3 +1,7 @@
+### 대기 정보 조회
+GET localhost:8086/internal/v1/waitings/00000000-0000-0000-0000-000000000001
+Content-Type: application/json
+
 ### 대기 요청 생성
 POST localhost:8086/api/v1/waiting-requests
 Content-Type: application/json


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #117 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 대기 정보 도메인 및 조회 기능 구현, 테스트
  - [x]  대기 요청 리팩토링

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 일간 대기 정보 조회를 위한 내부 API 엔드포인트가 추가되었습니다.
  - 일간 대기 정보 엔티티 및 관련 DTO, 서비스, 레포지토리, 예외 코드가 도입되었습니다.
  - 대기 요청 생성 시 일간 대기 정보와 연동되어 실시간 데이터 기반으로 처리됩니다.

- **버그 수정**
  - 대기가 불가능한 식당에 대한 예외 처리가 추가되었습니다.

- **테스트**
  - 일간 대기 정보 서비스 및 컨트롤러, 대기 요청 서비스의 신규/변경 기능에 대한 테스트가 추가되었습니다.

- **문서화**
  - 내부 API 엔드포인트에 대한 HTTP 테스트 케이스가 추가되었습니다.

- **기타**
  - Gateway 라우팅 설정이 세분화되어 관리가 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->