### PR TITLE
[reservation] 예약 취소

### DIFF
--- a/common/src/main/java/table/eat/now/common/domain/BaseEntity.java
+++ b/common/src/main/java/table/eat/now/common/domain/BaseEntity.java
@@ -39,4 +39,8 @@ public abstract class BaseEntity implements Serializable {
     this.deletedAt = LocalDateTime.now();
     this.deletedBy = deletedBy;
   }
+
+  public boolean isDeleted(){
+    return deletedAt != null || deletedBy != null;
+  }
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/exception/ReservationErrorCode.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/exception/ReservationErrorCode.java
@@ -17,8 +17,9 @@ public enum ReservationErrorCode implements ErrorCode {
    * BAD_REQUEST
   */
   // BAD_REQUEST - CANCEL
-  ALREADY_CANCELED("이미 취소되었는 예약입니다.", HttpStatus.BAD_REQUEST),
-  CANCEL_POLICY_VIOLATION("예약 취소가 불가능한 상태입니다..", HttpStatus.BAD_REQUEST),
+  CANCELLATION_DEADLINE_PASSED("취소 마감 시간이 지났습니다.", HttpStatus.BAD_REQUEST),
+  ALREADY_CANCELED("이미 취소가 된 상태입니다.", HttpStatus.BAD_REQUEST),
+  ALREADY_DELETED("이미 삭제가 된 상태입니다.", HttpStatus.BAD_REQUEST),
 
   // BAD_REQUEST - AMOUNT`
   INVALID_MENU_TOTAL_AMOUNT("총 금액이 메뉴 금액과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
@@ -48,6 +49,11 @@ public enum ReservationErrorCode implements ErrorCode {
   PROMOTION_INVALID_RUNNING("진행중인 프로모션이 아닙니다.", HttpStatus.BAD_REQUEST),
   INVALID_PROMOTION_DISCOUNT("적용된 프로모션 할인 금액이 실제 할인 금액과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
   PROMOTION_USAGE_LIMIT_EXCEEDED("프로모션 최대 사용 개수를 초과합니다.", HttpStatus.BAD_REQUEST),
+
+  /**
+   * FORBIDDEN
+   */
+  NO_CANCEL_PERMISSION("해당 예약에 대한 취소 권한이 없습니다.",HttpStatus.FORBIDDEN),
 
   /**
    * NOT_FOUND

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/exception/ReservationErrorCode.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/exception/ReservationErrorCode.java
@@ -16,6 +16,10 @@ public enum ReservationErrorCode implements ErrorCode {
   /**
    * BAD_REQUEST
   */
+  // BAD_REQUEST - CANCEL
+  ALREADY_CANCELED("이미 취소되었는 예약입니다.", HttpStatus.BAD_REQUEST),
+  CANCEL_POLICY_VIOLATION("예약 취소가 불가능한 상태입니다..", HttpStatus.BAD_REQUEST),
+
   // BAD_REQUEST - AMOUNT`
   INVALID_MENU_TOTAL_AMOUNT("총 금액이 메뉴 금액과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
   INVALID_PAYMENT_DETAILS_TOTAL_AMOUNT("총 금액이결제 총 금액과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/listener/CancelReservationEventListener.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/listener/CancelReservationEventListener.java
@@ -1,0 +1,23 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 17.
+ */
+package table.eat.now.reservation.reservation.application.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import table.eat.now.reservation.reservation.application.listener.event.CancelReservationAfterCommitEvent;
+
+@Component
+@RequiredArgsConstructor
+public class CancelReservationEventListener {
+
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleCancelReservationAfterCommitEvent(
+      final CancelReservationAfterCommitEvent event) {
+    // todo: kafka ReservationCancelEvent 이벤트 발행
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/listener/event/CancelReservationAfterCommitEvent.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/listener/event/CancelReservationAfterCommitEvent.java
@@ -1,0 +1,19 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 17.
+ */
+package table.eat.now.reservation.reservation.application.listener.event;
+
+import lombok.Builder;
+
+@Builder
+public record CancelReservationAfterCommitEvent(
+    String reservationUuid
+) {
+
+  public static CancelReservationAfterCommitEvent from(String reservationUuid) {
+    return CancelReservationAfterCommitEvent.builder()
+        .reservationUuid(reservationUuid)
+        .build(); // todo: 필요한 것들
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/listener/event/CancelReservationAfterCommitEvent.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/listener/event/CancelReservationAfterCommitEvent.java
@@ -4,16 +4,57 @@
  */
 package table.eat.now.reservation.reservation.application.listener.event;
 
+import java.math.BigDecimal;
+import java.util.List;
 import lombok.Builder;
+import table.eat.now.reservation.reservation.domain.entity.Reservation;
+import table.eat.now.reservation.reservation.domain.entity.ReservationPaymentDetail;
+import table.eat.now.reservation.reservation.domain.entity.ReservationPaymentDetail.PaymentType;
 
 @Builder
 public record CancelReservationAfterCommitEvent(
-    String reservationUuid
+    String reservationUuid,
+
+    // 결제
+    String paymentIdempotencyKey,
+    BigDecimal cancelAmount, // 결제 취소 금액
+    String cancelReason, // 최대 200자
+
+    // 식당
+    String restaurantUuid,
+    Integer guestCount,
+
+    // 쿠폰
+    List<String> couponUuids,
+
+    // 유저
+    Long reserverId
 ) {
 
-  public static CancelReservationAfterCommitEvent from(String reservationUuid) {
+  public static CancelReservationAfterCommitEvent from(
+      Reservation reservation
+  ) {
+    ReservationPaymentDetail paymentDetail = reservation.getPaymentDetails().getValues()
+        .stream()
+        .filter(detail -> detail.getType() == PaymentType.PAYMENT)
+        .findFirst().get();
+
+    List<String> couponUuids = reservation.getPaymentDetails()
+        .getValues()
+        .stream()
+        .filter(detail -> detail.getType() == PaymentType.PROMOTION_COUPON)
+        .map(couponDetail -> couponDetail.getDetailReferenceId())
+        .toList();
+
     return CancelReservationAfterCommitEvent.builder()
-        .reservationUuid(reservationUuid)
-        .build(); // todo: 필요한 것들
+        .reservationUuid(reservation.getReservationUuid())
+        .paymentIdempotencyKey(paymentDetail.getReservationPaymentDetailUuid())
+        .cancelAmount(paymentDetail.getAmount())
+        .cancelReason(reservation.getCancelReason())
+        .restaurantUuid(reservation.getRestaurantId())
+        .guestCount(reservation.getGuestInfo().getGuestCount())
+        .couponUuids(couponUuids)
+        .reserverId(reservation.getReserverId())
+        .build();
   }
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/DefaultReservationCancelPolicy.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/DefaultReservationCancelPolicy.java
@@ -1,0 +1,45 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 17.
+ */
+package table.eat.now.reservation.reservation.application.service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.reservation.reservation.application.exception.ReservationErrorCode;
+import table.eat.now.reservation.reservation.domain.entity.Reservation;
+
+@Component
+public class DefaultReservationCancelPolicy implements ReservationCancelPolicy {
+
+  private static final long MINIMUM_HOURS_BEFORE_CANCELLATION = 3;
+
+  // 요부분 예약 생성이랑 같이 후에 좀 더 리펙토링..
+  @Override
+  public void validCancelableBy(
+      Reservation reservation,
+      LocalDateTime cancelRequestDateTime,
+      Long requesterId,
+      UserRole userRole
+  ) {
+    if (reservation.isCanceled()) {
+      throw CustomException.from(ReservationErrorCode.ALREADY_CANCELED);
+    }
+
+    LocalDateTime reservationDateTime = reservation.getRestaurantTimeSlotDetails()
+        .reservationDateTime();
+
+    // 예약 3시간 전까지만 취소 가능
+    Duration durationUntilReservation = Duration.between(cancelRequestDateTime, reservationDateTime);
+    if(durationUntilReservation.toHours() < MINIMUM_HOURS_BEFORE_CANCELLATION){
+      throw CustomException.from(ReservationErrorCode.CANCELLATION_DEADLINE_PASSED);
+    }
+
+    if(!reservation.isEditableBy(requesterId, userRole)){
+      throw CustomException.from(ReservationErrorCode.NO_CANCEL_PERMISSION);
+    }
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/ReservationCancelPolicy.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/ReservationCancelPolicy.java
@@ -1,0 +1,18 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 17.
+ */
+package table.eat.now.reservation.reservation.application.service;
+
+import java.time.LocalDateTime;
+import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.reservation.reservation.domain.entity.Reservation;
+
+public interface ReservationCancelPolicy {
+  void validCancelableBy(
+      Reservation reservation,
+      LocalDateTime cancelRequestDateTime,
+      Long requesterId,
+      UserRole userRole
+  );
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/ReservationService.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/ReservationService.java
@@ -4,8 +4,10 @@
  */
 package table.eat.now.reservation.reservation.application.service;
 
+import java.time.LocalDateTime;
 import table.eat.now.reservation.reservation.application.service.dto.request.CreateReservationCommand;
 import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
+import table.eat.now.reservation.reservation.application.service.dto.response.CancelReservationInfo;
 import table.eat.now.reservation.reservation.application.service.dto.response.CreateReservationInfo;
 import table.eat.now.reservation.reservation.application.service.dto.response.GetReservationInfo;
 
@@ -14,4 +16,6 @@ public interface ReservationService {
   CreateReservationInfo createReservation(CreateReservationCommand command);
 
   GetReservationInfo getReservation(GetReservationCriteria criteria);
+
+  CancelReservationInfo cancelReservation(String reservationUuid, LocalDateTime cancelRequestDateTime);
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/ReservationService.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/ReservationService.java
@@ -4,7 +4,7 @@
  */
 package table.eat.now.reservation.reservation.application.service;
 
-import java.time.LocalDateTime;
+import table.eat.now.reservation.reservation.application.service.dto.request.CancelReservationCommand;
 import table.eat.now.reservation.reservation.application.service.dto.request.CreateReservationCommand;
 import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
 import table.eat.now.reservation.reservation.application.service.dto.response.CancelReservationInfo;
@@ -17,5 +17,5 @@ public interface ReservationService {
 
   GetReservationInfo getReservation(GetReservationCriteria criteria);
 
-  CancelReservationInfo cancelReservation(String reservationUuid, LocalDateTime cancelRequestDateTime);
+  CancelReservationInfo cancelReservation(CancelReservationCommand command);
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/request/CancelReservationCommand.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/request/CancelReservationCommand.java
@@ -1,0 +1,20 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 17.
+ */
+package table.eat.now.reservation.reservation.application.service.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.common.resolver.dto.UserRole;
+
+@Builder
+public record CancelReservationCommand(
+    String reservationUuid,
+    LocalDateTime cancelRequestDateTime,
+    Long requesterId,
+    UserRole userRole,
+    String reason
+) {
+
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/response/CancelReservationInfo.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/application/service/dto/response/CancelReservationInfo.java
@@ -1,0 +1,22 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 17.
+ */
+package table.eat.now.reservation.reservation.application.service.dto.response;
+
+import lombok.Builder;
+import table.eat.now.reservation.reservation.domain.entity.Reservation;
+
+@Builder
+public record CancelReservationInfo(
+    String reservationUuid,
+    String status
+) {
+
+  public static CancelReservationInfo from(Reservation reservation) {
+    return CancelReservationInfo.builder()
+        .reservationUuid(reservation.getReservationUuid())
+        .status(reservation.getStatus().toString())
+        .build();
+  }
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/Reservation.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/Reservation.java
@@ -16,7 +16,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.AccessLevel;
@@ -160,6 +162,29 @@ public class Reservation extends BaseEntity {
         && getDeletedAt() == null) return true;
 
     return false;
+  }
+
+  public boolean isCanceled() {
+    return this.status == ReservationStatus.CANCELLED;
+  }
+
+  public boolean isCancelable(LocalDateTime cancelRequestDateTime) {
+    if (isCanceled()) return false;
+
+    LocalDateTime reservationDateTime =
+        LocalDateTime.of(
+            this.restaurantTimeSlotDetails.getAvailableDate(),
+            this.restaurantTimeSlotDetails.getTimeslot()
+        );
+
+    Duration durationUntilReservation = Duration.between(cancelRequestDateTime, reservationDateTime);
+    long hoursUntilReservation = durationUntilReservation.toHours();
+
+    return hoursUntilReservation >= 3;
+  }
+
+  public void cancel() {
+    this.status = ReservationStatus.CANCELLED;
   }
 
   @Getter

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/json/RestaurantTimeSlotDetails.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/entity/json/RestaurantTimeSlotDetails.java
@@ -5,6 +5,7 @@
 package table.eat.now.reservation.reservation.domain.entity.json;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -20,5 +21,10 @@ public class RestaurantTimeSlotDetails {
 
   public static RestaurantTimeSlotDetails of(LocalDate availableDate, LocalTime timeslot) {
     return new RestaurantTimeSlotDetails(availableDate, timeslot);
+  }
+
+  // get하니까 역직렬화 오류뜨네요?
+  public LocalDateTime reservationDateTime() {
+    return LocalDateTime.of(availableDate, timeslot);
   }
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/domain/repository/ReservationRepository.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/domain/repository/ReservationRepository.java
@@ -14,6 +14,8 @@ public interface ReservationRepository {
 
   Optional<Reservation> findWithDetailsByReservationUuid(String reservationUuid);
 
+  Optional<Reservation> findByReservationUuid(String reservationUuid);
+
   // test 용
   List<Reservation> findAll();
 

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/JpaReservationRepository.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/JpaReservationRepository.java
@@ -4,10 +4,12 @@
  */
 package table.eat.now.reservation.reservation.infrastructure.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import table.eat.now.reservation.reservation.domain.entity.Reservation;
 
 public interface JpaReservationRepository extends JpaRepository<Reservation, Long>,
     ReservationRepositoryCustom {
 
+  Optional<Reservation> findByReservationUuid(String reservationUuid);
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryImpl.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/infrastructure/persistence/ReservationRepositoryImpl.java
@@ -28,6 +28,11 @@ public class ReservationRepositoryImpl implements ReservationRepository {
   }
 
   @Override
+  public Optional<Reservation> findByReservationUuid(String reservationUuid) {
+    return jpaReservationRepository.findByReservationUuid(reservationUuid);
+  }
+
+  @Override
   public List<Reservation> findAll() {
     return jpaReservationRepository.findAll();
   }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
@@ -20,8 +20,10 @@ import table.eat.now.common.aop.annotation.AuthCheck;
 import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.reservation.reservation.application.service.ReservationService;
+import table.eat.now.reservation.reservation.application.service.dto.request.CancelReservationCommand;
 import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
 import table.eat.now.reservation.reservation.application.service.dto.response.CancelReservationInfo;
+import table.eat.now.reservation.reservation.presentation.dto.request.CancelReservationRequest;
 import table.eat.now.reservation.reservation.presentation.dto.request.CreateReservationRequest;
 import table.eat.now.reservation.reservation.presentation.dto.response.CancelReservationResponse;
 import table.eat.now.reservation.reservation.presentation.dto.response.CreateReservationResponse;
@@ -68,11 +70,21 @@ public class ReservationApiController {
   }
 
   @PatchMapping("/{reservationUuid}/cancel")
+  @AuthCheck
   public ResponseEntity<CancelReservationResponse> cancelReservation(
-      @PathVariable String reservationUuid) {
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @PathVariable String reservationUuid,
+      @Valid CancelReservationRequest request
+  ) {
 
     CancelReservationInfo response = reservationService.cancelReservation(
-        reservationUuid, LocalDateTime.now());
+        CancelReservationCommand.builder()
+            .reservationUuid(reservationUuid)
+            .reason(request.cancelReason())
+            .requesterId(userInfo.userId())
+            .userRole(userInfo.role())
+            .cancelRequestDateTime(LocalDateTime.now())
+            .build());
     return ResponseEntity.ok(CancelReservationResponse.from(response));
   }
 

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
@@ -74,7 +74,7 @@ public class ReservationApiController {
   public ResponseEntity<CancelReservationResponse> cancelReservation(
       @CurrentUserInfo CurrentUserInfoDto userInfo,
       @PathVariable String reservationUuid,
-      @Valid CancelReservationRequest request
+      @Valid @RequestBody CancelReservationRequest request
   ) {
 
     CancelReservationInfo response = reservationService.cancelReservation(

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/ReservationApiController.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,9 @@ import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.reservation.reservation.application.service.ReservationService;
 import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
+import table.eat.now.reservation.reservation.application.service.dto.response.CancelReservationInfo;
 import table.eat.now.reservation.reservation.presentation.dto.request.CreateReservationRequest;
+import table.eat.now.reservation.reservation.presentation.dto.response.CancelReservationResponse;
 import table.eat.now.reservation.reservation.presentation.dto.response.CreateReservationResponse;
 import table.eat.now.reservation.reservation.presentation.dto.response.GetReservationResponse;
 
@@ -62,6 +65,15 @@ public class ReservationApiController {
             )
         )
     );
+  }
+
+  @PatchMapping("/{reservationUuid}/cancel")
+  public ResponseEntity<CancelReservationResponse> cancelReservation(
+      @PathVariable String reservationUuid) {
+
+    CancelReservationInfo response = reservationService.cancelReservation(
+        reservationUuid, LocalDateTime.now());
+    return ResponseEntity.ok(CancelReservationResponse.from(response));
   }
 
 }

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/dto/request/CancelReservationRequest.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/dto/request/CancelReservationRequest.java
@@ -1,0 +1,16 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 17.
+ */
+package table.eat.now.reservation.reservation.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CancelReservationRequest(
+    @NotBlank
+    @Size(max = 200, message = "취소이유(cancelReason)는 최대 200자까지 입력할 수 있습니다.")
+    String cancelReason
+) {
+
+}

--- a/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/dto/response/CancelReservationResponse.java
+++ b/reservation/src/main/java/table/eat/now/reservation/reservation/presentation/dto/response/CancelReservationResponse.java
@@ -1,0 +1,22 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 17.
+ */
+package table.eat.now.reservation.reservation.presentation.dto.response;
+
+import lombok.Builder;
+import table.eat.now.reservation.reservation.application.service.dto.response.CancelReservationInfo;
+
+@Builder
+public record CancelReservationResponse(
+    String reservationUuid,
+    String status
+) {
+
+  public static CancelReservationResponse from(CancelReservationInfo response) {
+    return CancelReservationResponse.builder()
+        .reservationUuid(response.reservationUuid())
+        .status(response.status())
+        .build();
+  }
+}

--- a/reservation/src/test/java/table/eat/now/reservation/global/IntegrationTestSupport.java
+++ b/reservation/src/test/java/table/eat/now/reservation/global/IntegrationTestSupport.java
@@ -7,6 +7,7 @@ package table.eat.now.reservation.global;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestConstructor;
@@ -39,6 +40,9 @@ public abstract class IntegrationTestSupport {
 
   @MockitoBean
   protected RestaurantClient restaurantClient;
+
+  @MockitoBean
+  protected ApplicationEventPublisher eventPublisher;
 
   @AfterEach
   void tearDown() {

--- a/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
+++ b/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
@@ -1963,34 +1963,20 @@ class ReservationServiceTest extends IntegrationTestSupport {
   class cancel_success {
 
     Reservation confirmedReservation;
-    Reservation canceledReservation;
-    Reservation deletedReservation;
 
     @BeforeEach
     void setUp() {
       confirmedReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
           ReservationPaymentDetailFixture.createRandomByType(
+              ReservationPaymentDetail.PaymentType.PAYMENT),
+          ReservationPaymentDetailFixture.createRandomByType(
+              ReservationPaymentDetail.PaymentType.PROMOTION_COUPON),
+          ReservationPaymentDetailFixture.createRandomByType(
               ReservationPaymentDetail.PaymentType.PAYMENT)
       ));
       ReflectionTestUtils.setField(confirmedReservation, "status", ReservationStatus.CONFIRMED);
 
-      canceledReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
-          ReservationPaymentDetailFixture.createRandomByType(
-              ReservationPaymentDetail.PaymentType.PAYMENT)
-      ));
-
-      ReflectionTestUtils.setField(canceledReservation, "status", ReservationStatus.CANCELLED);
-
-      deletedReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
-          ReservationPaymentDetailFixture.createRandomByType(
-              ReservationPaymentDetail.PaymentType.PAYMENT)
-      ));
-
-      ReflectionTestUtils.setField(deletedReservation, "status", ReservationStatus.CANCELLED);
-      ReflectionTestUtils.setField(deletedReservation, "deletedAt",
-          LocalDateTime.now().minusDays(1));
-      ReflectionTestUtils.setField(deletedReservation, "deletedBy", 1L);
-      reservationRepository.saveAll(List.of(confirmedReservation, canceledReservation, deletedReservation));
+      reservationRepository.saveAll(List.of(confirmedReservation));
     }
 
     @DisplayName("MASTER 는 모든 예약을 취소할 수 있다.")

--- a/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
+++ b/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
@@ -2184,7 +2184,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
           .reservationUuid(confirmedReservation.getReservationUuid())
           .cancelRequestDateTime(
               confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
-          .requesterId(confirmedReservation.getRestaurantDetails().getOwnerId() - 1) // 잘못된 ID
+          .requesterId(confirmedReservation.getRestaurantDetails().getOwnerId() - 10000L) // 잘못된 ID
           .userRole(UserRole.OWNER)
           .reason("황하온의 변덕")
           .build();
@@ -2203,7 +2203,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
           .reservationUuid(confirmedReservation.getReservationUuid())
           .cancelRequestDateTime(
               confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
-          .requesterId(confirmedReservation.getRestaurantDetails().getStaffId() - 1) // 잘못된 ID
+          .requesterId(confirmedReservation.getRestaurantDetails().getStaffId() - 10000L) // 잘못된 ID
           .userRole(UserRole.STAFF)
           .reason("강혜주의 바쁜 그녀")
           .build();
@@ -2222,7 +2222,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
           .reservationUuid(confirmedReservation.getReservationUuid())
           .cancelRequestDateTime(
               confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
-          .requesterId(confirmedReservation.getReserverId() - 1) // 잘못된 ID
+          .requesterId(confirmedReservation.getReserverId() + 10000L) // 잘못된 ID
           .userRole(UserRole.CUSTOMER)
           .reason("박지은의 잠옴")
           .build();

--- a/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
+++ b/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
@@ -1828,7 +1828,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
       // given
       GetReservationCriteria criteria = new GetReservationCriteria(
           reservation.getReservationUuid(),
-          reservation.getRestaurantDetails().getOwnerId() + 1,
+          reservation.getRestaurantDetails().getOwnerId() + 10000L,
           UserRole.OWNER);
 
       // when & then
@@ -1843,7 +1843,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
       // given
       GetReservationCriteria criteria = new GetReservationCriteria(
           reservation.getReservationUuid(),
-          reservation.getRestaurantDetails().getStaffId() + 1,
+          reservation.getRestaurantDetails().getStaffId() + 10000L,
           UserRole.STAFF);
 
       // when & then
@@ -1858,7 +1858,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
       // given
       GetReservationCriteria criteria = new GetReservationCriteria(
           reservation.getReservationUuid(),
-          reservation.getReserverId() + 1,
+          reservation.getReserverId() + 10000L,
           UserRole.CUSTOMER);
 
       // when & then

--- a/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
+++ b/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
@@ -1968,7 +1968,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
     void setUp() {
       confirmedReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
           ReservationPaymentDetailFixture.createRandomByType(
-              ReservationPaymentDetail.PaymentType.PAYMENT),
+              ReservationPaymentDetail.PaymentType.PROMOTION_EVENT),
           ReservationPaymentDetailFixture.createRandomByType(
               ReservationPaymentDetail.PaymentType.PROMOTION_COUPON),
           ReservationPaymentDetailFixture.createRandomByType(

--- a/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
+++ b/reservation/src/test/java/table/eat/now/reservation/reservation/application/service/ReservationServiceTest.java
@@ -38,12 +38,14 @@ import table.eat.now.reservation.reservation.application.client.dto.response.Get
 import table.eat.now.reservation.reservation.application.client.dto.response.GetPromotionsInfo.Promotion;
 import table.eat.now.reservation.reservation.application.client.dto.response.GetPromotionsInfo.Promotion.PromotionStatus;
 import table.eat.now.reservation.reservation.application.exception.ReservationErrorCode;
+import table.eat.now.reservation.reservation.application.service.dto.request.CancelReservationCommand;
 import table.eat.now.reservation.reservation.application.service.dto.request.CreateReservationCommand;
 import table.eat.now.reservation.reservation.application.service.dto.request.CreateReservationCommand.PaymentDetail.PaymentType;
 import table.eat.now.reservation.reservation.application.service.dto.request.CreateReservationCommand.RestaurantDetails;
 import table.eat.now.reservation.reservation.application.service.dto.request.CreateReservationCommand.RestaurantMenuDetails;
 import table.eat.now.reservation.reservation.application.service.dto.request.CreateReservationCommand.RestaurantTimeSlotDetails;
 import table.eat.now.reservation.reservation.application.service.dto.request.GetReservationCriteria;
+import table.eat.now.reservation.reservation.application.service.dto.response.CancelReservationInfo;
 import table.eat.now.reservation.reservation.application.service.dto.response.GetReservationInfo;
 import table.eat.now.reservation.reservation.application.service.dto.response.GetRestaurantInfo;
 import table.eat.now.reservation.reservation.domain.entity.Reservation;
@@ -1826,7 +1828,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
       // given
       GetReservationCriteria criteria = new GetReservationCriteria(
           reservation.getReservationUuid(),
-          reservation.getRestaurantDetails().getOwnerId()+1,
+          reservation.getRestaurantDetails().getOwnerId() + 1,
           UserRole.OWNER);
 
       // when & then
@@ -1841,7 +1843,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
       // given
       GetReservationCriteria criteria = new GetReservationCriteria(
           reservation.getReservationUuid(),
-          reservation.getRestaurantDetails().getStaffId()+1,
+          reservation.getRestaurantDetails().getStaffId() + 1,
           UserRole.STAFF);
 
       // when & then
@@ -1856,7 +1858,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
       // given
       GetReservationCriteria criteria = new GetReservationCriteria(
           reservation.getReservationUuid(),
-          reservation.getReserverId()+1,
+          reservation.getReserverId() + 1,
           UserRole.CUSTOMER);
 
       // when & then
@@ -1956,4 +1958,294 @@ class ReservationServiceTest extends IntegrationTestSupport {
     }
   }
 
+  @DisplayName("예약 취소 서비스: 성공")
+  @Nested
+  class cancel_success {
+
+    Reservation confirmedReservation;
+    Reservation canceledReservation;
+    Reservation deletedReservation;
+
+    @BeforeEach
+    void setUp() {
+      confirmedReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
+          ReservationPaymentDetailFixture.createRandomByType(
+              ReservationPaymentDetail.PaymentType.PAYMENT)
+      ));
+      ReflectionTestUtils.setField(confirmedReservation, "status", ReservationStatus.CONFIRMED);
+
+      canceledReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
+          ReservationPaymentDetailFixture.createRandomByType(
+              ReservationPaymentDetail.PaymentType.PAYMENT)
+      ));
+
+      ReflectionTestUtils.setField(canceledReservation, "status", ReservationStatus.CANCELLED);
+
+      deletedReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
+          ReservationPaymentDetailFixture.createRandomByType(
+              ReservationPaymentDetail.PaymentType.PAYMENT)
+      ));
+
+      ReflectionTestUtils.setField(deletedReservation, "status", ReservationStatus.CANCELLED);
+      ReflectionTestUtils.setField(deletedReservation, "deletedAt",
+          LocalDateTime.now().minusDays(1));
+      ReflectionTestUtils.setField(deletedReservation, "deletedBy", 1L);
+      reservationRepository.saveAll(List.of(confirmedReservation, canceledReservation, deletedReservation));
+    }
+
+    @DisplayName("MASTER 는 모든 예약을 취소할 수 있다.")
+    @Test
+    void success_master() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(confirmedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(1L)
+          .userRole(UserRole.MASTER)
+          .reason("한지훈의 단순변심")
+          .build();
+
+      // when
+      CancelReservationInfo result = reservationService.cancelReservation(command);
+
+      // then
+      assertThat(result.reservationUuid()).isEqualTo(confirmedReservation.getReservationUuid());
+      assertThat(result.status()).isEqualTo(ReservationStatus.CANCELLED.toString());
+    }
+
+    @DisplayName("OWNER 는 본인의 가게의 예약을 취소할 수 있다.")
+    @Test
+    void success_owner() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(confirmedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(confirmedReservation.getRestaurantDetails().getOwnerId())
+          .userRole(UserRole.OWNER)
+          .reason("황하온의 변덕")
+          .build();
+
+      // when
+      CancelReservationInfo result = reservationService.cancelReservation(command);
+
+      // then
+      assertThat(result.reservationUuid()).isEqualTo(confirmedReservation.getReservationUuid());
+      assertThat(result.status()).isEqualTo(ReservationStatus.CANCELLED.toString());
+    }
+
+    @DisplayName("STAFF 는 본인의 가게의 예약을 취소할 수 있다.")
+    @Test
+    void success_staff() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(confirmedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(confirmedReservation.getRestaurantDetails().getStaffId())
+          .userRole(UserRole.STAFF)
+          .reason("강혜주의 바쁜 그녀")
+          .build();
+
+      // when
+      CancelReservationInfo result = reservationService.cancelReservation(command);
+
+      // then
+      assertThat(result.reservationUuid()).isEqualTo(confirmedReservation.getReservationUuid());
+      assertThat(result.status()).isEqualTo(ReservationStatus.CANCELLED.toString());
+    }
+
+    @DisplayName("CUSTOMER 는 본인의 예약을 취소 할 수 있다.")
+    @Test
+    void success_customer() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(confirmedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(confirmedReservation.getReserverId())
+          .userRole(UserRole.CUSTOMER)
+          .reason("박지은의 잠옴")
+          .build();
+
+      // when
+      CancelReservationInfo result = reservationService.cancelReservation(command);
+
+      // then
+      assertThat(result.reservationUuid()).isEqualTo(confirmedReservation.getReservationUuid());
+      assertThat(result.status()).isEqualTo(ReservationStatus.CANCELLED.toString());
+    }
+
+  }
+
+  @DisplayName("예약 취소 서비스: 실패")
+  @Nested
+  class cancel_fail {
+
+    Reservation confirmedReservation;
+    Reservation canceledReservation;
+    Reservation deletedReservation;
+
+    @BeforeEach
+    void setUp() {
+      confirmedReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
+          ReservationPaymentDetailFixture.createRandomByType(
+              ReservationPaymentDetail.PaymentType.PAYMENT)
+      ));
+      ReflectionTestUtils.setField(confirmedReservation, "status", ReservationStatus.CONFIRMED);
+
+      canceledReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
+          ReservationPaymentDetailFixture.createRandomByType(
+              ReservationPaymentDetail.PaymentType.PAYMENT)
+      ));
+
+      ReflectionTestUtils.setField(canceledReservation, "status", ReservationStatus.CANCELLED);
+
+      deletedReservation = ReservationFixture.createRandomByPaymentDetails(List.of(
+          ReservationPaymentDetailFixture.createRandomByType(
+              ReservationPaymentDetail.PaymentType.PAYMENT)
+      ));
+
+      ReflectionTestUtils.setField(deletedReservation, "status", ReservationStatus.CANCELLED);
+      ReflectionTestUtils.setField(deletedReservation, "deletedAt",
+          LocalDateTime.now().minusDays(1));
+      ReflectionTestUtils.setField(deletedReservation, "deletedBy", 1L);
+      reservationRepository.saveAll(List.of(confirmedReservation, canceledReservation, deletedReservation));
+    }
+
+    @DisplayName("없는 예약을 취소하려고 하면 찾을 수 없어 예외가 발생한다.")
+    @Test
+    void fail_notFound() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid("not-found-uuid")
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(1L)
+          .userRole(UserRole.MASTER)
+          .reason("한지훈의 단순변심")
+          .build();
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancelReservation(command))
+          .isInstanceOf(CustomException.class)
+          .hasMessageContaining(ReservationErrorCode.NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("이미 삭제된 예약을 취소하려고 하면 찾을 수 없어 예외가 발생한다.")
+    @Test
+    void fail_notFound_alreadyDeleted() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(deletedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(1L)
+          .userRole(UserRole.MASTER)
+          .reason("한지훈의 단순변심")
+          .build();
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancelReservation(command))
+          .isInstanceOf(CustomException.class)
+          .hasMessageContaining(ReservationErrorCode.NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("이미 취소된 예약을 취소하려고 하면 예외가 발생한다.")
+    @Test
+    void fail_alreadyCanceled() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(canceledReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(1L)
+          .userRole(UserRole.MASTER)
+          .reason("한지훈의 단순변심")
+          .build();
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancelReservation(command))
+          .isInstanceOf(CustomException.class)
+          .hasMessageContaining(ReservationErrorCode.ALREADY_CANCELED.getMessage());
+    }
+
+    @DisplayName("취소 마감 시간이 지나서 취소를 하려고 하면 예외가 발생한다.")
+    @Test
+    void fail_cancellationDeadlinePassed() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(confirmedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusHours(2)) // 3시간 조건 위배
+          .requesterId(confirmedReservation.getRestaurantDetails().getOwnerId())
+          .userRole(UserRole.OWNER)
+          .reason("황하온의 변덕")
+          .build();
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancelReservation(command))
+          .isInstanceOf(CustomException.class)
+          .hasMessageContaining(ReservationErrorCode.CANCELLATION_DEADLINE_PASSED.getMessage());
+    }
+
+    @DisplayName("OWNER 가 본인의 가게가 아닌 예약을 취소하려고 하면 예외가 발생한다.")
+    @Test
+    void fail_owner_permission() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(confirmedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(confirmedReservation.getRestaurantDetails().getOwnerId() - 1) // 잘못된 ID
+          .userRole(UserRole.OWNER)
+          .reason("황하온의 변덕")
+          .build();
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancelReservation(command))
+          .isInstanceOf(CustomException.class)
+          .hasMessageContaining(ReservationErrorCode.NO_CANCEL_PERMISSION.getMessage());
+    }
+
+    @DisplayName("STAFF 가 본인의 가게가 아닌 예약을 취소하려고 하면 예외가 발생한다.")
+    @Test
+    void fail_staff() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(confirmedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(confirmedReservation.getRestaurantDetails().getStaffId() - 1) // 잘못된 ID
+          .userRole(UserRole.STAFF)
+          .reason("강혜주의 바쁜 그녀")
+          .build();
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancelReservation(command))
+          .isInstanceOf(CustomException.class)
+          .hasMessageContaining(ReservationErrorCode.NO_CANCEL_PERMISSION.getMessage());
+    }
+
+    @DisplayName("CUSTOMER 는 본인의 예약이 아닌 예약을 취소하려고 하면 예외가 발생한다.")
+    @Test
+    void fail_customer() {
+      // given
+      CancelReservationCommand command = CancelReservationCommand.builder()
+          .reservationUuid(confirmedReservation.getReservationUuid())
+          .cancelRequestDateTime(
+              confirmedReservation.getRestaurantTimeSlotDetails().reservationDateTime().minusDays(1))
+          .requesterId(confirmedReservation.getReserverId() - 1) // 잘못된 ID
+          .userRole(UserRole.CUSTOMER)
+          .reason("박지은의 잠옴")
+          .build();
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancelReservation(command))
+          .isInstanceOf(CustomException.class)
+          .hasMessageContaining(ReservationErrorCode.NO_CANCEL_PERMISSION.getMessage());
+    }
+
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #136 

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용

- **to-be**

  - [x] 예약 취소

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [x] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- kafka 이벤트 발행은 다음 pr에서 진행하겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 예약 취소 기능이 추가되었습니다. 이제 사용자는 예약 상세 화면에서 예약을 취소할 수 있습니다.
  - 예약 취소 시 사유를 입력할 수 있으며, 취소된 예약의 상태와 사유가 확인 가능합니다.
  - 예약 취소 API 엔드포인트가 추가되어 다양한 사용자 역할(마스터, 오너, 스태프, 고객)이 권한에 따라 취소를 요청할 수 있습니다.

- **버그 수정**
  - 예약 취소와 관련된 다양한 예외 상황(이미 취소된 예약, 삭제된 예약, 취소 마감 시간 초과, 권한 없음 등)에 대한 상세한 오류 메시지가 제공됩니다.

- **테스트**
  - 예약 취소 성공 및 실패 시나리오에 대한 서비스 및 API 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->