### PR TITLE
[waiting] 알림 전송 이벤트 발행 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - grafana-storage:/var/lib/grafana  # Grafana 데이터 저장소
 
   zookeeper:
+    container_name: ten-zookeeper
     image: bitnami/zookeeper:latest
     platform: linux/amd64
     ports:
@@ -68,6 +69,7 @@ services:
       ALLOW_ANONYMOUS_LOGIN: "yes"
 
   kafka:
+    container_name: ten-kafka
     image: bitnami/kafka:3.8.1
     platform: linux/amd64
     ports:
@@ -82,6 +84,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-ui:
+    container_name: ten-kafka-ui
     image: provectuslabs/kafka-ui:latest
     platform: linux/amd64
     ports:
@@ -91,7 +94,6 @@ services:
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
       KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
       KAFKA_CLUSTERS_0_READONLY: "false"
-
 
 networks:
   app_network:

--- a/waiting/build.gradle
+++ b/waiting/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    // feign Apache HttpClient 5 (hc5) 기반으로 통신
+    implementation 'io.github.openfeign:feign-hc5'
 
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'

--- a/waiting/src/main/java/table/eat/now/waiting/waiting/domain/entity/DailyWaiting.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting/domain/entity/DailyWaiting.java
@@ -41,12 +41,12 @@ public class DailyWaiting extends BaseEntity {
   private LocalDate waitingDate;
 
   @Column(nullable = false)
-  private long avgWaitingSec;
+  private Long avgWaitingSec;
 
   private Long totalSequence;
 
   private DailyWaiting(String restaurantUuid, String restaurantName, WaitingStatus status,
-      LocalDate waitingDate, long avgWaitingSec) {
+      LocalDate waitingDate, Long avgWaitingSec) {
     this.dailyWaitingUuid = UUID.randomUUID().toString();
     this.restaurantUuid = restaurantUuid;
     this.restaurantName = restaurantName;
@@ -56,7 +56,7 @@ public class DailyWaiting extends BaseEntity {
   }
 
   public static DailyWaiting of(String restaurantUuid, String restaurantName, String status,
-      LocalDate waitingDate, long avgWaitingSec) {
+      LocalDate waitingDate, Long avgWaitingSec) {
     return new DailyWaiting(restaurantUuid, restaurantName, WaitingStatus.valueOf(status), waitingDate, avgWaitingSec);
   }
 

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/EventPublisher.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/EventPublisher.java
@@ -1,0 +1,6 @@
+package table.eat.now.waiting.waiting_request.application.event;
+
+public interface EventPublisher<T> {
+
+  void publish(T event);
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/EventType.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/EventType.java
@@ -1,0 +1,7 @@
+package table.eat.now.waiting.waiting_request.application.event.dto;
+
+public enum EventType {
+  WAITING_CREATED,
+  WAITING_ENTRANCE,
+  ;
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestCreatedEvent.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestCreatedEvent.java
@@ -1,0 +1,19 @@
+package table.eat.now.waiting.waiting_request.application.event.dto;
+
+import lombok.Builder;
+
+@Builder
+public record WaitingRequestCreatedEvent(
+    String waitingRequestUuid,
+    EventType eventType,
+    WaitingRequestCreatedInfo payload
+) implements WaitingRequestEvent  {
+
+  public static WaitingRequestCreatedEvent from(WaitingRequestCreatedInfo info) {
+    return WaitingRequestCreatedEvent.builder()
+        .waitingRequestUuid(info.waitingRequestUuid())
+        .eventType(EventType.WAITING_CREATED)
+        .payload(info)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestCreatedInfo.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestCreatedInfo.java
@@ -1,9 +1,10 @@
-package table.eat.now.waiting.waiting_request.application.dto.event;
+package table.eat.now.waiting.waiting_request.application.event.dto;
 
 import lombok.Builder;
 
 @Builder
-public record WaitingRequestCreatedEvent(
+public record WaitingRequestCreatedInfo(
+    String waitingRequestUuid,
     String phone,
     String slackId,
     String restaurantName,
@@ -11,10 +12,12 @@ public record WaitingRequestCreatedEvent(
     Long remainingCount,
     long estimatedWaitingMin
 ) {
-  public static WaitingRequestCreatedEvent of(
-      String phone, String slackId, String restaurantName,
+  public static WaitingRequestCreatedInfo of(
+      String waitingRequestUuid, String phone, String slackId, String restaurantName,
       Long sequence, Long remainingCount, long estimatedWaitingSec) {
-    return WaitingRequestCreatedEvent.builder()
+
+    return WaitingRequestCreatedInfo.builder()
+        .waitingRequestUuid(waitingRequestUuid)
         .phone(phone)
         .slackId(slackId)
         .restaurantName(restaurantName)

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestEntranceEvent.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestEntranceEvent.java
@@ -1,0 +1,19 @@
+package table.eat.now.waiting.waiting_request.application.event.dto;
+
+import lombok.Builder;
+
+@Builder
+public record WaitingRequestEntranceEvent(
+    String waitingRequestUuid,
+    EventType eventType,
+    WaitingRequestEntranceInfo payload
+) implements WaitingRequestEvent {
+
+  public static WaitingRequestEntranceEvent from(WaitingRequestEntranceInfo info) {
+    return WaitingRequestEntranceEvent.builder()
+        .waitingRequestUuid(info.waitingRequestUuid())
+        .eventType(EventType.WAITING_ENTRANCE)
+        .payload(info)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestEntranceInfo.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestEntranceInfo.java
@@ -1,0 +1,24 @@
+package table.eat.now.waiting.waiting_request.application.event.dto;
+
+import lombok.Builder;
+
+@Builder
+public record WaitingRequestEntranceInfo(
+    String waitingRequestUuid,
+    String phone,
+    String slackId,
+    String restaurantName,
+    Long sequence
+) {
+  public static WaitingRequestEntranceInfo of(
+      String waitingRequestUuid, String phone, String slackId, String restaurantName, Long sequence)
+  {
+    return WaitingRequestEntranceInfo.builder()
+        .waitingRequestUuid(waitingRequestUuid)
+        .phone(phone)
+        .slackId(slackId)
+        .restaurantName(restaurantName)
+        .sequence(sequence)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestEvent.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestEvent.java
@@ -1,0 +1,6 @@
+package table.eat.now.waiting.waiting_request.application.event.dto;
+
+public interface WaitingRequestEvent {
+  String waitingRequestUuid();
+  EventType eventType();
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/client/feign/WaitingFeignClient.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/client/feign/WaitingFeignClient.java
@@ -10,6 +10,6 @@ import table.eat.now.waiting.waiting_request.infrastructure.client.feign.config.
 @FeignClient(name="waiting", configuration = InternalFeignConfig.class)
 public interface WaitingFeignClient {
 
-  @GetMapping("/internal/v1/waiting/{dailyWaitingUuid}")
+  @GetMapping("/internal/v1/waitings/{dailyWaitingUuid}")
   ResponseEntity<GetDailyWaitingResponse> getDailyWaitingInfo(@PathVariable String dailyWaitingUuid);
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/WaitingRequestEventPublisher.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/WaitingRequestEventPublisher.java
@@ -1,0 +1,20 @@
+package table.eat.now.waiting.waiting_request.infrastructure.event.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import table.eat.now.waiting.waiting_request.application.event.EventPublisher;
+import table.eat.now.waiting.waiting_request.application.event.dto.WaitingRequestEvent;
+import table.eat.now.waiting.waiting_request.infrastructure.event.kafka.config.TopicConfig;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingRequestEventPublisher implements EventPublisher<WaitingRequestEvent> {
+
+  private final KafkaTemplate<String, WaitingRequestEvent> kafkaTemplate;
+
+  @Override
+  public void publish(WaitingRequestEvent event) {
+    kafkaTemplate.send(TopicConfig.TOPIC_NAME, event.waitingRequestUuid() ,event);
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/WaitingRequestEventPublisher.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/WaitingRequestEventPublisher.java
@@ -15,6 +15,6 @@ public class WaitingRequestEventPublisher implements EventPublisher<WaitingReque
 
   @Override
   public void publish(WaitingRequestEvent event) {
-    kafkaTemplate.send(TopicConfig.TOPIC_NAME, event.waitingRequestUuid() ,event);
+    kafkaTemplate.send(TopicConfig.TOPIC_NAME, event.waitingRequestUuid(), event);
   }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/config/ProducerConfig.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/config/ProducerConfig.java
@@ -1,0 +1,41 @@
+package table.eat.now.waiting.waiting_request.infrastructure.event.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import table.eat.now.waiting.waiting_request.application.event.dto.WaitingRequestEvent;
+import table.eat.now.waiting.waiting_request.infrastructure.event.kafka.interceptor.EventTypeHeaderInterceptor;
+
+@Configuration
+public class ProducerConfig {
+
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  @Bean
+  public ProducerFactory<String, WaitingRequestEvent> producerFactory() {
+
+    Map<String, Object> props = new HashMap<>();
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG, "all");
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.RETRIES_CONFIG, 3);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, EventTypeHeaderInterceptor.class.getName());
+
+    return new DefaultKafkaProducerFactory<>(props);
+  }
+
+  @Bean
+  public KafkaTemplate<String, WaitingRequestEvent> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/config/TopicConfig.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/config/TopicConfig.java
@@ -1,0 +1,28 @@
+package table.eat.now.waiting.waiting_request.infrastructure.event.kafka.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class TopicConfig {
+
+  public static final String TOPIC_NAME = "waiting-request-event";
+  @Value("${kafka.topic.waiting-request.partitions:3}")
+  private int partitions;
+  @Value("${kafka.topic.waiting-request.replicas:3}")
+  private int replicas;
+  @Value("${kafka.topic.waiting-request.min-insync-replicas:2}")
+  private String minInsyncReplicas;
+
+  @Bean
+  public NewTopic createWaitingRequestTopic() {
+    return TopicBuilder.name(TOPIC_NAME)
+        .partitions(partitions)
+        .replicas(replicas)
+        .config("min.insync.replicas", minInsyncReplicas)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/interceptor/EventTypeHeaderInterceptor.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/interceptor/EventTypeHeaderInterceptor.java
@@ -1,0 +1,34 @@
+package table.eat.now.waiting.waiting_request.infrastructure.event.kafka.interceptor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import table.eat.now.waiting.waiting_request.application.event.dto.WaitingRequestEvent;
+
+public class EventTypeHeaderInterceptor implements ProducerInterceptor<String, WaitingRequestEvent> {
+
+  private static final String EVENT_TYPE_HEADER = "eventType";
+
+  @Override
+  public ProducerRecord<String, WaitingRequestEvent> onSend(ProducerRecord<String, WaitingRequestEvent> record) {
+    WaitingRequestEvent event = record.value();
+    record
+        .headers()
+        .add(EVENT_TYPE_HEADER, event.eventType().name().getBytes(StandardCharsets.UTF_8));
+    return record;
+  }
+
+  @Override
+  public void onAcknowledgement(RecordMetadata recordMetadata, Exception e) {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/interceptor/EventTypeHeaderInterceptor.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/event/kafka/interceptor/EventTypeHeaderInterceptor.java
@@ -14,6 +14,9 @@ public class EventTypeHeaderInterceptor implements ProducerInterceptor<String, W
   @Override
   public ProducerRecord<String, WaitingRequestEvent> onSend(ProducerRecord<String, WaitingRequestEvent> record) {
     WaitingRequestEvent event = record.value();
+    if (event == null || event.eventType() == null) {
+      return record;
+    }
     record
         .headers()
         .add(EVENT_TYPE_HEADER, event.eventType().name().getBytes(StandardCharsets.UTF_8));

--- a/waiting/src/main/resources/application.yml
+++ b/waiting/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
       - classpath:properties/redis.yml
       - classpath:properties/cloud.yml
       - classpath:properties/zipkin.yml
+      - classpath:properties/kafka.yml
   profiles:
     group:
       local: local

--- a/waiting/src/main/resources/properties/kafka.yml
+++ b/waiting/src/main/resources/properties/kafka.yml
@@ -12,6 +12,19 @@ kafka:
 
 ---
 spring:
+  config.activate.on-profile: test
+  kafka:
+    bootstrap-servers: ${LOCAL_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+
+kafka:
+  topic:
+    waiting-request:
+      partitions: 3
+      replicas: 3
+      min-insync-replicas: 2
+
+---
+spring:
   config.activate.on-profile: develop
   kafka:
     bootstrap-servers: ${DEV_KAFKA_BOOTSTRAP_SERVERS}

--- a/waiting/src/main/resources/properties/kafka.yml
+++ b/waiting/src/main/resources/properties/kafka.yml
@@ -1,0 +1,24 @@
+spring:
+  config.activate.on-profile: local
+  kafka:
+    bootstrap-servers: ${LOCAL_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+
+kafka:
+  topic:
+    waiting-request:
+      partitions: 3
+      replicas: 3
+      min-insync-replicas: 2
+
+---
+spring:
+  config.activate.on-profile: develop
+  kafka:
+    bootstrap-servers: ${DEV_KAFKA_BOOTSTRAP_SERVERS}
+
+kafka:
+  topic:
+    waiting-request:
+      partitions: 3
+      replicas: 3
+      min-insync-replicas: 2


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #138

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 알림 전송 이벤트 발행 추가

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 대기 요청 생성 및 입장 시 도메인 이벤트가 Kafka로 발행됩니다.
    - 이벤트 타입, 이벤트 정보 등 다양한 이벤트 DTO가 추가되었습니다.
    - Kafka 토픽 및 프로듀서 설정, 이벤트 헤더 인터셉터가 도입되었습니다.

- **버그 수정**
    - 일부 REST API 경로가 복수형으로 수정되었습니다.

- **환경설정**
    - Kafka 관련 설정 파일 및 프로파일별 환경변수가 추가되었습니다.
    - docker-compose 서비스에 컨테이너 이름이 명시되었습니다.

- **테스트**
    - 대기 요청 서비스의 이벤트 발행 동작에 대한 테스트가 보강되었습니다.

- **기타**
    - 일부 엔티티 및 DTO의 필드 타입 및 이름이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->