### PR TITLE
[waiting] 대기 미루기 기능 구현

### DIFF
--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/request/CreateWaitingRequestCommand.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/request/CreateWaitingRequestCommand.java
@@ -3,6 +3,7 @@ package table.eat.now.waiting.waiting_request.application.dto.request;
 import lombok.Builder;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequestHistory;
+import table.eat.now.waiting.waiting_request.domain.entity.WaitingStatus;
 
 @Builder
 public record CreateWaitingRequestCommand(
@@ -20,7 +21,7 @@ public record CreateWaitingRequestCommand(
     WaitingRequest waitingRequest = WaitingRequest.of(
         waitingRequestUuid, dailyWaitingUuid, restaurantUuid,
         userId, sequence.intValue(), phone, slackId, seatSize);
-    WaitingRequestHistory history = WaitingRequestHistory.create();
+    WaitingRequestHistory history = WaitingRequestHistory.of(WaitingStatus.WAITING);
     waitingRequest.addHistory(history);
     return waitingRequest;
   }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/EventType.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/EventType.java
@@ -3,5 +3,5 @@ package table.eat.now.waiting.waiting_request.application.event.dto;
 public enum EventType {
   WAITING_CREATED,
   WAITING_ENTRANCE,
-  ;
+  WAITING_POSTPONED;
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestPostponedEvent.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestPostponedEvent.java
@@ -1,0 +1,19 @@
+package table.eat.now.waiting.waiting_request.application.event.dto;
+
+import lombok.Builder;
+
+@Builder
+public record WaitingRequestPostponedEvent(
+    String waitingRequestUuid,
+    EventType eventType,
+    WaitingRequestPostponedInfo payload
+) implements WaitingRequestEvent  {
+
+  public static WaitingRequestPostponedEvent from(WaitingRequestPostponedInfo info) {
+    return WaitingRequestPostponedEvent.builder()
+        .waitingRequestUuid(info.waitingRequestUuid())
+        .eventType(EventType.WAITING_POSTPONED)
+        .payload(info)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestPostponedInfo.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestPostponedInfo.java
@@ -1,0 +1,29 @@
+package table.eat.now.waiting.waiting_request.application.event.dto;
+
+import lombok.Builder;
+
+@Builder
+public record WaitingRequestPostponedInfo(
+    String waitingRequestUuid,
+    String phone,
+    String slackId,
+    String restaurantName,
+    Long sequence,
+    Long remainingCount,
+    long estimatedWaitingMin
+) {
+  public static WaitingRequestPostponedInfo of(
+      String waitingRequestUuid, String phone, String slackId, String restaurantName,
+      Long sequence, Long remainingCount, long estimatedWaitingSec) {
+
+    return WaitingRequestPostponedInfo.builder()
+        .waitingRequestUuid(waitingRequestUuid)
+        .phone(phone)
+        .slackId(slackId)
+        .restaurantName(restaurantName)
+        .sequence(sequence)
+        .remainingCount(remainingCount)
+        .estimatedWaitingMin(estimatedWaitingSec/60)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestService.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestService.java
@@ -15,4 +15,6 @@ public interface WaitingRequestService {
       CurrentUserInfoDto userInfo, String waitingRequestUuid, String phone);
 
   GetWaitingRequestInfo getWaitingRequestAdmin(CurrentUserInfoDto userInfo, String string);
+
+  void postponeWaitingRequest(CurrentUserInfoDto userInfo, String waitingRequestUuid, String phone);
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingRequest.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingRequest.java
@@ -83,4 +83,13 @@ public class WaitingRequest extends BaseEntity {
     history.registerWaitingRequest(this);
     this.histories.add(history);
   }
+
+  public void updateStatus(WaitingStatus status) {
+    if (!this.status.isPossibleToUpdate(status)) {
+      throw new IllegalArgumentException("적절하지 못한 대기 상태 수정입니다.");
+    }
+    this.status = status;
+    WaitingRequestHistory waitingRequestHistory = WaitingRequestHistory.of(this.status);
+    addHistory(waitingRequestHistory);
+  }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingRequestHistory.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingRequestHistory.java
@@ -34,8 +34,8 @@ public class WaitingRequestHistory extends HistoryBaseEntity {
     this.status = status;
   }
 
-  public static WaitingRequestHistory create() {
-    return new WaitingRequestHistory(WaitingStatus.WAITING);
+  public static WaitingRequestHistory of(WaitingStatus status) {
+    return new WaitingRequestHistory(status);
   }
 
   public void registerWaitingRequest(WaitingRequest waitingRequest) {

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingStatus.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingStatus.java
@@ -1,18 +1,25 @@
 package table.eat.now.waiting.waiting_request.domain.entity;
 
+import java.util.function.Predicate;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum WaitingStatus {
 
-  WAITING("대기중"),
-  POSTPONED("입장연기"),
-  CANCELED("취소"),
-  NO_SHOW("노쇼"),
-  SEATED("착석"),
-  LEAVED("식사종료"),
+  WAITING("대기중", 1, status -> true),
+  POSTPONED("입장연기", 2, status -> status.order > 1 || status.order < 0),
+  SEATED("착석", 3, status -> status.order > 3 || status.order < 0),
+  LEAVED("식사종료", 4, status -> false),
+  CANCELED("취소", -1, status -> false),
+  NO_SHOW("노쇼", -2, status -> status.order > 1 || status.order == -1),
   ;
 
   private final String description;
+  private final int order;
+  private final Predicate<WaitingStatus> updateRule;
+
+  public boolean isPossibleToUpdate(WaitingStatus status) {
+    return updateRule.test(status);
+  }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/repository/WaitingRequestRepository.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/repository/WaitingRequestRepository.java
@@ -9,7 +9,7 @@ public interface WaitingRequestRepository {
 
   boolean existsByConditionAndStatusIsWaitingAndDeletedAtIsNull(String dailyWaitingUuid, String phone);
 
-  boolean enqueueWaitingRequest(
+  Boolean enqueueWaitingRequest(
       String dailyWaitingUuid, String waitingRequestUuid, long epochMilli);
 
   WaitingRequest save(WaitingRequest waitingRequest);

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/WaitingRequestRepositoryImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/WaitingRequestRepositoryImpl.java
@@ -26,7 +26,7 @@ public class WaitingRequestRepositoryImpl implements WaitingRequestRepository {
   }
 
   @Override
-  public boolean enqueueWaitingRequest(
+  public Boolean enqueueWaitingRequest(
       String dailyWaitingUuid, String waitingRequestUuid, long epochMilli) {
     return redisRepository.addWaitingRequest(dailyWaitingUuid, waitingRequestUuid, epochMilli);
   }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/redis/RedisWaitingRequestRepository.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/redis/RedisWaitingRequestRepository.java
@@ -4,7 +4,7 @@ public interface RedisWaitingRequestRepository {
 
   Long increaseSequence(String dailyWaitingUuid);
 
-  boolean addWaitingRequest(String dailyWaitingUuid, String waitingRequestUuid, long timestamp);
+  Boolean addWaitingRequest(String dailyWaitingUuid, String waitingRequestUuid, long timestamp);
 
   Integer getSequence(String dailyWaitingUuid);
 

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/redis/RedisWaitingRequestRepositoryImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/redis/RedisWaitingRequestRepositoryImpl.java
@@ -17,11 +17,10 @@ public class RedisWaitingRequestRepositoryImpl implements RedisWaitingRequestRep
   }
 
   @Override
-  public boolean addWaitingRequest(
+  public Boolean addWaitingRequest(
       String dailyWaitingUuid, String waitingRequestUuid, long timestamp) {
-    return Boolean.TRUE.equals(
-        redisTemplate.opsForZSet()
-            .add(WAITING_ZSET_PREFIX + dailyWaitingUuid, waitingRequestUuid, timestamp));
+    return redisTemplate.opsForZSet()
+            .add(WAITING_ZSET_PREFIX + dailyWaitingUuid, waitingRequestUuid, timestamp);
   }
 
   @Override

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiController.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,5 +54,16 @@ public class WaitingRequestApiController {
     GetWaitingRequestInfo info =
         waitingRequestService.getWaitingRequest(userInfo, waitingRequestUuid.toString(), phone);
     return ResponseEntity.ok().body(GetWaitingRequestResponse.from(info));
+  }
+
+  @PatchMapping("/{waitingRequestUuid}/postpone")
+  public ResponseEntity<GetWaitingRequestResponse> postponeWaitingRequest(
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @PathVariable UUID waitingRequestUuid,
+      @RequestParam @Valid @Pattern(regexp = "^[0-9]{8,15}$") String phone
+  ) {
+
+    waitingRequestService.postponeWaitingRequest(userInfo, waitingRequestUuid.toString(), phone);
+    return ResponseEntity.ok().build();
   }
 }

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiControllerTest.java
@@ -3,7 +3,9 @@ package table.eat.now.waiting.waiting_request.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -97,6 +99,26 @@ class WaitingRequestApiControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.dailyWaitingUuid").value(info.dailyWaitingUuid()))
         .andExpect(jsonPath("$.restaurantUuid").value(info.restaurantUuid()))
         .andExpect(jsonPath("$.restaurantName").value(info.restaurantName()))
+        .andDo(print());
+  }
+
+  @DisplayName("대기 연기 요청 검증 - 200 응답")
+  @Test
+  void postponeWaitingRequest() throws Exception {
+    // given
+    var waitingRequestUuid = UUID.randomUUID().toString();
+    var phone = "01000000000";
+
+    doNothing().when(waitingRequestService)
+        .postponeWaitingRequest(null, waitingRequestUuid, phone);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        patch("/api/v1/waiting-requests/{waitingRequestUuid}/postpone", waitingRequestUuid)
+            .param("phone", phone));
+
+    // then
+    resultActions.andExpect(status().isOk())
         .andDo(print());
   }
 }

--- a/waiting/src/test/waiting.http
+++ b/waiting/src/test/waiting.http
@@ -30,21 +30,16 @@ Content-Type: application/json
 X-User-Id: 3
 X-User-Role: STAFF
 
-{
-  "restaurantUuid":"00000000-0000-0000-0000-000000000001"
-}
-
-### 대기 요청 조회 
-GET localhost:8086/api/v1/waiting-requests/{{waitingRequestUuid}}?phone=01000000000
-Content-Type: application/json
-
-
 ### 대기 요청 조회 admin # 임시
 GET localhost:8086/admin/v1/waiting-requests/{{waitingRequestUuid}}
 Content-Type: application/json
 X-User-Id: 3
 X-User-Role: STAFF
 
-{
-  "restaurantUuid":"00000000-0000-0000-0000-000000000001"
-}
+### 대기 요청 조회 
+GET localhost:8086/api/v1/waiting-requests/{{waitingRequestUuid}}?phone=01000000000
+Content-Type: application/json
+
+### 대기 연기 요청
+PATCH localhost:8086/api/v1/waiting-requests/{{waitingRequestUuid}}/postpone?phone=01000000000
+Content-Type: application/json


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #140

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 대기 미루기 기능 및 테스트
 
## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 대기 요청을 연기할 수 있는 API 엔드포인트(PATCH /api/v1/waiting-requests/{waitingRequestUuid}/postpone)가 추가되었습니다.
  - 대기 요청 연기 시 관련 이벤트 및 상태 변경이 반영됩니다.

- **버그 수정**
  - 일부 테스트 HTTP 요청에서 불필요한 JSON 본문이 제거되고, 요청 순서가 정리되었습니다.

- **테스트**
  - 대기 요청 연기 기능에 대한 서비스 및 API 테스트가 추가되었습니다.

- **리팩터**
  - 대기 상태 전이 로직이 개선되고, 관련 메서드 명명 규칙이 통일되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->