### PR TITLE
[reservation] 예약 단건 조회

### DIFF
--- a/common/src/main/java/table/eat/now/common/resolver/dto/UserRole.java
+++ b/common/src/main/java/table/eat/now/common/resolver/dto/UserRole.java
@@ -28,4 +28,8 @@ public enum UserRole {
   public boolean isMaster() {
     return this == MASTER;
   }
+
+  public boolean isCustomer() {
+    return this == CUSTOMER;
+  }
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/exception/ReservationErrorCode.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/exception/ReservationErrorCode.java
@@ -46,9 +46,15 @@ public enum ReservationErrorCode implements ErrorCode {
   PROMOTION_USAGE_LIMIT_EXCEEDED("프로모션 최대 사용 개수를 초과합니다.", HttpStatus.BAD_REQUEST),
 
   /**
+   * NOT_FOUND
+   */
+  NOT_FOUND("예약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+  /**
    * INTERNAL_SERVER_ERROR
    */
-  RESERVATION_SAVE_FAILED("예약 저장에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+  RESERVATION_SAVE_FAILED("예약 저장에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  ;
 
   private final String message;
   private final HttpStatus status;

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/ReservationService.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/ReservationService.java
@@ -5,9 +5,13 @@
 package table.eat.now.reservation.reservation.application.service;
 
 import table.eat.now.reservation.reservation.application.service.dto.request.CreateReservationCommand;
+import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
 import table.eat.now.reservation.reservation.application.service.dto.response.CreateReservationInfo;
+import table.eat.now.reservation.reservation.application.service.dto.response.GetReservationInfo;
 
 public interface ReservationService {
 
   CreateReservationInfo createReservation(CreateReservationCommand command);
+
+  GetReservationInfo getReservation(GetReservationCriteria criteria);
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/request/CreateReservationCommand.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/request/CreateReservationCommand.java
@@ -33,7 +33,7 @@ public record CreateReservationCommand(
 ) {
 
   public Reservation toEntityWithUuidAndPaymentKey(
-      String reservationUuid, String reservationName, String paymentKey) {
+      String reservationUuid, String reservationName, Long ownerId, Long staffId, String paymentKey) {
     List<ReservationPaymentDetail> paymentDetails = this.payments().stream()
         .map(paymentDetail -> paymentDetail.toEntityWithPaymentKey(paymentKey))
         .toList();
@@ -48,6 +48,8 @@ public record CreateReservationCommand(
         .restaurantId(restaurantUuid)
         .restaurantName(restaurantDetails.name())
         .restaurantAddress(restaurantDetails.address())
+        .ownerId(ownerId)
+        .staffId(staffId)
         .restaurantContactNumber(restaurantDetails.contactNumber())
         .restaurantOpeningTime(restaurantDetails.openingTime())
         .restaurantClosingTime(restaurantDetails.closingTime())
@@ -86,6 +88,7 @@ public record CreateReservationCommand(
   public record RestaurantDetails(
       String name,
       String address,
+      Long ownerId,
       String contactNumber,
       LocalTime openingTime,
       LocalTime closingTime

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/request/GetReservationCriteria.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/request/GetReservationCriteria.java
@@ -1,0 +1,17 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 16.
+ */
+package table.eat.now.reservation.reservation.application.service.dto.request;
+
+import table.eat.now.common.resolver.dto.UserRole;
+
+public record GetReservationCriteria(
+    String reservationUuid,
+    Long userId,
+    UserRole role
+) {
+  public static GetReservationCriteria from(String uuid, UserRole role, Long userId) {
+    return new GetReservationCriteria(uuid, userId, role);
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/response/GetReservationInfo.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/response/GetReservationInfo.java
@@ -56,7 +56,7 @@ public record GetReservationInfo(
   }
 
   public enum ReservationStatus {
-    PENDING, CONFIRMED, CANCELLED // 예시
+    PENDING_PAYMENT, CONFIRMED, CANCELLED // 예시
   }
 
   public record PaymentDetailInfo(
@@ -69,7 +69,7 @@ public record GetReservationInfo(
     public static PaymentDetailInfo from(ReservationPaymentDetail detail) {
       return new PaymentDetailInfo(
           detail.getReservationPaymentDetailUuid(),
-          PaymentType.valueOf(detail.getType().getName()),
+          PaymentType.valueOf(detail.getType().name()),
           detail.getAmount(),
           detail.getDetailReferenceId()
       );
@@ -77,6 +77,6 @@ public record GetReservationInfo(
   }
 
   public enum PaymentType {
-    CARD, CASH, COUPON // 예시
+    PAYMENT, PROMOTION_COUPON, PROMOTION_EVENT // 예시
   }
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/response/GetReservationInfo.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/response/GetReservationInfo.java
@@ -8,9 +8,11 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import lombok.Builder;
 import table.eat.now.reservation.reservation.domain.entity.Reservation;
 import table.eat.now.reservation.reservation.domain.entity.ReservationPaymentDetail;
 
+@Builder
 public record GetReservationInfo(
     String reservationUuid,
     String name,
@@ -59,6 +61,7 @@ public record GetReservationInfo(
     PENDING_PAYMENT, CONFIRMED, CANCELLED // 예시
   }
 
+  @Builder
   public record PaymentDetailInfo(
       String reservationPaymentDetailUuid,
       PaymentType type,

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/response/GetReservationInfo.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/response/GetReservationInfo.java
@@ -1,0 +1,82 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 16.
+ */
+package table.eat.now.reservation.reservation.application.service.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import table.eat.now.reservation.reservation.domain.entity.Reservation;
+import table.eat.now.reservation.reservation.domain.entity.ReservationPaymentDetail;
+
+public record GetReservationInfo(
+    String reservationUuid,
+    String name,
+    String reserverName,
+    String reserverContact,
+    int guestCount,
+    String restaurantName,
+    String restaurantContactNumber,
+    String restaurantAddress,
+    LocalDate reservationDate,
+    LocalTime reservationTime,
+    String menuName,
+    BigDecimal menuPrice,
+    int menuQuantity,
+    ReservationStatus status,
+    String specialRequest,
+    BigDecimal totalAmount,
+    List<PaymentDetailInfo> paymentDetails
+) {
+
+  public static GetReservationInfo from(Reservation reservation) {
+    return new GetReservationInfo(
+        reservation.getReservationUuid(),
+        reservation.getName(),
+        reservation.getGuestInfo().getReserverName(),
+        reservation.getGuestInfo().getReserverContact(),
+        reservation.getGuestInfo().getGuestCount(),
+        reservation.getRestaurantDetails().getName(),
+        reservation.getRestaurantDetails().getContactNumber(),
+        reservation.getRestaurantDetails().getAddress(),
+        reservation.getRestaurantTimeSlotDetails().getAvailableDate(),
+        reservation.getRestaurantTimeSlotDetails().getTimeslot(),
+        reservation.getRestaurantMenuDetails().getName(),
+        reservation.getRestaurantMenuDetails().getPrice(),
+        reservation.getRestaurantMenuDetails().getQuantity(),
+        ReservationStatus.valueOf(reservation.getStatus().toString()),
+        reservation.getSpecialRequest(),
+        reservation.getTotalAmount(),
+        reservation.getPaymentDetails().getValues().stream()
+            .map(PaymentDetailInfo::from)
+            .toList()
+    );
+  }
+
+  public enum ReservationStatus {
+    PENDING, CONFIRMED, CANCELLED // 예시
+  }
+
+  public record PaymentDetailInfo(
+      String reservationPaymentDetailUuid,
+      PaymentType type,
+      BigDecimal amount,
+      String detailReferenceId
+  ) {
+
+    public static PaymentDetailInfo from(ReservationPaymentDetail detail) {
+      return new PaymentDetailInfo(
+          detail.getReservationPaymentDetailUuid(),
+          PaymentType.valueOf(detail.getType().getName()),
+          detail.getAmount(),
+          detail.getDetailReferenceId()
+      );
+    }
+  }
+
+  public enum PaymentType {
+    CARD, CASH, COUPON // 예시
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/Reservation.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/Reservation.java
@@ -58,7 +58,7 @@ public class Reservation extends BaseEntity {
   private String restaurantTimeSlotUuid;
 
   @Column(name = "restaurant_uuid", nullable = false, length = 100)
-  private String restaurantId;
+  private String restaurantId; // todo: 변수명 수정 필요
 
   @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "restaurant_timeslot_details", columnDefinition = "json", nullable = false)
@@ -146,9 +146,19 @@ public class Reservation extends BaseEntity {
 
   public boolean isReadableUser(Long userId, UserRole role) {
     if(role.isMaster()) return true;
-    if(role.isOwner() && restaurantDetails.getOwnerId().equals(userId)) return true;
-    if(role.isStaff() && restaurantDetails.getStaffId().equals(userId)) return true;
-    if(reserverId.equals(userId)) return true;
+
+    if(role.isOwner()
+        && restaurantDetails.getOwnerId().equals(userId)
+        && getDeletedAt() == null) return true;
+
+    if(role.isStaff()
+        && restaurantDetails.getStaffId().equals(userId)
+        && getDeletedAt() == null) return true;
+
+    if(role.isCustomer()
+        && reserverId.equals(userId)
+        && getDeletedAt() == null) return true;
+
     return false;
   }
 

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/Reservation.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/Reservation.java
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import table.eat.now.common.domain.BaseEntity;
+import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.reservation.reservation.domain.entity.json.RestaurantDetails;
 import table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails;
 import table.eat.now.reservation.reservation.domain.entity.json.RestaurantTimeSlotDetails;
@@ -103,6 +104,8 @@ public class Reservation extends BaseEntity {
       String restaurantId,
       String restaurantAddress,
       LocalTime restaurantClosingTime,
+      Long ownerId,
+      Long staffId,
       String restaurantContactNumber,
       String restaurantName,
       LocalTime restaurantOpeningTime,
@@ -127,6 +130,8 @@ public class Reservation extends BaseEntity {
         RestaurantDetails.of(
             restaurantName,
             restaurantAddress,
+            ownerId,
+            staffId,
             restaurantContactNumber,
             restaurantOpeningTime,
             restaurantClosingTime
@@ -137,6 +142,14 @@ public class Reservation extends BaseEntity {
     this.specialRequest = specialRequest;
     this.paymentDetails = ReservationPaymentDetails.of(details, this);
     this.totalAmount = paymentDetails.getTotalAmount();
+  }
+
+  public boolean isReadableUser(Long userId, UserRole role) {
+    if(role.isMaster()) return true;
+    if(role.isOwner() && restaurantDetails.getOwnerId().equals(userId)) return true;
+    if(role.isStaff() && restaurantDetails.getStaffId().equals(userId)) return true;
+    if(reserverId.equals(userId)) return true;
+    return false;
   }
 
   @Getter

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/ReservationPaymentDetail.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/ReservationPaymentDetail.java
@@ -77,6 +77,6 @@ public class ReservationPaymentDetail extends BaseEntity {
     PROMOTION_EVENT("이벤트"),
     ;
 
-    private final String name;
+    private final String description;
   }
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/json/RestaurantDetails.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/json/RestaurantDetails.java
@@ -16,6 +16,8 @@ import lombok.NoArgsConstructor;
 public class RestaurantDetails {
   private String name;
   private String address;
+  private Long ownerId;
+  private Long staffId;
   private String contactNumber;
   private LocalTime openingTime;
   private LocalTime closingTime;
@@ -23,10 +25,12 @@ public class RestaurantDetails {
   public static RestaurantDetails of(
       String name,
       String address,
+      Long ownerId,
+      Long staffId,
       String contactNumber,
       LocalTime openingTime,
       LocalTime closingTime
       ) {
-    return new RestaurantDetails(name, address, contactNumber, openingTime, closingTime);
+    return new RestaurantDetails(name, address, ownerId, staffId, contactNumber, openingTime, closingTime);
   }
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/json/RestaurantMenuDetails.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/json/RestaurantMenuDetails.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 public class RestaurantMenuDetails {
   private String name;
   private BigDecimal price;
-  private Integer count;
+  private Integer quantity;
 
   public static RestaurantMenuDetails of(String name, BigDecimal price, Integer quantity) {
     return new RestaurantMenuDetails(name, price, quantity);

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/vo/ReservationPaymentDetails.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/vo/ReservationPaymentDetails.java
@@ -29,6 +29,10 @@ public class ReservationPaymentDetails {
     this.values.addAll(details);
   }
 
+  public List<ReservationPaymentDetail> getValues() {
+    return values.stream().toList();
+  }
+
   public static ReservationPaymentDetails of(List<ReservationPaymentDetail> details,
       Reservation reservation) {
     return new ReservationPaymentDetails(details, reservation);

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/repository/ReservationRepository.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/repository/ReservationRepository.java
@@ -16,4 +16,6 @@ public interface ReservationRepository {
 
   // test 용
   List<Reservation> findAll();
+
+  <S extends Reservation> List<S> saveAll(Iterable<S> entities);
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/repository/ReservationRepository.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/repository/ReservationRepository.java
@@ -5,11 +5,14 @@
 package table.eat.now.reservation.reservation.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import table.eat.now.reservation.reservation.domain.entity.Reservation;
 
 public interface ReservationRepository {
 
   Reservation save(Reservation reservation);
+
+  Optional<Reservation> findWithDetailsByReservationUuid(String reservationUuid);
 
   // test 용
   List<Reservation> findAll();

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/JpaReservationRepository.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/JpaReservationRepository.java
@@ -7,6 +7,7 @@ package table.eat.now.reservation.reservation.infrastructure.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 import table.eat.now.reservation.reservation.domain.entity.Reservation;
 
-public interface JpaReservationRepository extends JpaRepository<Reservation, Long> {
+public interface JpaReservationRepository extends JpaRepository<Reservation, Long>,
+    ReservationRepositoryCustom {
 
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryCustom.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryCustom.java
@@ -1,0 +1,12 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 16.
+ */
+package table.eat.now.reservation.reservation.infrastructure.persistence;
+
+import java.util.Optional;
+import table.eat.now.reservation.reservation.domain.entity.Reservation;
+
+public interface ReservationRepositoryCustom {
+  Optional<Reservation> findWithDetailsByReservationUuid(String reservationUuid);
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryCustomImpl.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryCustomImpl.java
@@ -1,0 +1,30 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 16.
+ */
+package table.eat.now.reservation.reservation.infrastructure.persistence;
+
+import static table.eat.now.reservation.reservation.domain.entity.QReservation.reservation;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import table.eat.now.reservation.reservation.domain.entity.QReservationPaymentDetail;
+import table.eat.now.reservation.reservation.domain.entity.Reservation;
+
+@RequiredArgsConstructor
+public class ReservationRepositoryCustomImpl implements ReservationRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<Reservation> findWithDetailsByReservationUuid(String reservationUuid) {
+    return Optional.ofNullable(
+        queryFactory
+        .selectFrom(reservation)
+        .leftJoin(reservation.paymentDetails.values,
+            QReservationPaymentDetail.reservationPaymentDetail).fetchJoin()
+        .where(reservation.reservationUuid.eq(reservationUuid))
+        .fetchOne());
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryImpl.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryImpl.java
@@ -5,6 +5,7 @@
 package table.eat.now.reservation.reservation.infrastructure.persistence;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import table.eat.now.reservation.reservation.domain.entity.Reservation;
@@ -19,6 +20,11 @@ public class ReservationRepositoryImpl implements ReservationRepository {
   @Override
   public Reservation save(Reservation reservation) {
     return jpaReservationRepository.save(reservation);
+  }
+
+  @Override
+  public Optional<Reservation> findWithDetailsByReservationUuid(String reservationUuid) {
+    return jpaReservationRepository.findWithDetailsByReservationUuid(reservationUuid);
   }
 
   @Override

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryImpl.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryImpl.java
@@ -31,4 +31,9 @@ public class ReservationRepositoryImpl implements ReservationRepository {
   public List<Reservation> findAll() {
     return jpaReservationRepository.findAll();
   }
+
+  @Override
+  public <S extends Reservation> List<S> saveAll(Iterable<S> entities) {
+    return jpaReservationRepository.saveAll(entities);
+  }
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/config/QuerydslConfig.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 15.
+ */
+package table.eat.now.reservation.reservation.infrastructure.persistence.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @Bean
+  JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationAdminController.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationAdminController.java
@@ -1,0 +1,38 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 16.
+ */
+package table.eat.now.reservation.reservation.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import table.eat.now.common.resolver.annotation.CurrentUserInfo;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.reservation.reservation.application.service.ReservationService;
+import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
+import table.eat.now.reservation.reservation.presentation.dto.response.GetReservationResponse;
+
+@RestController
+@RequestMapping("/admin/v1/reservations")
+@RequiredArgsConstructor
+public class ReservationAdminController {
+  private final ReservationService reservationService;
+
+  @GetMapping("/{reservationUuid}")
+  public ResponseEntity<GetReservationResponse> getReservationAdmin(
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @PathVariable String reservationUuid
+  ) {
+    return ResponseEntity.ok(
+        GetReservationResponse.from(
+            reservationService.getReservation(
+                GetReservationCriteria.from(reservationUuid, userInfo.role(), userInfo.userId())
+            )
+        )
+    );
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationAdminController.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationAdminController.java
@@ -10,8 +10,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import table.eat.now.common.aop.annotation.AuthCheck;
 import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.reservation.reservation.application.service.ReservationService;
 import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
 import table.eat.now.reservation.reservation.presentation.dto.response.GetReservationResponse;
@@ -23,6 +25,7 @@ public class ReservationAdminController {
   private final ReservationService reservationService;
 
   @GetMapping("/{reservationUuid}")
+  @AuthCheck(roles = {UserRole.MASTER, UserRole.OWNER, UserRole.STAFF})
   public ResponseEntity<GetReservationResponse> getReservationAdmin(
       @CurrentUserInfo CurrentUserInfoDto userInfo,
       @PathVariable String reservationUuid

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
@@ -23,7 +23,7 @@ import table.eat.now.reservation.reservation.presentation.dto.response.CreateRes
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reservations")
-public class ReservationController {
+public class ReservationApiController {
 
   private final ReservationService reservationService;
 

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
@@ -8,6 +8,8 @@ import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,8 +19,10 @@ import table.eat.now.common.aop.annotation.AuthCheck;
 import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.reservation.reservation.application.service.ReservationService;
+import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
 import table.eat.now.reservation.reservation.presentation.dto.request.CreateReservationRequest;
 import table.eat.now.reservation.reservation.presentation.dto.response.CreateReservationResponse;
+import table.eat.now.reservation.reservation.presentation.dto.response.GetReservationResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,6 +47,20 @@ public class ReservationApiController {
                 reservation.reservationUuid())
             .toUri()
     ).body(reservation);
+  }
+
+  @GetMapping("/{reservationUuid}")
+  public ResponseEntity<GetReservationResponse> getReservation(
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @PathVariable String reservationUuid
+  ) {
+    return ResponseEntity.ok(
+        GetReservationResponse.from(
+            reservationService.getReservation(
+                GetReservationCriteria.from(reservationUuid, userInfo.role(), userInfo.userId())
+            )
+        )
+    );
   }
 
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
@@ -50,6 +50,7 @@ public class ReservationApiController {
   }
 
   @GetMapping("/{reservationUuid}")
+  @AuthCheck
   public ResponseEntity<GetReservationResponse> getReservation(
       @CurrentUserInfo CurrentUserInfoDto userInfo,
       @PathVariable String reservationUuid

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/dto/response/GetReservationResponse.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/dto/response/GetReservationResponse.java
@@ -24,7 +24,7 @@ public record GetReservationResponse(
     String menuName,
     BigDecimal menuPrice,
     int menuQuantity,
-    GetReservationInfo.ReservationStatus status,
+    String status,
     String specialRequest,
     BigDecimal totalAmount,
     List<PaymentDetailDto> paymentDetails
@@ -44,7 +44,7 @@ public record GetReservationResponse(
         info.menuName(),
         info.menuPrice(),
         info.menuQuantity(),
-        info.status(),
+        info.status().name(),
         info.specialRequest(),
         info.totalAmount(),
         info.paymentDetails().stream()
@@ -55,14 +55,14 @@ public record GetReservationResponse(
 
   public record PaymentDetailDto(
       String reservationPaymentDetailUuid,
-      GetReservationInfo.PaymentType type,
+      String type,
       BigDecimal amount,
       String detailReferenceId
   ) {
     public static PaymentDetailDto from(GetReservationInfo.PaymentDetailInfo detail) {
       return new PaymentDetailDto(
           detail.reservationPaymentDetailUuid(),
-          detail.type(),
+          detail.type().name(),
           detail.amount(),
           detail.detailReferenceId()
       );

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/dto/response/GetReservationResponse.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/dto/response/GetReservationResponse.java
@@ -1,0 +1,71 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 16.
+ */
+package table.eat.now.reservation.reservation.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import table.eat.now.reservation.reservation.application.service.dto.response.GetReservationInfo;
+
+public record GetReservationResponse(
+    String reservationUuid,
+    String name,
+    String reserverName,
+    String reserverContact,
+    int guestCount,
+    String restaurantName,
+    String restaurantContactNumber,
+    String restaurantAddress,
+    LocalDate reservationDate,
+    LocalTime reservationTime,
+    String menuName,
+    BigDecimal menuPrice,
+    int menuQuantity,
+    GetReservationInfo.ReservationStatus status,
+    String specialRequest,
+    BigDecimal totalAmount,
+    List<PaymentDetailDto> paymentDetails
+) {
+  public static GetReservationResponse from(GetReservationInfo info) {
+    return new GetReservationResponse(
+        info.reservationUuid(),
+        info.name(),
+        info.reserverName(),
+        info.reserverContact(),
+        info.guestCount(),
+        info.restaurantName(),
+        info.restaurantContactNumber(),
+        info.restaurantAddress(),
+        info.reservationDate(),
+        info.reservationTime(),
+        info.menuName(),
+        info.menuPrice(),
+        info.menuQuantity(),
+        info.status(),
+        info.specialRequest(),
+        info.totalAmount(),
+        info.paymentDetails().stream()
+            .map(PaymentDetailDto::from)
+            .toList()
+    );
+  }
+
+  public record PaymentDetailDto(
+      String reservationPaymentDetailUuid,
+      GetReservationInfo.PaymentType type,
+      BigDecimal amount,
+      String detailReferenceId
+  ) {
+    public static PaymentDetailDto from(GetReservationInfo.PaymentDetailInfo detail) {
+      return new PaymentDetailDto(
+          detail.reservationPaymentDetailUuid(),
+          detail.type(),
+          detail.amount(),
+          detail.detailReferenceId()
+      );
+    }
+  }
+}

--- a/reservation/src/test/java/table/eat/now/reservation/global/ControllerTestSupport.java
+++ b/reservation/src/test/java/table/eat/now/reservation/global/ControllerTestSupport.java
@@ -7,14 +7,31 @@ package table.eat.now.reservation.global;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import table.eat.now.common.aop.AuthCheckAspect;
+import table.eat.now.common.config.WebConfig;
+import table.eat.now.common.exception.GlobalErrorHandler;
+import table.eat.now.common.resolver.CurrentUserInfoResolver;
+import table.eat.now.common.resolver.CustomPageableArgumentResolver;
 import table.eat.now.reservation.reservation.application.service.ReservationService;
+import table.eat.now.reservation.reservation.presentation.ReservationAdminController;
 import table.eat.now.reservation.reservation.presentation.ReservationApiController;
 
 @WebMvcTest(controllers = {
-    ReservationApiController.class
+    ReservationApiController.class,
+    ReservationAdminController.class
 })
+@Import({
+    WebConfig.class,
+    CustomPageableArgumentResolver.class,
+    CurrentUserInfoResolver.class,
+    GlobalErrorHandler.class,
+    AuthCheckAspect.class
+})
+@EnableAspectJAutoProxy(proxyTargetClass = true)
 public abstract class ControllerTestSupport {
   @Autowired
   protected MockMvc mockMvc;

--- a/reservation/src/test/java/table/eat/now/reservation/global/ControllerTestSupport.java
+++ b/reservation/src/test/java/table/eat/now/reservation/global/ControllerTestSupport.java
@@ -10,10 +10,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import table.eat.now.reservation.reservation.application.service.ReservationService;
-import table.eat.now.reservation.reservation.presentation.ReservationController;
+import table.eat.now.reservation.reservation.presentation.ReservationApiController;
 
 @WebMvcTest(controllers = {
-    ReservationController.class
+    ReservationApiController.class
 })
 public abstract class ControllerTestSupport {
   @Autowired

--- a/reservation/src/test/java/table/eat/now/reservation/global/fixture/ReservationFixture.java
+++ b/reservation/src/test/java/table/eat/now/reservation/global/fixture/ReservationFixture.java
@@ -5,11 +5,121 @@
 package table.eat.now.reservation.global.fixture;
 
 
-public class ReservationFixture {
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import table.eat.now.reservation.global.util.LongIdGenerator;
+import table.eat.now.reservation.reservation.domain.entity.Reservation;
+import table.eat.now.reservation.reservation.domain.entity.Reservation.ReservationStatus;
+import table.eat.now.reservation.reservation.domain.entity.ReservationPaymentDetail;
 
-//  public static Reservation createRestaurant(
-//      Long id,
-//  ) {
-//
-//  }
+public class ReservationFixture {
+  public static Reservation createRandomByPaymentDetails(
+      List<ReservationPaymentDetail> paymentDetails) {
+    Long num = LongIdGenerator.makeLong();
+    Long reserverId = num;
+    String reservationUuid = UUID.randomUUID().toString();
+    String name = "Test Reservation"+num;
+    String restaurantTimeSlotUuid = UUID.randomUUID().toString();
+    LocalDate reservationDate = LocalDate.now();
+    LocalTime reservationTimeslot = LocalTime.of(18, 30);
+    String restaurantId = UUID.randomUUID().toString();
+    String restaurantAddress = "123 Main Street, Seoul" + num;
+    LocalTime restaurantClosingTime = LocalTime.of(22, 0);
+    Long ownerId = LongIdGenerator.makeLong();
+    Long staffId = LongIdGenerator.makeLong();
+    String restaurantContactNumber = "010-1234-5678";
+    String restaurantName = "테스트 레스토랑"+num;
+    LocalTime restaurantOpeningTime = LocalTime.of(11, 0);
+    String menuName = "테스트 메뉴" + num;
+    BigDecimal menuPrice = BigDecimal.valueOf(15000);
+    Integer menuQuantity = 2;
+    String reserverName = "홍길동" + num;
+    String reserverContact = "010-9876-5432";
+    Integer guestCount = 3;
+    ReservationStatus status = ReservationStatus.PENDING_PAYMENT;
+    String specialRequest = "창가 자리 부탁드립니다."+num;
+
+    return create(
+        reserverId,
+        reservationUuid,
+        name,
+        restaurantTimeSlotUuid,
+        reservationDate,
+        reservationTimeslot,
+        restaurantId,
+        restaurantAddress,
+        restaurantClosingTime,
+        ownerId,
+        staffId,
+        restaurantContactNumber,
+        restaurantName,
+        restaurantOpeningTime,
+        menuName,
+        menuPrice,
+        menuQuantity,
+        reserverName,
+        reserverContact,
+        guestCount,
+        status,
+        specialRequest,
+        paymentDetails
+    );
+  }
+  public static Reservation create(
+      Long reserverId,
+      String reservationUuid,
+      String name,
+      String restaurantTimeSlotUuid,
+      LocalDate reservationDate,
+      LocalTime reservationTimeslot,
+      String restaurantId,
+      String restaurantAddress,
+      LocalTime restaurantClosingTime,
+      Long ownerId,
+      Long staffId,
+      String restaurantContactNumber,
+      String restaurantName,
+      LocalTime restaurantOpeningTime,
+      String menuName,
+      BigDecimal menuPrice,
+      Integer menuQuantity,
+      String reserverName,
+      String reserverContact,
+      Integer guestCount,
+      ReservationStatus status,
+      String specialRequest,
+      List<ReservationPaymentDetail> details
+  ) {
+
+    Reservation reservation = Reservation.builder()
+        .reserverId(reserverId)
+        .reservationUuid(reservationUuid)
+        .name(name)
+        .restaurantTimeSlotUuid(restaurantTimeSlotUuid)
+        .reservationDate(reservationDate)
+        .reservationTimeslot(reservationTimeslot)
+        .restaurantId(restaurantId)
+        .restaurantName(restaurantName)
+        .restaurantAddress(restaurantAddress)
+        .restaurantContactNumber(restaurantContactNumber)
+        .restaurantOpeningTime(restaurantOpeningTime)
+        .restaurantClosingTime(restaurantClosingTime)
+        .ownerId(ownerId)
+        .staffId(staffId)
+        .menuName(menuName)
+        .menuPrice(menuPrice)
+        .menuQuantity(menuQuantity)
+        .reserverName(reserverName)
+        .reserverContact(reserverContact)
+        .guestCount(guestCount)
+        .status(status)
+        .specialRequest(specialRequest)
+        .details(details)
+        .build();
+
+    return reservation;
+  }
 }

--- a/reservation/src/test/java/table/eat/now/reservation/global/fixture/ReservationPaymentDetailFixture.java
+++ b/reservation/src/test/java/table/eat/now/reservation/global/fixture/ReservationPaymentDetailFixture.java
@@ -1,0 +1,36 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 16.
+ */
+package table.eat.now.reservation.global.fixture;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import table.eat.now.reservation.global.util.LongIdGenerator;
+import table.eat.now.reservation.reservation.domain.entity.ReservationPaymentDetail;
+import table.eat.now.reservation.reservation.domain.entity.ReservationPaymentDetail.PaymentType;
+
+public class ReservationPaymentDetailFixture {
+  public static ReservationPaymentDetail create(
+      BigDecimal amount,
+      String detailReferenceId,
+      PaymentType type
+  ) {
+    return ReservationPaymentDetail.builder()
+        .amount(amount)
+        .detailReferenceId(detailReferenceId)
+        .type(type)
+        .build();
+  }
+
+  public static ReservationPaymentDetail createRandomByType(PaymentType type) {
+    Long num = LongIdGenerator.makeLong();
+    BigDecimal amount = BigDecimal.valueOf(num + 1000);
+    String detailReferenceId = UUID.randomUUID().toString();
+    return create(
+        amount,
+        detailReferenceId,
+        type
+    );
+  }
+}

--- a/reservation/src/test/java/table/eat/now/reservation/global/util/LongIdGenerator.java
+++ b/reservation/src/test/java/table/eat/now/reservation/global/util/LongIdGenerator.java
@@ -1,0 +1,16 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 16.
+ */
+package table.eat.now.reservation.global.util;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class LongIdGenerator {
+  private static final AtomicLong counter = new AtomicLong(1);
+
+  public static Long makeLong(){
+    return counter.getAndIncrement();
+  }
+
+}

--- a/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
+++ b/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
@@ -1314,7 +1314,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
           .extracting(
               table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getName,
               table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getPrice,
-              table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getCount
+              table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getQuantity
           )
           .containsExactly(
               command.restaurantMenuDetails().name(),
@@ -1493,7 +1493,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
           .extracting(
               table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getName,
               table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getPrice,
-              table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getCount
+              table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getQuantity
           )
           .containsExactly(
               command.restaurantMenuDetails().name(),
@@ -1665,7 +1665,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
           .extracting(
               table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getName,
               table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getPrice,
-              table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getCount
+              table.eat.now.reservation.reservation.domain.entity.json.RestaurantMenuDetails::getQuantity
           )
           .containsExactly(
               command.restaurantMenuDetails().name(),

--- a/reservation/src/test/java/table/eat/now/reservation/reservation/presentation/ReservationApiControllerTest.java
+++ b/reservation/src/test/java/table/eat/now/reservation/reservation/presentation/ReservationApiControllerTest.java
@@ -28,7 +28,7 @@ import table.eat.now.reservation.global.util.UuidMaker;
 import table.eat.now.reservation.reservation.application.service.dto.response.CreateReservationInfo;
 import table.eat.now.reservation.reservation.presentation.dto.request.CreateReservationRequest;
 
-class ReservationControllerTest extends ControllerTestSupport {
+class ReservationApiControllerTest extends ControllerTestSupport {
 
   @DisplayName("예약 신청 컨트롤러")
   @Nested


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #129

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용

- **to-be**

  - [x] 예약 단건 조회 (api/admin)

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [x] 문서(코드, 주석, README 등)를 업데이트했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 예약 상세 조회 API가 추가되어, 관리자는 `/admin/v1/reservations/{reservationUuid}`에서, 일반 사용자는 `/api/v1/reservations/{reservationUuid}`에서 예약 상세 정보를 확인할 수 있습니다.
  - 예약 상세 정보에는 예약자, 레스토랑, 메뉴, 결제 내역 등 다양한 정보가 포함됩니다.

- **버그 수정**
  - 예약 메뉴 수량 필드명이 `count`에서 `quantity`로 변경되어 일관성이 개선되었습니다.

- **테스트**
  - 예약 상세 조회 및 권한별 접근에 대한 단위 테스트와 컨트롤러 테스트가 추가되었습니다.
  - 테스트 데이터 생성을 위한 Fixture 및 유틸 클래스가 새로 도입되었습니다.

- **기타**
  - 예약 엔티티와 관련 DTO, 레포지토리, 서비스 구조가 확장되어, 예약 정보 조회 및 권한 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->