### PR TITLE
[notification] 예약 알림 스케줄링 구성 및 테스트

### DIFF
--- a/notification/src/main/java/table/eat/now/notification/NotificationApplication.java
+++ b/notification/src/main/java/table/eat/now/notification/NotificationApplication.java
@@ -2,8 +2,10 @@ package table.eat.now.notification;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class NotificationApplication {
 
 	public static void main(String[] args) {

--- a/notification/src/main/java/table/eat/now/notification/application/schedule/NotificationScheduler.java
+++ b/notification/src/main/java/table/eat/now/notification/application/schedule/NotificationScheduler.java
@@ -1,0 +1,64 @@
+package table.eat.now.notification.application.schedule;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import table.eat.now.notification.application.strategy.NotificationFormatterStrategy;
+import table.eat.now.notification.application.strategy.NotificationFormatterStrategySelector;
+import table.eat.now.notification.application.strategy.NotificationParamExtractor;
+import table.eat.now.notification.application.strategy.NotificationTemplate;
+import table.eat.now.notification.application.strategy.send.NotificationSenderStrategy;
+import table.eat.now.notification.application.strategy.send.NotificationSenderStrategySelector;
+import table.eat.now.notification.domain.entity.Notification;
+import table.eat.now.notification.domain.entity.NotificationStatus;
+import table.eat.now.notification.domain.repository.NotificationRepository;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 16.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class NotificationScheduler {
+
+  private final NotificationRepository notificationRepository;
+  private final NotificationFormatterStrategySelector formatterSelector;
+  private final NotificationSenderStrategySelector sendSelector;
+  private final NotificationParamExtractor paramExtractor;
+
+  @Scheduled(cron = "0 */10 * * * *")
+  @Transactional
+  public void sendScheduledNotifications() {
+    LocalDateTime now = LocalDateTime.now();
+
+    List<Notification> notifications = notificationRepository.
+        findByStatusAndScheduledTimeLessThanEqualAndDeletedByIsNull(
+        NotificationStatus.PENDING, now);
+
+    for (Notification notification : notifications) {
+      try {
+        NotificationFormatterStrategy strategy = formatterSelector.select(
+            notification.getNotificationType());
+        Map<String, String> params = paramExtractor.extract(notification);
+        NotificationTemplate formattedMessage = strategy.format(params);
+
+        NotificationSenderStrategy senderStrategy = sendSelector.select(
+            notification.getNotificationMethod());
+
+        senderStrategy.send(notification.getUserId(), formattedMessage);
+
+        notification.modifyNotificationStatusIsSent();
+
+      } catch (Exception e) {
+        log.error("스케줄링 알림 전송 실패: {}", notification.getId(), e);
+        notification.modifyNotificationStatusIsFailed();
+      }
+    }
+  }
+}

--- a/notification/src/main/java/table/eat/now/notification/application/service/NotificationServiceImpl.java
+++ b/notification/src/main/java/table/eat/now/notification/application/service/NotificationServiceImpl.java
@@ -106,7 +106,7 @@ public class NotificationServiceImpl implements NotificationService{
 
     senderStrategy.send(notification.getUserId(), formattedMessage);
 
-    notification.modifyNotificationStatus();
+    notification.modifyNotificationStatusIsSent();
   }
 
 

--- a/notification/src/main/java/table/eat/now/notification/domain/entity/Notification.java
+++ b/notification/src/main/java/table/eat/now/notification/domain/entity/Notification.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -55,6 +56,10 @@ public class Notification extends BaseEntity{
   @Column(name = "scheduled_time")
   private LocalDateTime scheduledTime;
 
+  //// DB에 저장되지 않고 알림 재시도를 위한 필드
+  @Transient
+  private int retryCount = 0;
+
   private Notification(Long userId, NotificationType notificationType,
       String customerName, LocalDateTime reservationTime, String restaurantName,
       NotificationStatus status, NotificationMethod notificationMethod,
@@ -89,7 +94,10 @@ public class Notification extends BaseEntity{
     this.scheduledTime = scheduledTime;
   }
 
-  public void modifyNotificationStatus() {
+  public void modifyNotificationStatusIsSent() {
     this.status = NotificationStatus.SENT;
+  }
+  public void modifyNotificationStatusIsFailed() {
+    this.status = NotificationStatus.FAILED;
   }
 }

--- a/notification/src/main/java/table/eat/now/notification/domain/repository/NotificationRepository.java
+++ b/notification/src/main/java/table/eat/now/notification/domain/repository/NotificationRepository.java
@@ -1,8 +1,11 @@
 package table.eat.now.notification.domain.repository;
 
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import table.eat.now.notification.domain.entity.Notification;
+import table.eat.now.notification.domain.entity.NotificationStatus;
 import table.eat.now.notification.domain.repository.search.NotificationSearchCriteria;
 import table.eat.now.notification.domain.repository.search.NotificationSearchCriteriaQuery;
 import table.eat.now.notification.domain.repository.search.PaginatedResult;
@@ -18,5 +21,8 @@ public interface NotificationRepository {
   Optional<Notification> findByNotificationUuidAndDeletedByIsNull(String notificationUuid);
 
   PaginatedResult<NotificationSearchCriteriaQuery> searchNotification(NotificationSearchCriteria searchCriteria);
+
+  List<Notification> findByStatusAndScheduledTimeLessThanEqualAndDeletedByIsNull(
+      NotificationStatus status, LocalDateTime localDateTime);
 
 }

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/persistence/JpaNotificationRepository.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/persistence/JpaNotificationRepository.java
@@ -1,8 +1,11 @@
 package table.eat.now.notification.infrastructure.persistence;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import table.eat.now.notification.domain.entity.Notification;
+import table.eat.now.notification.domain.entity.NotificationStatus;
 import table.eat.now.notification.domain.repository.NotificationRepository;
 
 /**
@@ -12,5 +15,8 @@ import table.eat.now.notification.domain.repository.NotificationRepository;
 public interface JpaNotificationRepository extends
     JpaRepository<Notification, Long>, NotificationRepository, JpaNotificationRepositoryCustom {
   Optional<Notification> findByNotificationUuidAndDeletedByIsNull(String notificationUuid);
+
+  List<Notification> findByStatusAndScheduledTimeLessThanEqualAndDeletedByIsNull(
+      NotificationStatus status, LocalDateTime localDateTime);
 }
 

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/sender/EmailSender.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/sender/EmailSender.java
@@ -1,10 +1,11 @@
-package table.eat.now.notification.application.strategy.send;
+package table.eat.now.notification.infrastructure.sender;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
 import table.eat.now.notification.application.strategy.NotificationTemplate;
+import table.eat.now.notification.application.strategy.send.NotificationSenderStrategy;
 import table.eat.now.notification.domain.entity.NotificationMethod;
 
 /**

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/sender/SlackSender.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/sender/SlackSender.java
@@ -1,4 +1,4 @@
-package table.eat.now.notification.application.strategy.send;
+package table.eat.now.notification.infrastructure.sender;
 
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import table.eat.now.notification.application.strategy.NotificationTemplate;
+import table.eat.now.notification.application.strategy.send.NotificationSenderStrategy;
 import table.eat.now.notification.domain.entity.NotificationMethod;
 
 /**

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/webclient/WebClientConfig.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/webclient/WebClientConfig.java
@@ -1,0 +1,18 @@
+package table.eat.now.notification.infrastructure.webclient;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 16.
+ */
+@Configuration
+public class WebClientConfig {
+
+  @Bean
+  public WebClient webClient() {
+    return WebClient.create();
+  }
+}

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -20,6 +20,11 @@ spring:
         jdbc:
           batch_size: 30
     show-sql: true
+  data:
+    redis:
+      host: localhost
+      port: ${DEV_REDIS_PORT}
+      username: ${DEV_REDIS_USERNAME}
   mail:
     host: smtp.gmail.com
     port: 587

--- a/notification/src/test/java/table/eat/now/notification/application/schedule/NotificationSchedulerTest.java
+++ b/notification/src/test/java/table/eat/now/notification/application/schedule/NotificationSchedulerTest.java
@@ -1,0 +1,142 @@
+package table.eat.now.notification.application.schedule;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import table.eat.now.notification.application.strategy.NotificationFormatterStrategy;
+import table.eat.now.notification.application.strategy.NotificationFormatterStrategySelector;
+import table.eat.now.notification.application.strategy.NotificationParamExtractor;
+import table.eat.now.notification.application.strategy.NotificationTemplate;
+import table.eat.now.notification.application.strategy.send.NotificationSenderStrategy;
+import table.eat.now.notification.application.strategy.send.NotificationSenderStrategySelector;
+import table.eat.now.notification.domain.entity.Notification;
+import table.eat.now.notification.domain.entity.NotificationMethod;
+import table.eat.now.notification.domain.entity.NotificationStatus;
+import table.eat.now.notification.domain.entity.NotificationType;
+import table.eat.now.notification.domain.repository.NotificationRepository;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 04. 16.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationSchedulerTest {
+
+  @Mock
+  private NotificationRepository notificationRepository;
+
+  @Mock
+  private NotificationFormatterStrategySelector formatterSelector;
+
+  @Mock
+  private NotificationSenderStrategySelector sendSelector;
+
+  @Mock
+  private NotificationParamExtractor paramExtractor;
+
+  @Mock
+  private NotificationFormatterStrategy formatterStrategy;
+
+  @Mock
+  private NotificationSenderStrategy senderStrategy;
+
+  private NotificationScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler = new NotificationScheduler(
+        notificationRepository,
+        formatterSelector,
+        sendSelector,
+        paramExtractor
+    );
+  }
+
+  @DisplayName("스케줄러가 정상적으로 알림을 전송한다")
+  @Test
+  void scheduler_success_notification_sent() {
+    // given
+    Notification notification = Notification.of(
+        1L,
+        NotificationType.CONFIRM_CUSTOMER,
+        "11조",
+        LocalDateTime.of(2025, 4, 20, 18, 30),
+        "HI-dle 식당",
+        NotificationStatus.PENDING,
+        NotificationMethod.EMAIL,
+        LocalDateTime.now().minusMinutes(5)
+    );
+
+    given(notificationRepository.findByStatusAndScheduledTimeLessThanEqualAndDeletedByIsNull(
+        any(), any())).willReturn(List.of(notification));
+
+    given(formatterSelector.select(any())).willReturn(formatterStrategy);
+    given(paramExtractor.extract(any())).willReturn(Map.of(
+        "customerName", "11조",
+        "reservationTime", "2025-04-20 18:30",
+        "restaurantName", "HI-dle 식당"
+    ));
+    given(formatterStrategy.format(any())).willReturn(new NotificationTemplate("제목", "본문"));
+
+    given(sendSelector.select(any())).willReturn(senderStrategy);
+
+    // when
+    scheduler.sendScheduledNotifications();
+
+    // then
+    assertThat(notification.getStatus()).isEqualTo(NotificationStatus.SENT);
+    verify(senderStrategy).send(eq(1L), any(NotificationTemplate.class));
+  }
+
+  @DisplayName("스케줄러가 알림 전송에 실패하면 상태는 FAILED가 된다")
+  @Test
+  void scheduler_failed_notification_no_sent() {
+    // given
+    Notification notification = Notification.of(
+        1L,
+        NotificationType.CONFIRM_CUSTOMER,
+        "11조",
+        LocalDateTime.of(2025, 4, 20, 18, 30),
+        "HI-dle 식당",
+        NotificationStatus.PENDING,
+        NotificationMethod.EMAIL,
+        LocalDateTime.now().minusMinutes(5)
+    );
+
+    given(notificationRepository.findByStatusAndScheduledTimeLessThanEqualAndDeletedByIsNull(
+        any(), any())).willReturn(List.of(notification));
+
+    given(formatterSelector.select(any())).willReturn(formatterStrategy);
+    given(paramExtractor.extract(any())).willReturn(Map.of(
+        "customerName", "11조",
+        "reservationTime", "2025-04-20 18:30",
+        "restaurantName", "HI-dle 식당"
+    ));
+    given(formatterStrategy.format(any())).willReturn(new NotificationTemplate("제목", "본문"));
+    given(sendSelector.select(any())).willReturn(senderStrategy);
+
+
+    doThrow(new RuntimeException("전송 실패")).when(senderStrategy).send(eq(1L), any(NotificationTemplate.class));
+
+    // when
+    scheduler.sendScheduledNotifications();
+
+    // then
+    assertThat(notification.getStatus()).isEqualTo(NotificationStatus.FAILED);
+  }
+
+}

--- a/notification/src/test/java/table/eat/now/notification/application/service/NotificationServiceImplTest.java
+++ b/notification/src/test/java/table/eat/now/notification/application/service/NotificationServiceImplTest.java
@@ -55,10 +55,8 @@ import table.eat.now.notification.application.strategy.message.formatter.InfoWai
 import table.eat.now.notification.application.strategy.message.formatter.NoShowFormatter;
 import table.eat.now.notification.application.strategy.message.formatter.Reminder1HrFormatter;
 import table.eat.now.notification.application.strategy.message.formatter.Reminder9AmFormatter;
-import table.eat.now.notification.application.strategy.send.EmailSender;
 import table.eat.now.notification.application.strategy.send.NotificationSenderStrategy;
 import table.eat.now.notification.application.strategy.send.NotificationSenderStrategySelector;
-import table.eat.now.notification.application.strategy.send.SlackSender;
 import table.eat.now.notification.domain.entity.Notification;
 import table.eat.now.notification.domain.entity.NotificationMethod;
 import table.eat.now.notification.domain.entity.NotificationStatus;
@@ -68,6 +66,8 @@ import table.eat.now.notification.domain.repository.NotificationRepository;
 import table.eat.now.notification.domain.repository.search.NotificationSearchCriteria;
 import table.eat.now.notification.domain.repository.search.NotificationSearchCriteriaQuery;
 import table.eat.now.notification.domain.repository.search.PaginatedResult;
+import table.eat.now.notification.infrastructure.sender.EmailSender;
+import table.eat.now.notification.infrastructure.sender.SlackSender;
 
 /**
  * @author : hanjihoon


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #122 

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용


- **to-be**(변경 후 설명을 여기에 작성)

  - [x] [notification] 예약 알림 스케줄링 구성 및 테스트


## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.


## 코멘트
mvp를 위해서 단순 스케줄링을 구현 했습니다. 카프카를 사용하게 된다면 카프카와 레디스로 딜레이큐를 사용해 구성할 계획이고 알림 실패에 따른 재처리는 카프카 사용했을 때 더 구성하곘습니다...! 멀티 인스턴스 환경에서 한 곳만 스케줄러가 실행되는 것이나 스케줄러가 여러 인스턴스에서 동시에 실행되는 문제는 레디스 딜레이큐와 카프카를 사용할 때 해결 하겠습니다! 스케줄러 여러 인스턴스에서 실행 되는 건 분산락 예상 중입니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 예약된 알림을 10분마다 자동으로 전송하는 스케줄러 기능이 추가되었습니다.
  - Redis 데이터 소스 구성이 추가되었습니다.
  - WebClient를 빈으로 제공하는 설정이 도입되었습니다.

- **버그 수정**
  - 알림 전송 상태 업데이트가 더 명확하게 처리되도록 개선되었습니다.

- **테스트**
  - 예약 알림 스케줄러 동작을 검증하는 테스트가 추가되었습니다.

- **기타**
  - 일부 패키지 구조 및 import 정리가 이루어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->