### PR TITLE
[restaurant] 타임슬롯 현재 인원 변경

### DIFF
--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/exception/RestaurantTimeSlotErrorCode.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/exception/RestaurantTimeSlotErrorCode.java
@@ -1,0 +1,24 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 15.
+ */
+package table.eat.now.restaurant.restaurant.application.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import table.eat.now.common.exception.type.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum RestaurantTimeSlotErrorCode implements ErrorCode {
+
+  // BAD_REQUEST
+  EXCEEDS_CAPACITY("식당 타임 슬롯의 자리가 부족합니다.", HttpStatus.BAD_REQUEST),
+
+  // NOT_FOUNT
+  NOT_FOUND("식당 타임 슬롯을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  ;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantService.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantService.java
@@ -14,4 +14,6 @@ public interface RestaurantService {
   CreateRestaurantInfo createRestaurant(CreateRestaurantCommand command);
 
   GetRestaurantInfo getRestaurant(GetRestaurantCriteria criteria);
+
+  void modifyTimeSlotGuestCount(String restaurantTimeSlotUuid, int delta);
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantService.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantService.java
@@ -15,5 +15,5 @@ public interface RestaurantService {
 
   GetRestaurantInfo getRestaurant(GetRestaurantCriteria criteria);
 
-  void modifyTimeSlotGuestCount(String restaurantTimeSlotUuid, int delta);
+  void increaseOrDecreaseTimeSlotGuestCount(String restaurantTimeSlotUuid, int delta);
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantServiceImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantServiceImpl.java
@@ -69,7 +69,7 @@ public class RestaurantServiceImpl implements RestaurantService {
 
   @Override
   @Transactional
-  public void modifyTimeSlotGuestCount(String restaurantTimeSlotUuid, int delta) {
+  public void increaseOrDecreaseTimeSlotGuestCount(String restaurantTimeSlotUuid, int delta) {
     RestaurantTimeSlot timeSlot = restaurantTimeSlotRepository
         .findWithLockByRestaurantTimeslotUuid(restaurantTimeSlotUuid)
         .orElseThrow(() -> new CustomException(RestaurantTimeSlotErrorCode.NOT_FOUND));

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantServiceImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantServiceImpl.java
@@ -9,18 +9,23 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.restaurant.restaurant.application.exception.RestaurantErrorCode;
+import table.eat.now.restaurant.restaurant.application.exception.RestaurantTimeSlotErrorCode;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.CreateRestaurantCommand;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantCriteria;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.CreateRestaurantInfo;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.GetRestaurantInfo;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
+import table.eat.now.restaurant.restaurant.domain.entity.RestaurantTimeSlot;
 import table.eat.now.restaurant.restaurant.domain.repository.RestaurantRepository;
+import table.eat.now.restaurant.restaurant.domain.repository.RestaurantTimeSlotRepository;
 
 @Service
 @RequiredArgsConstructor
 public class RestaurantServiceImpl implements RestaurantService {
 
   private final RestaurantRepository restaurantRepository;
+
+  private final RestaurantTimeSlotRepository restaurantTimeSlotRepository;
 
   @Override
   public CreateRestaurantInfo createRestaurant(CreateRestaurantCommand command) {
@@ -39,14 +44,16 @@ public class RestaurantServiceImpl implements RestaurantService {
         includeInactive = true;
       }
       case OWNER -> {
-        boolean isOwner = restaurantRepository.isOwner(criteria.userId(), criteria.restaurantUuid());
+        boolean isOwner = restaurantRepository.isOwner(criteria.userId(),
+            criteria.restaurantUuid());
         if (isOwner) {
           includeDeleted = true;
           includeInactive = true;
         }
       }
       case STAFF -> {
-        boolean isStaff = restaurantRepository.isStaff(criteria.userId(), criteria.restaurantUuid());
+        boolean isStaff = restaurantRepository.isStaff(criteria.userId(),
+            criteria.restaurantUuid());
         if (isStaff) {
           includeInactive = true;
         }
@@ -58,6 +65,22 @@ public class RestaurantServiceImpl implements RestaurantService {
     ).orElseThrow(() -> CustomException.from(RestaurantErrorCode.RESTAURANT_NOT_FOUND));
 
     return GetRestaurantInfo.from(restaurant);
+  }
+
+  @Override
+  @Transactional
+  public void modifyTimeSlotGuestCount(String restaurantTimeSlotUuid, int delta) {
+    RestaurantTimeSlot timeSlot = restaurantTimeSlotRepository
+        .findWithLockByRestaurantTimeslotUuid(restaurantTimeSlotUuid)
+        .orElseThrow(() -> new CustomException(RestaurantTimeSlotErrorCode.NOT_FOUND));
+
+    int newCount = timeSlot.getCurTotalGuestCount() + delta;
+
+    if (newCount < 0 || newCount > timeSlot.getMaxCapacity()) {
+      throw new CustomException(RestaurantTimeSlotErrorCode.EXCEEDS_CAPACITY);
+    }
+
+    timeSlot.modifyCurTotalGuestCount(newCount);
   }
 
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/entity/RestaurantTimeSlot.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/entity/RestaurantTimeSlot.java
@@ -71,6 +71,9 @@ public class RestaurantTimeSlot extends BaseEntity {
   }
 
   public void modifyCurTotalGuestCount(int newCount) {
+    if(maxCapacity < newCount) {
+      throw new IllegalArgumentException("curTotalGuestCount 는 maxCapacity 보다 클 수 없습니다.");
+    }
     this.curTotalGuestCount = newCount;
   }
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/entity/RestaurantTimeSlot.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/entity/RestaurantTimeSlot.java
@@ -69,4 +69,8 @@ public class RestaurantTimeSlot extends BaseEntity {
   public void modifyRestaurant(Restaurant restaurant) {
     this.restaurant = restaurant;
   }
+
+  public void modifyCurTotalGuestCount(int newCount) {
+    this.curTotalGuestCount = newCount;
+  }
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/entity/RestaurantTimeSlot.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/entity/RestaurantTimeSlot.java
@@ -71,7 +71,10 @@ public class RestaurantTimeSlot extends BaseEntity {
   }
 
   public void modifyCurTotalGuestCount(int newCount) {
-    if(maxCapacity < newCount) {
+    if(newCount < 0) {
+      throw new IllegalArgumentException("curTotalGuestCount 는 음수가 될 수 없습니다.");
+    }
+    if(newCount > maxCapacity) {
       throw new IllegalArgumentException("curTotalGuestCount 는 maxCapacity 보다 클 수 없습니다.");
     }
     this.curTotalGuestCount = newCount;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/repository/RestaurantTimeSlotRepository.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/repository/RestaurantTimeSlotRepository.java
@@ -1,0 +1,9 @@
+package table.eat.now.restaurant.restaurant.domain.repository;
+
+import java.util.Optional;
+import table.eat.now.restaurant.restaurant.domain.entity.RestaurantTimeSlot;
+
+public interface RestaurantTimeSlotRepository {
+
+  Optional<RestaurantTimeSlot> findWithLockByRestaurantTimeslotUuid(String restaurantTimeSlotUuid);
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/repository/RestaurantTimeSlotRepository.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/repository/RestaurantTimeSlotRepository.java
@@ -6,4 +6,8 @@ import table.eat.now.restaurant.restaurant.domain.entity.RestaurantTimeSlot;
 public interface RestaurantTimeSlotRepository {
 
   Optional<RestaurantTimeSlot> findWithLockByRestaurantTimeslotUuid(String restaurantTimeSlotUuid);
+
+  // test 용
+  Optional<RestaurantTimeSlot> findById(Long id);
+
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/repository/RestaurantTimeSlotRepository.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/repository/RestaurantTimeSlotRepository.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 15.
+ */
 package table.eat.now.restaurant.restaurant.domain.repository;
 
 import java.util.Optional;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/JpaRestaurantTimeSlotRepository.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/JpaRestaurantTimeSlotRepository.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 15.
+ */
 package table.eat.now.restaurant.restaurant.infrastructure.persistence;
 
 import jakarta.persistence.LockModeType;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/JpaRestaurantTimeSlotRepository.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/JpaRestaurantTimeSlotRepository.java
@@ -1,0 +1,18 @@
+package table.eat.now.restaurant.restaurant.infrastructure.persistence;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import table.eat.now.restaurant.restaurant.domain.entity.RestaurantTimeSlot;
+import table.eat.now.restaurant.restaurant.domain.repository.RestaurantTimeSlotRepository;
+
+public interface JpaRestaurantTimeSlotRepository extends JpaRepository<RestaurantTimeSlot, Long>,
+    RestaurantTimeSlotRepository {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT rt FROM RestaurantTimeSlot rt WHERE rt.restaurantTimeslotUuid = :uuid")
+  Optional<RestaurantTimeSlot> findWithLockByRestaurantTimeslotUuid(@Param("uuid") String uuid);
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/RestaurantInternalController.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/RestaurantInternalController.java
@@ -7,8 +7,10 @@ package table.eat.now.restaurant.restaurant.presentation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
@@ -29,5 +31,15 @@ public class RestaurantInternalController {
         .body(GetRestaurantResponse.from(
             restaurantService.getRestaurant(
                 GetRestaurantCriteria.from(restaurantUuid, userInfo.role(), userInfo.userId()))));
+  }
+
+  @PatchMapping("/{restaurantUuid}/timeslot/{restaurantTimeSlotUuid}/cur-total-guest-count")
+  public ResponseEntity<Void> updateGuestCount(
+      @PathVariable String restaurantUuid,
+      @PathVariable String restaurantTimeSlotUuid,
+      @RequestParam int delta
+  ) {
+    restaurantService.modifyTimeSlotGuestCount(restaurantTimeSlotUuid, delta);
+    return ResponseEntity.ok().build();
   }
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/RestaurantInternalController.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/RestaurantInternalController.java
@@ -34,12 +34,12 @@ public class RestaurantInternalController {
   }
 
   @PatchMapping("/{restaurantUuid}/timeslot/{restaurantTimeSlotUuid}/cur-total-guest-count")
-  public ResponseEntity<Void> updateGuestCount(
+  public ResponseEntity<Void> modifyGuestCount(
       @PathVariable String restaurantUuid,
       @PathVariable String restaurantTimeSlotUuid,
       @RequestParam int delta
   ) {
-    restaurantService.modifyTimeSlotGuestCount(restaurantTimeSlotUuid, delta);
+    restaurantService.increaseOrDecreaseTimeSlotGuestCount(restaurantTimeSlotUuid, delta);
     return ResponseEntity.ok().build();
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #127

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용

- **to-be**
  - [x] 타임슬롯 현재 인원 변경

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [x] 문서(코드, 주석, README 등)를 업데이트했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 레스토랑 타임슬롯의 현재 총 게스트 수를 증감하는 PATCH API 엔드포인트가 추가되었습니다.
- **버그 수정**
    - 타임슬롯의 게스트 수가 최대 수용 인원을 초과하거나 음수로 내려가는 경우 오류가 반환됩니다.
- **테스트**
    - 타임슬롯 게스트 수 증감 기능에 대한 단위 테스트 및 동시성 테스트가 추가되었습니다.
    - 관련 컨트롤러 API 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->