### PR TITLE
[promotion] 쿠폰 프로모션 참여 인원 couponUser에 메시지 전송 추가

### DIFF
--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/request/CreatePromotionCommand.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/request/CreatePromotionCommand.java
@@ -10,7 +10,8 @@ import table.eat.now.promotion.promotion.domain.entity.PromotionType;
  * @author : hanjihoon
  * @Date : 2025. 04. 08.
  */
-public record CreatePromotionCommand(String promotionName,
+public record CreatePromotionCommand(String couponUuid,
+                                     String promotionName,
                                      String description,
                                      LocalDateTime startTime,
                                      LocalDateTime endTime,
@@ -20,7 +21,7 @@ public record CreatePromotionCommand(String promotionName,
 
   public Promotion toEntity() {
     return Promotion.of(
-        promotionName, description, startTime, endTime,
+        couponUuid, promotionName, description, startTime, endTime,
         discountAmount, PromotionStatus.valueOf(promotionStatus),
         PromotionType.valueOf(promotionType));
   }

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/request/UpdatePromotionCommand.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/request/UpdatePromotionCommand.java
@@ -7,7 +7,8 @@ import java.time.LocalDateTime;
  * @author : hanjihoon
  * @Date : 2025. 04. 10.
  */
-public record UpdatePromotionCommand(String promotionName,
+public record UpdatePromotionCommand(String couponUuid,
+                                     String promotionName,
                                      String description,
                                      LocalDateTime startTime,
                                      LocalDateTime endTime,

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/response/GetPromotionInfo.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/response/GetPromotionInfo.java
@@ -11,6 +11,7 @@ import table.eat.now.promotion.promotion.domain.entity.Promotion;
  */
 @Builder
 public record GetPromotionInfo(Long promotionId,
+                               String couponUuid,
                                String promotionUuid,
                                String promotionName,
                                String description,
@@ -23,6 +24,7 @@ public record GetPromotionInfo(Long promotionId,
   public static GetPromotionInfo from(Promotion promotion) {
     return GetPromotionInfo.builder()
         .promotionId(promotion.getId())
+        .couponUuid(promotion.getCouponUuid())
         .promotionUuid(promotion.getPromotionUuid())
         .promotionName(promotion.getDetails().getPromotionName())
         .description(promotion.getDetails().getDescription())

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/response/SearchPromotionInfo.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/response/SearchPromotionInfo.java
@@ -11,6 +11,7 @@ import table.eat.now.promotion.promotion.domain.entity.repository.search.Promoti
  */
 @Builder
 public record SearchPromotionInfo(Long promotionId,
+                                  String couponUuid,
                                   String promotionUuid,
                                   String promotionName,
                                   String description,
@@ -23,6 +24,7 @@ public record SearchPromotionInfo(Long promotionId,
   public static SearchPromotionInfo from(PromotionSearchCriteriaQuery query) {
     return SearchPromotionInfo.builder()
         .promotionId(query.promotionId())
+        .couponUuid(query.couponUuid())
         .promotionUuid(query.promotionUuid())
         .promotionName(query.promotionName())
         .description(query.description())

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/response/UpdatePromotionInfo.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/dto/response/UpdatePromotionInfo.java
@@ -11,6 +11,7 @@ import table.eat.now.promotion.promotion.domain.entity.Promotion;
  */
 @Builder
 public record UpdatePromotionInfo(Long promotionId,
+                                  String couponUuid,
                                   String promotionUuid,
                                   String promotionName,
                                   String description,
@@ -23,6 +24,7 @@ public record UpdatePromotionInfo(Long promotionId,
   public static UpdatePromotionInfo from(Promotion promotion) {
     return UpdatePromotionInfo.builder()
         .promotionId(promotion.getId())
+        .couponUuid(promotion.getCouponUuid())
         .promotionUuid(promotion.getPromotionUuid())
         .promotionName(promotion.getDetails().getPromotionName())
         .description(promotion.getDetails().getDescription())

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/EventType.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/EventType.java
@@ -3,7 +3,4 @@ package table.eat.now.promotion.promotion.application.event;
 public enum EventType {
   //일단 따라 갔습니다...상의 후에 바꾸시죠!
   SUCCEED,
-  FAILED,
-  CANCEL_SUCCEED,
-  CANCEL_FAILED
 }

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/PromotionEventPublisher.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/PromotionEventPublisher.java
@@ -1,5 +1,7 @@
 package table.eat.now.promotion.promotion.application.event;
 
+import table.eat.now.promotion.promotion.application.event.produce.PromotionUserCouponSaveEvent;
+
 /**
  * @author : hanjihoon
  * @Date : 2025. 04. 16.
@@ -7,5 +9,6 @@ package table.eat.now.promotion.promotion.application.event;
 public interface PromotionEventPublisher {
 
   void publish(PromotionEvent event);
+  void publish(PromotionUserCouponSaveEvent event);
 
 }

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/produce/PromotionUserCouponSaveEvent.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/produce/PromotionUserCouponSaveEvent.java
@@ -1,0 +1,26 @@
+package table.eat.now.promotion.promotion.application.event.produce;
+
+
+
+import java.util.List;
+import lombok.Builder;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.promotion.promotion.application.event.EventType;
+import table.eat.now.promotion.promotion.application.event.PromotionEvent;
+@Builder
+public record PromotionUserCouponSaveEvent(
+    EventType eventType,
+    List<PromotionUserSavePayload> payloads,
+    CurrentUserInfoDto userInfo,
+    String couponUuid
+) implements PromotionEvent {
+
+  public static PromotionUserCouponSaveEvent of(PromotionUserSaveEvent event, String couponUuid) {
+    return PromotionUserCouponSaveEvent.builder()
+        .eventType(event.eventType())
+        .payloads(event.payloads())
+        .userInfo(event.userInfo())
+        .couponUuid(couponUuid)
+        .build();
+  }
+}

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/domain/entity/Promotion.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/domain/entity/Promotion.java
@@ -37,6 +37,9 @@ public class Promotion extends BaseEntity {
   @Column(nullable = false, unique = true, length = 100, name = "promotion_uuid")
   private String promotionUuid;
 
+  @Column(length = 100, name = "coupon_uuid")
+  private String couponUuid;
+
   @Embedded
   private PromotionDetails details;
 
@@ -56,9 +59,11 @@ public class Promotion extends BaseEntity {
 
 
   private Promotion(
-      String promotionName, String description, LocalDateTime startTime, LocalDateTime endTime,
+      String couponUuid, String promotionName, String description,
+      LocalDateTime startTime, LocalDateTime endTime,
       BigDecimal amount, PromotionStatus promotionStatus, PromotionType promotionType) {
     this.promotionUuid = UUID.randomUUID().toString();
+    this.couponUuid = couponUuid;
     this.details = PromotionDetails.of(promotionName, description);
     this.period = PromotionPeriod.of(startTime,endTime);
     this.discountPrice = DiscountPrice.of(amount);
@@ -67,17 +72,19 @@ public class Promotion extends BaseEntity {
   }
 
   public static Promotion of(
-      String promotionName, String description, LocalDateTime startTime, LocalDateTime endTime,
+      String couponUuid, String promotionName, String description,
+      LocalDateTime startTime, LocalDateTime endTime,
       BigDecimal amount, PromotionStatus promotionStatus, PromotionType promotionType) {
     return new Promotion(
-        promotionName, description, startTime, endTime,
+        couponUuid, promotionName, description, startTime, endTime,
         amount,promotionStatus,promotionType);
   }
 
   public void modifyPromotion(
-      String promotionName, String description, LocalDateTime startTime,
+      String couponUuid, String promotionName, String description, LocalDateTime startTime,
       LocalDateTime endTime, BigDecimal amount,
       PromotionStatus promotionStatus, PromotionType promotionType) {
+    this.couponUuid = couponUuid;
     this.details = PromotionDetails.of(promotionName, description);
     this.period = PromotionPeriod.of(startTime,endTime);
     this.discountPrice = DiscountPrice.of(amount);

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/domain/entity/repository/search/PromotionSearchCriteriaQuery.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/domain/entity/repository/search/PromotionSearchCriteriaQuery.java
@@ -11,6 +11,7 @@ import table.eat.now.promotion.promotion.domain.entity.Promotion;
  */
 @Builder
 public record PromotionSearchCriteriaQuery(Long promotionId,
+                                           String couponUuid,
                                            String promotionUuid,
                                            String promotionName,
                                            String description,
@@ -23,6 +24,7 @@ public record PromotionSearchCriteriaQuery(Long promotionId,
   public static PromotionSearchCriteriaQuery from(Promotion promotion) {
     return PromotionSearchCriteriaQuery.builder()
         .promotionId(promotion.getId())
+        .couponUuid(promotion.getCouponUuid())
         .promotionUuid(promotion.getPromotionUuid())
         .promotionName(promotion.getDetails().getPromotionName())
         .description(promotion.getDetails().getDescription())

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/infrastructure/kafka/KafkaPromotionProducer.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/infrastructure/kafka/KafkaPromotionProducer.java
@@ -6,6 +6,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import table.eat.now.promotion.promotion.application.event.PromotionEvent;
 import table.eat.now.promotion.promotion.application.event.PromotionEventPublisher;
+import table.eat.now.promotion.promotion.application.event.produce.PromotionUserCouponSaveEvent;
 
 @Slf4j
 @Component
@@ -14,6 +15,7 @@ public class KafkaPromotionProducer implements PromotionEventPublisher {
 
   private final KafkaTemplate<String, PromotionEvent> kafkaTemplate;
   private final String promotionTopic;
+  private final String couponTopic;
 
 
   @Override
@@ -21,6 +23,13 @@ public class KafkaPromotionProducer implements PromotionEventPublisher {
     kafkaTemplate.send(promotionTopic, event);
     logEvent(event);
   }
+
+  @Override
+  public void publish(PromotionUserCouponSaveEvent event) {
+    kafkaTemplate.send(couponTopic, event);
+    logEvent(event);
+  }
+
 
   private static void logEvent(PromotionEvent promotionEvent) {
     log.info("Published promotion event {}", promotionEvent.eventType().name());

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/infrastructure/kafka/config/PromotionKafkaTopicConfig.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/infrastructure/kafka/config/PromotionKafkaTopicConfig.java
@@ -9,9 +9,10 @@ import org.springframework.kafka.config.TopicBuilder;
 public class PromotionKafkaTopicConfig {
 
   private static final String PROMOTION_TOPIC_NAME = "promotion-event";
+  private static final String COUPON_TOPIC_NAME = "coupon-event";
 
   @Bean
-  public NewTopic createTopic() {
+  public NewTopic createPromotionTopic() {
     return TopicBuilder.name(PROMOTION_TOPIC_NAME)
         .partitions(3)
         .replicas(3)
@@ -22,5 +23,19 @@ public class PromotionKafkaTopicConfig {
   @Bean
   public String promotionTopic() {
     return PROMOTION_TOPIC_NAME;
+  }
+
+  @Bean
+  public NewTopic createCouponTopic() {
+    return TopicBuilder.name(COUPON_TOPIC_NAME)
+        .partitions(3)
+        .replicas(3)
+        .config("min.insync.replicas", "2")
+        .build();
+  }
+
+  @Bean
+  public String couponTopic() {
+    return COUPON_TOPIC_NAME;
   }
 }

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/request/CreatePromotionRequest.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/request/CreatePromotionRequest.java
@@ -15,7 +15,8 @@ import table.eat.now.promotion.promotion.application.dto.request.CreatePromotion
  * @author : hanjihoon
  * @Date : 2025. 04. 08.
  */
-public record CreatePromotionRequest(@NotBlank
+public record CreatePromotionRequest(String couponUuid,
+                                     @NotBlank
                                      @Size(max = 500)
                                      String promotionName,
                                      @NotBlank
@@ -26,7 +27,6 @@ public record CreatePromotionRequest(@NotBlank
                                      @NotNull
                                      @Future(message = "현재 시간보다 이후여야 합니다.")
                                      LocalDateTime endTime,
-                                     @NotNull
                                      @DecimalMin(value = "0.0", inclusive = false, message = "할인 금액은 0 이상이어야 합니다.")
                                      BigDecimal discountAmount,
                                      @NotBlank(message = "프로모션 상태는 필수입니다.")
@@ -40,6 +40,7 @@ public record CreatePromotionRequest(@NotBlank
 
   public CreatePromotionCommand toApplication() {
     return new CreatePromotionCommand(
+        couponUuid,
         promotionName,
         description,
         startTime,

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/request/UpdatePromotionRequest.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/request/UpdatePromotionRequest.java
@@ -13,7 +13,8 @@ import table.eat.now.promotion.promotion.application.dto.request.UpdatePromotion
  * @author : hanjihoon
  * @Date : 2025. 04. 10.
  */
-public record UpdatePromotionRequest(@Size(max = 500)
+public record UpdatePromotionRequest(String couponUuid,
+                                     @Size(max = 500)
                                      String promotionName,
                                      String description,
                                      @FutureOrPresent(message = "시작 시간은 현재 이후여야 합니다.")
@@ -32,6 +33,7 @@ public record UpdatePromotionRequest(@Size(max = 500)
 
   public UpdatePromotionCommand toApplication() {
     return new UpdatePromotionCommand(
+        couponUuid,
         promotionName,
         description,
         startTime,

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/response/GetPromotionResponse.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/response/GetPromotionResponse.java
@@ -11,6 +11,7 @@ import table.eat.now.promotion.promotion.application.dto.response.GetPromotionIn
  */
 @Builder
 public record GetPromotionResponse(Long promotionId,
+                                   String couponUuid,
                                    String promotionUuid,
                                    String promotionName,
                                    String description,
@@ -23,6 +24,7 @@ public record GetPromotionResponse(Long promotionId,
   public static GetPromotionResponse from(GetPromotionInfo getPromotionInfo) {
     return GetPromotionResponse.builder()
         .promotionId(getPromotionInfo.promotionId())
+        .couponUuid(getPromotionInfo.couponUuid())
         .promotionUuid(getPromotionInfo.promotionUuid())
         .promotionName(getPromotionInfo.promotionName())
         .description(getPromotionInfo.description())

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/response/SearchPromotionResponse.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/response/SearchPromotionResponse.java
@@ -11,6 +11,7 @@ import table.eat.now.promotion.promotion.application.dto.response.SearchPromotio
  */
 @Builder
 public record SearchPromotionResponse(Long promotionId,
+                                      String couponUuid,
                                       String promotionUuid,
                                       String promotionName,
                                       String description,
@@ -23,6 +24,7 @@ public record SearchPromotionResponse(Long promotionId,
   public static SearchPromotionResponse from(SearchPromotionInfo searchPromotionInfo) {
     return SearchPromotionResponse.builder()
         .promotionId(searchPromotionInfo.promotionId())
+        .couponUuid(searchPromotionInfo.couponUuid())
         .promotionUuid(searchPromotionInfo.promotionUuid())
         .promotionName(searchPromotionInfo.promotionName())
         .description(searchPromotionInfo.description())

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/response/UpdatePromotionResponse.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/presentation/dto/response/UpdatePromotionResponse.java
@@ -11,6 +11,7 @@ import table.eat.now.promotion.promotion.application.dto.response.UpdatePromotio
  */
 @Builder
 public record UpdatePromotionResponse(Long promotionId,
+                                      String couponUuid,
                                       String promotionUuid,
                                       String promotionName,
                                       String description,
@@ -23,6 +24,7 @@ public record UpdatePromotionResponse(Long promotionId,
   public static UpdatePromotionResponse from(UpdatePromotionInfo info) {
     return UpdatePromotionResponse.builder()
         .promotionId(info.promotionId())
+        .couponUuid(info.couponUuid())
         .promotionUuid(info.promotionUuid())
         .promotionName(info.promotionName())
         .description(info.description())

--- a/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionAdminControllerTest.java
+++ b/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionAdminControllerTest.java
@@ -1,16 +1,13 @@
 package table.eat.now.promotion.promotion.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -35,7 +32,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.promotion.promotion.application.dto.request.UpdatePromotionCommand;
 import table.eat.now.promotion.promotion.application.dto.response.CreatePromotionInfo;
-import table.eat.now.promotion.promotion.application.dto.response.GetPromotionInfo;
 import table.eat.now.promotion.promotion.application.dto.response.UpdatePromotionInfo;
 import table.eat.now.promotion.promotion.application.service.PromotionService;
 import table.eat.now.promotion.promotion.domain.entity.Promotion;
@@ -66,8 +62,10 @@ class PromotionAdminControllerTest {
   @DisplayName("프로모션 생성 테스트")
   @Test
   void promotion_create_test () throws Exception {
+    String couponUuid = UUID.randomUUID().toString();
     // given
     CreatePromotionRequest request = new CreatePromotionRequest(
+        couponUuid,
         "봄맞이 할인 프로모션",
         "전 메뉴 3000원 할인",
         LocalDateTime.now().plusDays(1),
@@ -98,8 +96,10 @@ class PromotionAdminControllerTest {
   void promotion_uuid_update_controller_test() throws Exception {
     // given
     String promotionUuid = UUID.randomUUID().toString();
+    String couponUuid = UUID.randomUUID().toString();
 
     UpdatePromotionRequest request = new UpdatePromotionRequest(
+        couponUuid,
         "봄맞이 할인 프로모션 - 수정 후",
         "전 메뉴 5000원 할인",
         LocalDateTime.now().plusDays(2),
@@ -112,6 +112,7 @@ class PromotionAdminControllerTest {
     UpdatePromotionCommand command = request.toApplication();
 
     Promotion promotion = Promotion.of(
+        couponUuid,
         "봄맞이 할인 프로모션 - 수정 전",
         "전 메뉴 5000원 할인",
         LocalDateTime.now().plusDays(2),
@@ -121,7 +122,9 @@ class PromotionAdminControllerTest {
         PromotionType.valueOf("COUPON")
     );
 
-    promotion.modifyPromotion( command.promotionName(),
+    promotion.modifyPromotion(
+        command.couponUuid(),
+        command.promotionName(),
         command.description(),
         command.startTime(),
         command.endTime(),
@@ -143,6 +146,7 @@ class PromotionAdminControllerTest {
 
     // then
     resultActions.andExpect(status().isOk())
+        .andExpect(jsonPath("$.couponUuid").value(couponUuid))
         .andExpect(jsonPath("$.promotionName").value("봄맞이 할인 프로모션 - 수정 후"))
         .andExpect(jsonPath("$.description").value("전 메뉴 5000원 할인"))
         .andExpect(jsonPath("$.discountAmount").value(5000))

--- a/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionControllerTest.java
+++ b/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionControllerTest.java
@@ -60,8 +60,10 @@ class PromotionControllerTest {
   void promotion_uuid_find_controller_test() throws Exception {
     // given
     String promotionUuid = UUID.randomUUID().toString();
+    String couponUuid = UUID.randomUUID().toString();
     GetPromotionInfo info = new GetPromotionInfo(
         1L,
+        couponUuid,
         promotionUuid,
         "봄맞이 할인",
         "따뜻한 봄을 맞이하여 전 메뉴 2000원 할인",
@@ -86,6 +88,7 @@ class PromotionControllerTest {
     // then
     resultActions.andExpect(status().isOk())
         .andExpect(jsonPath("$.promotionId").value(1L))
+        .andExpect(jsonPath("$.couponUuid").value(couponUuid))
         .andExpect(jsonPath("$.promotionUuid").value(promotionUuid))
         .andExpect(jsonPath("$.promotionName").value("봄맞이 할인"))
         .andExpect(jsonPath("$.description").value("따뜻한 봄을 맞이하여 전 메뉴 2000원 할인"))
@@ -100,6 +103,7 @@ class PromotionControllerTest {
   @Test
   void search_promotions_controller_test() throws Exception {
     // given
+    String couponUuid = UUID.randomUUID().toString();
     SearchPromotionRequest request = new SearchPromotionRequest(
         "할인",
         "시즌",
@@ -118,6 +122,7 @@ class PromotionControllerTest {
 
     SearchPromotionInfo info1 = new SearchPromotionInfo(
         1L,
+        couponUuid,
         UUID.randomUUID().toString(),
         "봄맞이 할인",
         "봄 시즌 한정 할인",
@@ -130,6 +135,7 @@ class PromotionControllerTest {
 
     SearchPromotionInfo info2 = new SearchPromotionInfo(
         2L,
+        couponUuid,
         UUID.randomUUID().toString(),
         "여름맞이 할인",
         "여름 시즌 한정 할인",


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #148 

## 변경 타입
- [x] 신규 기능 추가/수정


## 변경 내용


- **to-be**(변경 후 설명을 여기에 작성)

  - [x] [promotion] 쿠폰 프로모션 참여 인원 couponUser에 메시지 전송 추가


## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.


## 코멘트
전송은 아래와 같이 전송합니다! 하온님 확인하시고 필요한 필드나 변경 하고 싶은 사항 있다면 언제든 말씀해주세요!
```java
EventType eventType, //SUCCEED
    List<PromotionUserSavePayload> payloads,
    CurrentUserInfoDto userInfo,
    String couponUuid
````



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 프로모션에 쿠폰 UUID 필드가 추가되어, 프로모션 생성·수정·조회 시 쿠폰 정보를 함께 다룰 수 있습니다.
    - 쿠폰 관련 이벤트가 새롭게 발행되어, 쿠폰과 연동된 프로모션 참여 내역이 보다 명확하게 처리됩니다.

- **버그 수정**
    - 없음

- **테스트**
    - 모든 프로모션 관련 테스트에 쿠폰 UUID 필드가 반영되었습니다.

- **기타**
    - 일부 이벤트 타입이 정리되고, Kafka 토픽에 쿠폰 이벤트 토픽이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->