### PR TITLE
[payment] 예약취소 컨슈머 구현, 취소 이벤트발송

### DIFF
--- a/payment/src/main/java/table/eat/now/payment/payment/application/PaymentService.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/PaymentService.java
@@ -1,6 +1,7 @@
 package table.eat.now.payment.payment.application;
 
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.payment.payment.application.dto.request.CancelPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.ConfirmPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
 import table.eat.now.payment.payment.application.dto.response.ConfirmPaymentInfo;
@@ -17,4 +18,6 @@ public interface PaymentService {
   ConfirmPaymentInfo confirmPayment(ConfirmPaymentCommand command, CurrentUserInfoDto userInfo);
 
   GetPaymentInfo getPayment(String paymentUuid, CurrentUserInfoDto userInfo);
+
+  void cancelPayment(CancelPaymentCommand command, CurrentUserInfoDto userInfo);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/PaymentServiceImpl.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/PaymentServiceImpl.java
@@ -14,6 +14,7 @@ import table.eat.now.common.exception.CustomException;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.payment.payment.application.client.PgClient;
 import table.eat.now.payment.payment.application.client.ReservationClient;
+import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.CancelPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.ConfirmPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
@@ -24,6 +25,8 @@ import table.eat.now.payment.payment.application.dto.response.CreatePaymentInfo;
 import table.eat.now.payment.payment.application.dto.response.GetCheckoutDetailInfo;
 import table.eat.now.payment.payment.application.dto.response.GetPaymentInfo;
 import table.eat.now.payment.payment.application.client.dto.GetReservationInfo;
+import table.eat.now.payment.payment.application.event.PaymentCanceledEvent;
+import table.eat.now.payment.payment.application.event.PaymentCanceledPayload;
 import table.eat.now.payment.payment.application.event.PaymentEventPublisher;
 import table.eat.now.payment.payment.application.event.PaymentFailedEvent;
 import table.eat.now.payment.payment.application.event.PaymentFailedPayload;
@@ -86,9 +89,9 @@ public class PaymentServiceImpl implements PaymentService {
     ConfirmPgPaymentInfo confirmedInfo = confirm(command, payment);
     try {
       completePayment(userInfo, payment, confirmedInfo);
-    } catch (IllegalArgumentException e) {
-      transactionalHelper
-          .doInNewTransaction(() -> rollbackPayment(command, userInfo, e, payment));
+    } catch (Exception e) {
+      transactionalHelper.doInNewTransaction(
+          () -> rollbackPayment(command, userInfo, e, payment));
     }
     return ConfirmPaymentInfo.from(payment);
   }
@@ -112,20 +115,30 @@ public class PaymentServiceImpl implements PaymentService {
         .publish(PaymentSuccessEvent.of(PaymentSuccessPayload.from(payment), userInfo));
   }
 
-  private void rollbackPayment(ConfirmPaymentCommand command, CurrentUserInfoDto userInfo,
-      IllegalArgumentException e, Payment payment) {
+  private void rollbackPayment(
+      ConfirmPaymentCommand command, CurrentUserInfoDto userInfo, Exception e, Payment payment) {
     String cancelReason = e.getMessage();
-    cancel(command, cancelReason, payment);
+    cancel(command.paymentKey(), cancelReason, payment);
     paymentEventPublisher.publish(PaymentFailedEvent.of(
         PaymentFailedPayload.from(payment, cancelReason), userInfo
     ));
   }
 
-  private void cancel(ConfirmPaymentCommand command, String cancelReason, Payment payment) {
+  private void cancel(String paymentKey, String cancelReason, Payment payment) {
     CancelPgPaymentInfo cancelledInfo = pgClient.cancel(
-        CancelPaymentCommand.of(command.paymentKey(), cancelReason), payment.getIdempotencyKey());
+        CancelPgPaymentCommand.of(paymentKey, cancelReason), payment.getIdempotencyKey());
     log.info("Cancel payment {}", cancelledInfo);
     payment.cancel(cancelledInfo.toCancel());
+  }
+
+  @Override
+  @Transactional
+  public void cancelPayment(CancelPaymentCommand command, CurrentUserInfoDto userInfo) {
+    Payment payment = getPaymentByReservationId(command.reservationUuid());
+    cancel(command.idempotencyKey(), command.cancelReason(), payment);
+    paymentEventPublisher.publish(PaymentCanceledEvent.of(
+        PaymentCanceledPayload.from(payment), userInfo
+    ));
   }
 
   @Override

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/PgClient.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/PgClient.java
@@ -1,6 +1,6 @@
 package table.eat.now.payment.payment.application.client;
 
-import table.eat.now.payment.payment.application.dto.request.CancelPaymentCommand;
+import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.ConfirmPaymentCommand;
 import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentInfo;
 import table.eat.now.payment.payment.application.client.dto.ConfirmPgPaymentInfo;
@@ -9,5 +9,5 @@ public interface PgClient {
 
   ConfirmPgPaymentInfo confirm(ConfirmPaymentCommand command, String idempotencyKey);
 
-  CancelPgPaymentInfo cancel(CancelPaymentCommand command, String idempotencyKey);
+  CancelPgPaymentInfo cancel(CancelPgPaymentCommand command, String idempotencyKey);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/CancelPgPaymentCommand.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/CancelPgPaymentCommand.java
@@ -1,0 +1,10 @@
+package table.eat.now.payment.payment.application.client.dto;
+
+public record CancelPgPaymentCommand(
+    String paymentKey,
+    String cancelReason
+) {
+  public static CancelPgPaymentCommand of(String paymentKey, String cancelReason) {
+    return new CancelPgPaymentCommand(paymentKey, cancelReason);
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/dto/request/CancelPaymentCommand.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/dto/request/CancelPaymentCommand.java
@@ -1,10 +1,9 @@
 package table.eat.now.payment.payment.application.dto.request;
 
 public record CancelPaymentCommand(
-    String paymentKey,
+    String reservationUuid,
+    String idempotencyKey,
     String cancelReason
 ) {
-  public static CancelPaymentCommand of(String paymentKey, String cancelReason) {
-    return new CancelPaymentCommand(paymentKey, cancelReason);
-  }
+
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentCanceledEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentCanceledEvent.java
@@ -1,0 +1,20 @@
+package table.eat.now.payment.payment.application.event;
+
+import static table.eat.now.payment.payment.application.event.EventType.CANCEL_SUCCEED;
+
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+
+public record PaymentCanceledEvent(
+    EventType eventType,
+    String paymentUuid,
+    PaymentCanceledPayload payload,
+    CurrentUserInfoDto userInfo
+) implements PaymentEvent {
+
+  public static PaymentCanceledEvent of(
+      PaymentCanceledPayload payload, CurrentUserInfoDto userInfo) {
+    return new PaymentCanceledEvent(
+        CANCEL_SUCCEED, payload.paymentUuid(), payload, userInfo);
+  }
+
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentCanceledPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentCanceledPayload.java
@@ -1,0 +1,20 @@
+package table.eat.now.payment.payment.application.event;
+
+import java.time.LocalDateTime;
+import table.eat.now.payment.payment.domain.entity.Payment;
+
+public record PaymentCanceledPayload(
+    String idempotencyKey,
+    String paymentUuid,
+    String paymentStatus,
+    LocalDateTime cancelledAt
+) {
+  public static PaymentCanceledPayload from(Payment payment) {
+    return new PaymentCanceledPayload(
+        payment.getIdentifier().getIdempotencyKey(),
+        payment.getIdentifier().getPaymentUuid(),
+        payment.getPaymentStatus().name(),
+        payment.getCancelledAt()
+    );
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEvent.java
@@ -1,12 +1,8 @@
 package table.eat.now.payment.payment.application.event;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 public interface PaymentEvent {
 
   EventType eventType();
 
   String paymentUuid();
-
-  JsonNode payload();
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEvent.java
@@ -1,8 +1,12 @@
 package table.eat.now.payment.payment.application.event;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public interface PaymentEvent {
 
   EventType eventType();
 
   String paymentUuid();
+
+  JsonNode payload();
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEventPublisher.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEventPublisher.java
@@ -3,4 +3,6 @@ package table.eat.now.payment.payment.application.event;
 public interface PaymentEventPublisher {
 
   void publish(PaymentSuccessEvent createdEvent);
+
+  void publish(PaymentFailedEvent failedEvent);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEventPublisher.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEventPublisher.java
@@ -5,4 +5,6 @@ public interface PaymentEventPublisher {
   void publish(PaymentSuccessEvent createdEvent);
 
   void publish(PaymentFailedEvent failedEvent);
+
+  void publish(PaymentCanceledEvent canceledEvent);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentFailedEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentFailedEvent.java
@@ -1,0 +1,20 @@
+package table.eat.now.payment.payment.application.event;
+
+import static table.eat.now.payment.payment.application.event.EventType.FAILED;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+
+public record PaymentFailedEvent(
+    EventType eventType,
+    String paymentUuid,
+    JsonNode payload,
+    CurrentUserInfoDto userInfo
+) implements PaymentEvent {
+
+  public static PaymentFailedEvent of(
+      PaymentFailedPayload payload, CurrentUserInfoDto userInfo) {
+    return new PaymentFailedEvent(
+        FAILED, payload.paymentUuid(), MapperUtil.toJsonNode(payload), userInfo);
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentFailedEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentFailedEvent.java
@@ -8,13 +8,13 @@ import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 public record PaymentFailedEvent(
     EventType eventType,
     String paymentUuid,
-    JsonNode payload,
+    PaymentFailedPayload payload,
     CurrentUserInfoDto userInfo
 ) implements PaymentEvent {
 
   public static PaymentFailedEvent of(
       PaymentFailedPayload payload, CurrentUserInfoDto userInfo) {
     return new PaymentFailedEvent(
-        FAILED, payload.paymentUuid(), MapperUtil.toJsonNode(payload), userInfo);
+        FAILED, payload.paymentUuid(), payload, userInfo);
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentFailedPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentFailedPayload.java
@@ -1,0 +1,22 @@
+package table.eat.now.payment.payment.application.event;
+
+import java.time.LocalDateTime;
+import table.eat.now.payment.payment.domain.entity.Payment;
+
+public record PaymentFailedPayload(
+    String paymentUuid,
+    String paymentKey,
+    String cancelReason,
+    LocalDateTime cancelledAt,
+    String paymentStatus
+) {
+  public static PaymentFailedPayload from(Payment payment, String cancelReason) {
+    return new PaymentFailedPayload(
+        payment.getIdentifier().getPaymentUuid(),
+        payment.getPaymentKey(),
+        cancelReason,
+        payment.getCancelledAt(),
+        payment.getPaymentStatus().name()
+    );
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentSuccessEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentSuccessEvent.java
@@ -3,13 +3,12 @@ package table.eat.now.payment.payment.application.event;
 
 import static table.eat.now.payment.payment.application.event.EventType.SUCCEED;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 
 public record PaymentSuccessEvent(
     EventType eventType,
     String paymentUuid,
-    JsonNode payload,
+    PaymentSuccessPayload payload,
     CurrentUserInfoDto userInfo
 ) implements PaymentEvent {
 
@@ -17,6 +16,6 @@ public record PaymentSuccessEvent(
       PaymentSuccessPayload payload, CurrentUserInfoDto userInfo) {
 
     return new PaymentSuccessEvent(
-        SUCCEED, payload.paymentUuid(), MapperUtil.toJsonNode(payload), userInfo);
+        SUCCEED, payload.paymentUuid(), payload, userInfo);
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/Payment.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/Payment.java
@@ -88,7 +88,7 @@ public class Payment extends BaseEntity {
   private Payment(PaymentReference reference, PaymentAmount amount) {
     this.reference = reference;
     this.identifier = PaymentIdentifier.create();
-    this.paymentStatus = PaymentStatus.CREATED;
+    this.paymentStatus = PaymentStatus.PENDING;
     this.amount = amount;
   }
 

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentStatus.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentStatus.java
@@ -1,7 +1,7 @@
 package table.eat.now.payment.payment.domain.entity;
 
 public enum PaymentStatus {
-  CREATED,
+  PENDING,
   APPROVED,
   CANCELED,
   REFUNDED,
@@ -9,7 +9,7 @@ public enum PaymentStatus {
 
   public boolean canChangeTo(PaymentStatus nextStatus) {
     return switch (this) {
-      case CREATED -> nextStatus == APPROVED || nextStatus == CANCELED;
+      case PENDING -> nextStatus == APPROVED || nextStatus == CANCELED;
       case APPROVED -> nextStatus == CANCELED || nextStatus == REFUNDED;
       case CANCELED, REFUNDED -> false;
     };

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/PgClientImpl.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/PgClientImpl.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import table.eat.now.payment.payment.application.client.PgClient;
-import table.eat.now.payment.payment.application.dto.request.CancelPaymentCommand;
+import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentCommand;
 import table.eat.now.payment.payment.application.dto.request.ConfirmPaymentCommand;
 import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentInfo;
 import table.eat.now.payment.payment.application.client.dto.ConfirmPgPaymentInfo;
@@ -26,7 +26,7 @@ public class PgClientImpl implements PgClient {
   }
 
   @Override
-  public CancelPgPaymentInfo cancel(CancelPaymentCommand command, String idempotencyKey) {
+  public CancelPgPaymentInfo cancel(CancelPgPaymentCommand command, String idempotencyKey) {
     return tossPaymentClient
         .cancelPayment(
             CancelTossPayRequest.from(command),

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/request/CancelTossPayRequest.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/request/CancelTossPayRequest.java
@@ -1,11 +1,11 @@
 package table.eat.now.payment.payment.infrastructure.client.dto.request;
 
-import table.eat.now.payment.payment.application.dto.request.CancelPaymentCommand;
+import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentCommand;
 
 public record CancelTossPayRequest(
     String cancelReason
 ) {
-  public static CancelTossPayRequest from(CancelPaymentCommand command) {
+  public static CancelTossPayRequest from(CancelPgPaymentCommand command) {
     return new CancelTossPayRequest(command.cancelReason());
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/KafkaPaymentProducer.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/KafkaPaymentProducer.java
@@ -1,11 +1,14 @@
 package table.eat.now.payment.payment.infrastructure.kafka;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
+import table.eat.now.payment.payment.application.event.EventType;
 import table.eat.now.payment.payment.application.event.PaymentEvent;
 import table.eat.now.payment.payment.application.event.PaymentEventPublisher;
+import table.eat.now.payment.payment.application.event.PaymentFailedEvent;
 import table.eat.now.payment.payment.application.event.PaymentSuccessEvent;
 
 @Slf4j
@@ -17,9 +20,19 @@ public class KafkaPaymentProducer implements PaymentEventPublisher {
   private final String paymentTopic;
 
   @Override
-  public void publish(PaymentSuccessEvent paymentEvent) {
-    kafkaTemplate.send(paymentTopic, paymentEvent.paymentUuid() ,paymentEvent);
-    log.info("payload is {} ", paymentEvent.payload().toString());
-    log.info("Published payment event {}", paymentEvent.eventType());
+  public void publish(PaymentSuccessEvent successEvent) {
+    kafkaTemplate.send(paymentTopic, successEvent.paymentUuid(), successEvent);
+    logEvent(successEvent.payload(), successEvent.eventType());
+  }
+
+  @Override
+  public void publish(PaymentFailedEvent failedEvent) {
+    kafkaTemplate.send(paymentTopic, failedEvent.paymentUuid(), failedEvent);
+    logEvent(failedEvent.payload(), failedEvent.eventType());
+  }
+
+  private static void logEvent(JsonNode payload, EventType eventType) {
+    log.info("payload is {} ", payload.toString());
+    log.info("Published payment event {}", eventType);
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/KafkaPaymentProducer.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/KafkaPaymentProducer.java
@@ -1,11 +1,10 @@
 package table.eat.now.payment.payment.infrastructure.kafka;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
-import table.eat.now.payment.payment.application.event.EventType;
+import table.eat.now.payment.payment.application.event.PaymentCanceledEvent;
 import table.eat.now.payment.payment.application.event.PaymentEvent;
 import table.eat.now.payment.payment.application.event.PaymentEventPublisher;
 import table.eat.now.payment.payment.application.event.PaymentFailedEvent;
@@ -21,18 +20,23 @@ public class KafkaPaymentProducer implements PaymentEventPublisher {
 
   @Override
   public void publish(PaymentSuccessEvent successEvent) {
-    kafkaTemplate.send(paymentTopic, successEvent.paymentUuid(), successEvent);
-    logEvent(successEvent.payload(), successEvent.eventType());
+    kafkaTemplate.send(paymentTopic, successEvent.paymentUuid() ,successEvent);
+    logEvent(successEvent);
   }
 
   @Override
   public void publish(PaymentFailedEvent failedEvent) {
-    kafkaTemplate.send(paymentTopic, failedEvent.paymentUuid(), failedEvent);
-    logEvent(failedEvent.payload(), failedEvent.eventType());
+    kafkaTemplate.send(paymentTopic, failedEvent.paymentUuid() ,failedEvent);
+    logEvent(failedEvent);
   }
 
-  private static void logEvent(JsonNode payload, EventType eventType) {
-    log.info("payload is {} ", payload.toString());
-    log.info("Published payment event {}", eventType);
+  @Override
+  public void publish(PaymentCanceledEvent canceledEvent) {
+    kafkaTemplate.send(paymentTopic, canceledEvent.paymentUuid() , canceledEvent);
+    logEvent(canceledEvent);
+  }
+
+  private static void logEvent(PaymentEvent paymentEvent) {
+    log.info("Published payment event {}", paymentEvent.eventType().name());
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/PaymentEventListener.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/PaymentEventListener.java
@@ -4,13 +4,17 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import table.eat.now.payment.payment.application.PaymentService;
 import table.eat.now.payment.payment.infrastructure.kafka.event.PaymentFailedEvent;
 import table.eat.now.payment.payment.infrastructure.kafka.event.PaymentSuccessEvent;
+import table.eat.now.payment.payment.infrastructure.kafka.event.ReservationCancelingEvent;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentEventListener {
+
+  private final PaymentService paymentService;
 
   @KafkaListener(
       topics = "payment-event",
@@ -29,5 +33,13 @@ public class PaymentEventListener {
   public void handlePaymentFailed(PaymentFailedEvent failedEvent) {
     log.info("Processing payment failed event: {}", failedEvent.paymentUuid());
     log.info("failed event payload: {}", failedEvent.payload());
+  }
+
+  @KafkaListener(
+      topics = "reservation-event",
+      containerFactory = "cancelingEventKafkaListenerContainerFactory"
+  )
+  public void handleReservationCanceled(ReservationCancelingEvent cancelEvent) {
+    paymentService.cancelPayment(cancelEvent.payload().toCommand(), cancelEvent.userInfo());
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/PaymentEventListener.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/PaymentEventListener.java
@@ -1,0 +1,33 @@
+package table.eat.now.payment.payment.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import table.eat.now.payment.payment.infrastructure.kafka.event.PaymentFailedEvent;
+import table.eat.now.payment.payment.infrastructure.kafka.event.PaymentSuccessEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+  @KafkaListener(
+      topics = "payment-event",
+      containerFactory = "successEventKafkaListenerContainerFactory"
+  )
+  public void handlePaymentSuccess(PaymentSuccessEvent successEvent) {
+    log.info("Processing payment success event: {}", successEvent.paymentUuid());
+    log.info("success event payload: {}", successEvent.payload());
+    log.info("success payload.paymentUuid: {}:", successEvent.payload().paymentUuid());
+  }
+
+  @KafkaListener(
+      topics = "payment-event",
+      containerFactory = "failedEventKafkaListenerContainerFactory"
+  )
+  public void handlePaymentFailed(PaymentFailedEvent failedEvent) {
+    log.info("Processing payment failed event: {}", failedEvent.paymentUuid());
+    log.info("failed event payload: {}", failedEvent.payload());
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaConsumerConfig.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaConsumerConfig.java
@@ -18,6 +18,7 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 import table.eat.now.payment.payment.infrastructure.kafka.event.EventType;
 import table.eat.now.payment.payment.infrastructure.kafka.event.PaymentFailedEvent;
 import table.eat.now.payment.payment.infrastructure.kafka.event.PaymentSuccessEvent;
+import table.eat.now.payment.payment.infrastructure.kafka.event.ReservationCancelingEvent;
 
 @EnableKafka
 @Configuration
@@ -37,8 +38,8 @@ public class PaymentKafkaConsumerConfig {
   }
 
   // 타입별 컨슈머 팩토리 생성 메서드
-  private <T> ConsumerFactory<String, T> createConsumerFactory(Class<T> targetType,
-      String groupId) {
+  private <T> ConsumerFactory<String, T> createConsumerFactory(
+      Class<T> targetType, String groupId) {
     Map<String, Object> props = getCommonConsumerProps(groupId);
 
     JsonDeserializer<T> jsonDeserializer = new JsonDeserializer<>(targetType);
@@ -98,5 +99,16 @@ public class PaymentKafkaConsumerConfig {
   public ConcurrentKafkaListenerContainerFactory<String, PaymentFailedEvent>
   failedEventKafkaListenerContainerFactory() {
     return createContainerFactory(failedEventConsumerFactory(), EventType.FAILED.name());
+  }
+
+  @Bean
+  public ConsumerFactory<String, ReservationCancelingEvent> cancelingEventConsumerFactory() {
+    return createConsumerFactory(ReservationCancelingEvent.class, "reservation-canceling-consumer");
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, ReservationCancelingEvent>
+  cancelingEventKafkaListenerContainerFactory() {
+    return createContainerFactory(cancelingEventConsumerFactory(), EventType.CANCELING.name());
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaConsumerConfig.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaConsumerConfig.java
@@ -1,0 +1,102 @@
+package table.eat.now.payment.payment.infrastructure.kafka.config;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import table.eat.now.payment.payment.infrastructure.kafka.event.EventType;
+import table.eat.now.payment.payment.infrastructure.kafka.event.PaymentFailedEvent;
+import table.eat.now.payment.payment.infrastructure.kafka.event.PaymentSuccessEvent;
+
+@EnableKafka
+@Configuration
+public class PaymentKafkaConsumerConfig {
+
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  // 공통 기본 설정 생성 메서드
+  private Map<String, Object> getCommonConsumerProps(String groupId) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    return props;
+  }
+
+  // 타입별 컨슈머 팩토리 생성 메서드
+  private <T> ConsumerFactory<String, T> createConsumerFactory(Class<T> targetType,
+      String groupId) {
+    Map<String, Object> props = getCommonConsumerProps(groupId);
+
+    JsonDeserializer<T> jsonDeserializer = new JsonDeserializer<>(targetType);
+    jsonDeserializer.setUseTypeHeaders(false);
+    jsonDeserializer.setRemoveTypeHeaders(true);
+
+    return new DefaultKafkaConsumerFactory<>(
+        props,
+        new StringDeserializer(),
+        jsonDeserializer
+    );
+  }
+
+  // 이벤트 타입 헤더 필터 생성 메서드
+  private <T> RecordFilterStrategy<String, T> createEventTypeFilter(String eventTypeName) {
+    return record -> {
+      Header eventTypeHeader = record.headers().lastHeader("eventType");
+      if (eventTypeHeader == null) {
+        return true; // 헤더가 없으면 필터링
+      }
+      String eventTypeValue = new String(eventTypeHeader.value(), StandardCharsets.UTF_8);
+      return !eventTypeValue.equals(eventTypeName); // 지정된 이벤트 타입만 통과
+    };
+  }
+
+  // 타입별 컨테이너 팩토리 생성 메서드
+  private <T> ConcurrentKafkaListenerContainerFactory<String, T> createContainerFactory(
+      ConsumerFactory<String, T> consumerFactory, String eventTypeName) {
+
+    ConcurrentKafkaListenerContainerFactory<String, T> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(consumerFactory);
+    factory.setRecordFilterStrategy(createEventTypeFilter(eventTypeName));
+
+    return factory;
+  }
+
+  // PaymentSuccessEvent 관련 컨슈머 팩토리들
+  @Bean
+  public ConsumerFactory<String, PaymentSuccessEvent> successEventConsumerFactory() {
+    return createConsumerFactory(PaymentSuccessEvent.class, "payment-success-consumer");
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, PaymentSuccessEvent>
+  successEventKafkaListenerContainerFactory() {
+    return createContainerFactory(successEventConsumerFactory(), EventType.SUCCEED.name());
+  }
+
+  // PaymentFailedEvent 관련 컨슈머 팩토리들
+  @Bean
+  public ConsumerFactory<String, PaymentFailedEvent> failedEventConsumerFactory() {
+    return createConsumerFactory(PaymentFailedEvent.class, "payment-failed-consumer");
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, PaymentFailedEvent>
+  failedEventKafkaListenerContainerFactory() {
+    return createContainerFactory(failedEventConsumerFactory(), EventType.FAILED.name());
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaProducerConfig.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/config/PaymentKafkaProducerConfig.java
@@ -12,6 +12,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import table.eat.now.payment.payment.application.event.PaymentEvent;
+import table.eat.now.payment.payment.infrastructure.kafka.interceptor.EventTypeHeaderInterceptor;
 
 @Configuration
 public class PaymentKafkaProducerConfig {
@@ -29,6 +30,7 @@ public class PaymentKafkaProducerConfig {
     props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
     props.put(ProducerConfig.ACKS_CONFIG, "all");
     props.put(ProducerConfig.RETRIES_CONFIG, 3);
+    props.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, EventTypeHeaderInterceptor.class.getName());
 
     return new DefaultKafkaProducerFactory<>(props);
   }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/EventType.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/EventType.java
@@ -1,0 +1,8 @@
+package table.eat.now.payment.payment.infrastructure.kafka.event;
+
+public enum EventType {
+  SUCCEED,
+  FAILED,
+  CANCEL_SUCCEED,
+  CANCEL_FAILED
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/EventType.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/EventType.java
@@ -4,5 +4,7 @@ public enum EventType {
   SUCCEED,
   FAILED,
   CANCEL_SUCCEED,
-  CANCEL_FAILED
+  CANCEL_FAILED,
+  CANCELING,
+  ;
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/PaymentFailedEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/PaymentFailedEvent.java
@@ -1,0 +1,11 @@
+package table.eat.now.payment.payment.infrastructure.kafka.event;
+
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+
+public record PaymentFailedEvent(
+    EventType eventType,
+    String paymentUuid,
+    PaymentFailedPayload payload,
+    CurrentUserInfoDto userInfo
+) {
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/PaymentFailedPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/PaymentFailedPayload.java
@@ -1,0 +1,12 @@
+package table.eat.now.payment.payment.infrastructure.kafka.event;
+
+import java.time.LocalDateTime;
+
+public record PaymentFailedPayload(
+    String paymentUuid,
+    String paymentKey,
+    String cancelReason,
+    LocalDateTime cancelledAt,
+    String paymentStatus
+) {
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/PaymentSuccessEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/PaymentSuccessEvent.java
@@ -1,0 +1,12 @@
+package table.eat.now.payment.payment.infrastructure.kafka.event;
+
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+
+public record PaymentSuccessEvent(
+    EventType eventType,
+    String paymentUuid,
+    PaymentSuccessPayload payload,
+    CurrentUserInfoDto userInfo
+) {
+
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/PaymentSuccessPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/PaymentSuccessPayload.java
@@ -1,0 +1,18 @@
+package table.eat.now.payment.payment.infrastructure.kafka.event;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record PaymentSuccessPayload(
+    String paymentUuid,
+    String idempotencyKey,
+    String paymentStatus,
+    BigDecimal originalAmount,
+    BigDecimal discountAmount,
+    BigDecimal totalAmount,
+    LocalDateTime createdAt,
+    LocalDateTime approvedAt
+) {
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/ReservationCancelingEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/ReservationCancelingEvent.java
@@ -1,0 +1,13 @@
+package table.eat.now.payment.payment.infrastructure.kafka.event;
+
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+
+public record ReservationCancelingEvent(
+    EventType eventType,
+    String reservationUuid,
+    ReservationCancelingPayload payload,
+    CurrentUserInfoDto userInfo
+) {
+
+
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/ReservationCancelingPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/ReservationCancelingPayload.java
@@ -1,0 +1,14 @@
+package table.eat.now.payment.payment.infrastructure.kafka.event;
+
+import table.eat.now.payment.payment.application.dto.request.CancelPaymentCommand;
+
+public record ReservationCancelingPayload(
+    String reservationUuid,
+    String idempotencyKey,
+    String cancelReason
+) {
+
+  public CancelPaymentCommand toCommand() {
+    return new CancelPaymentCommand(reservationUuid, idempotencyKey, cancelReason);
+  }
+}

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/interceptor/EventTypeHeaderInterceptor.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/interceptor/EventTypeHeaderInterceptor.java
@@ -1,0 +1,34 @@
+package table.eat.now.payment.payment.infrastructure.kafka.interceptor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import table.eat.now.payment.payment.application.event.PaymentEvent;
+
+public class EventTypeHeaderInterceptor implements ProducerInterceptor<String, PaymentEvent> {
+
+  private static final String EVENT_TYPE_HEADER = "eventType";
+
+  @Override
+  public ProducerRecord<String, PaymentEvent> onSend(ProducerRecord<String, PaymentEvent> record) {
+    PaymentEvent event = record.value();
+    record
+        .headers()
+        .add(EVENT_TYPE_HEADER, event.eventType().name().getBytes(StandardCharsets.UTF_8));
+    return record;
+  }
+
+  @Override
+  public void onAcknowledgement(RecordMetadata recordMetadata, Exception e) {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+  }
+}

--- a/payment/src/test/http/api.http
+++ b/payment/src/test/http/api.http
@@ -1,9 +1,33 @@
+###
+POST http://localhost:8081/api/v1/users/signup
+Content-Type: application/json
+
+{
+  "username": "test",
+  "email": "test@test",
+  "phone": "123",
+  "password": "1234",
+  "role": "MASTER"
+}
+
+###
+POST http://localhost:8080/api/v1/users/login
+Content-Type: application/json
+
+{
+"username": "test",
+"password": "1234"
+}
+> {%
+  client.global.set("access_token", response.headers.valueOf("Authorization"))
+%}
+
 ### 결제 생성
 POST localhost:8088/internal/v1/payments
 Content-Type: application/json
 
 {
-  "reservationUuid": "00000000-0000-0000-0000-000000000018",
+  "reservationUuid": "00000000-0000-0000-0000-000000000026",
   "restaurantUuid": "9882a539-0380-4a5d-bec4-da49d37f06e5",
   "customerId": 123,
   "reservationName": "하이들하신가",
@@ -13,6 +37,9 @@ Content-Type: application/json
   client.global.set("idempotencyKey", response.body.idempotencyKey)
   client.global.set("paymentUuid", response.body.paymentUuid)
 %}
+
+### 브라우저에서 해보시면 됩니다! (최상단의 GET요청 url을 복사붙여넣기하시면 됩니다.)
+GET http://localhost:8088/checkout?idempotencyKey={{idempotencyKey}}
 
 ### Checkout 상세 조회
 GET http://localhost:8088/api/v1/payments/checkout-info?idempotencyKey={{idempotencyKey}}
@@ -34,6 +61,6 @@ X-User-Id: 123
 X-User-Role: CUSTOMER
 
 ### 토스페이 거래내역 상세조회
-GET https://api.tosspayments.com/v1/payments/orders/00000000-0000-0000-0000-000000000011
+GET https://api.tosspayments.com/v1/payments/orders/00000000-0000-0000-0000-000000000020
 Authorization: Basic dGVzdF9za19BTG5RdkRkMlZKR2s0eUdLR1E5TnJNajdYNDFtOg
 Content-Type: application/json

--- a/payment/src/test/http/api.http
+++ b/payment/src/test/http/api.http
@@ -27,7 +27,7 @@ POST localhost:8088/internal/v1/payments
 Content-Type: application/json
 
 {
-  "reservationUuid": "00000000-0000-0000-0000-000000000026",
+  "reservationUuid": "00000000-0000-0000-0000-000000000027",
   "restaurantUuid": "9882a539-0380-4a5d-bec4-da49d37f06e5",
   "customerId": 123,
   "reservationName": "하이들하신가",
@@ -61,6 +61,6 @@ X-User-Id: 123
 X-User-Role: CUSTOMER
 
 ### 토스페이 거래내역 상세조회
-GET https://api.tosspayments.com/v1/payments/orders/00000000-0000-0000-0000-000000000020
+GET https://api.tosspayments.com/v1/payments/orders/00000000-0000-0000-0000-000000000027
 Authorization: Basic dGVzdF9za19BTG5RdkRkMlZKR2s0eUdLR1E5TnJNajdYNDFtOg
 Content-Type: application/json

--- a/payment/src/test/java/table/eat/now/payment/payment/application/event/MapperUtilTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/application/event/MapperUtilTest.java
@@ -2,11 +2,13 @@ package table.eat.now.payment.payment.application.event;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
@@ -52,6 +54,23 @@ class MapperUtilTest {
     });
 
     assertThat(exception.getMessage()).contains("Failed to convert object to JsonNode");
+  }
+
+  @Test
+  void MapperUtil_생성자는_인스턴스화_시도시_예외를_던진다() throws Exception {
+    // given
+    Constructor<MapperUtil> constructor = MapperUtil.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+
+    // when
+    InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+        constructor::newInstance);
+
+    // then
+    Throwable cause = exception.getCause();
+    assertNotNull(cause);
+    assertInstanceOf(AssertionError.class, cause);
+    assertEquals("Utility class should not be instantiated", cause.getMessage());
   }
 
   static class TestPayload {

--- a/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentTest.java
@@ -31,7 +31,7 @@ class PaymentTest {
       assertThat(payment).isNotNull();
       assertThat(payment.getReference()).isEqualTo(validReference);
       assertThat(payment.getAmount()).isEqualTo(validAmount);
-      assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CREATED);
+      assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
       assertThat(payment.getIdentifier()).isNotNull();
       assertThat(payment.getPaymentKey()).isNull();
       assertThat(payment.getApprovedAt()).isNull();


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #120

## 변경 타입
- [x] 신규 기능 추가/수정
- [x] 리팩토링


## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 예약취소 컨슈머 구현
  - [x] 결제실패 - 롤백 및 취소이벤트 발송

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.

## 코멘트
- MapperUtil은 무용해졌습니다..! (헤더를 사용하면서 별도의 페이로드가 필요없어졌어요) 
- 이벤트 형식은 적절히 얘기 나눠서 구체화시키면좋을것같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 결제 취소 기능이 추가되어 사용자가 결제를 취소할 수 있습니다.
  - 결제 성공, 실패, 취소 등 다양한 결제 이벤트가 카프카를 통해 처리 및 구독됩니다.

- **버그 수정**
  - 결제의 초기 상태가 "PENDING"으로 변경되어 결제 진행 상태가 명확해졌습니다.

- **테스트**
  - 결제 취소 및 이벤트 발행에 대한 테스트가 강화되었습니다.
  - 유틸리티 클래스의 인스턴스화 방지 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->