### PR TITLE
[waiting] 현재 대기 고객 목록 조회 기능 구현

### DIFF
--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/response/PageResult.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/response/PageResult.java
@@ -1,0 +1,80 @@
+package table.eat.now.waiting.waiting_request.application.dto.response;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import table.eat.now.waiting.waiting_request.domain.info.Paginated;
+
+@Builder
+public record PageResult<T>(
+    List<T> contents,
+    long totalElements,
+    int totalPages,
+    int pageNumber,
+    int pageSize
+) {
+
+  public static <T> PageResult<T> from(Page<T> page) {
+    Pageable pageable = page.getPageable();
+
+    return PageResult.<T>builder()
+        .contents(page.getContent())
+        .totalElements(page.getTotalElements())
+        .totalPages(page.getTotalPages())
+        .pageNumber(pageable.getPageNumber() + 1)
+        .pageSize(pageable.getPageSize())
+        .build();
+  }
+
+  public static <T> PageResult<T> of(
+      List<T> contents, long totalElements, int totalPages, int pageNumber, int pageSize) {
+
+    return PageResult.<T>builder()
+        .contents(contents)
+        .totalElements(totalElements)
+        .totalPages(totalPages)
+        .pageNumber(pageNumber)
+        .pageSize(pageSize)
+        .build();
+  }
+
+  private static <U, T> PageResult<U> from(PageResult<T> pageResult, List<U> list) {
+
+    return PageResult.<U>builder()
+        .contents(list)
+        .totalElements(pageResult.totalElements())
+        .totalPages(pageResult.totalPages())
+        .pageNumber(pageResult.pageNumber())
+        .pageSize(pageResult.pageSize())
+        .build();
+  }
+
+  public static <T> PageResult<T> from(Paginated<T> page) {
+
+    return PageResult.<T>builder()
+        .contents(page.contents())
+        .totalElements(page.totalElements())
+        .totalPages(page.totalPages())
+        .pageNumber(page.pageNumber())
+        .build();
+  }
+
+  public <U> PageResult<U> map(Function<T, U> mapper) {
+
+    return PageResult.from(this, this.contents.<T>stream()
+        .map(t -> mapper.apply(t))
+        .toList());
+  }
+
+  public <U> PageResult<U> mapWithIndex(long offset, BiFunction<T, Long, U> mapper) {
+
+    AtomicLong idx = new AtomicLong(offset);
+    return PageResult.from(this, this.contents.stream()
+        .map(t -> mapper.apply(t, idx.getAndIncrement()))
+        .toList());
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestService.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestService.java
@@ -1,8 +1,10 @@
 package table.eat.now.waiting.waiting_request.application.service;
 
+import org.springframework.data.domain.Pageable;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.waiting.waiting_request.application.dto.request.CreateWaitingRequestCommand;
 import table.eat.now.waiting.waiting_request.application.dto.response.GetWaitingRequestInfo;
+import table.eat.now.waiting.waiting_request.application.dto.response.PageResult;
 
 public interface WaitingRequestService {
 
@@ -17,4 +19,6 @@ public interface WaitingRequestService {
   GetWaitingRequestInfo getWaitingRequestAdmin(CurrentUserInfoDto userInfo, String string);
 
   void postponeWaitingRequest(CurrentUserInfoDto userInfo, String waitingRequestUuid, String phone);
+
+  PageResult<GetWaitingRequestInfo> getWaitingRequestsAdmin(CurrentUserInfoDto userInfo, String dailyWaitingUuid, Pageable pageable);
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/criteria/CurrentWaitingRequestCriteria.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/criteria/CurrentWaitingRequestCriteria.java
@@ -1,0 +1,20 @@
+package table.eat.now.waiting.waiting_request.domain.criteria;
+
+import lombok.Builder;
+import org.springframework.data.domain.Pageable;
+
+@Builder
+public record CurrentWaitingRequestCriteria(
+    int page,
+    int size,
+    String dailyWaitingUuid
+) {
+
+  public static CurrentWaitingRequestCriteria from(Pageable pageable, String dailyWaitingUuid) {
+    return CurrentWaitingRequestCriteria.builder()
+        .page(pageable.getPageNumber())
+        .size(pageable.getPageSize())
+        .dailyWaitingUuid(dailyWaitingUuid)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/info/Paginated.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/info/Paginated.java
@@ -1,0 +1,25 @@
+package table.eat.now.waiting.waiting_request.domain.info;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record Paginated<T>(
+    List<T> contents,
+    long totalElements,
+    int totalPages,
+    int pageNumber,
+    int pageSize
+) {
+
+  public static <T> Paginated<T> of(
+      List<T> contents, long totalElements, int totalPages, int pageNumber, int pageSize) {
+    return Paginated.<T>builder()
+        .contents(contents)
+        .totalElements(totalElements)
+        .totalPages(totalPages)
+        .pageNumber(pageNumber)
+        .pageSize(pageSize)
+        .build();
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/repository/WaitingRequestRepository.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/repository/WaitingRequestRepository.java
@@ -1,7 +1,11 @@
 package table.eat.now.waiting.waiting_request.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import table.eat.now.waiting.waiting_request.domain.criteria.CurrentWaitingRequestCriteria;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
+import table.eat.now.waiting.waiting_request.domain.info.Paginated;
 
 public interface WaitingRequestRepository {
 
@@ -21,4 +25,12 @@ public interface WaitingRequestRepository {
   Long getRank(String dailyWaitingUuid, String waitingRequestUuid);
 
   boolean dequeueWaitingRequest(String s, String waitingRequestsUuid);
+
+  Set<String> getIdsInRange(String dailyWaitingUuid, long start, long end);
+
+  Paginated<WaitingRequest> getCurrentWaitingRequests(CurrentWaitingRequestCriteria criteria);
+
+  List<WaitingRequest> findByWaitingRequestUuidInAndDeletedAtIsNull(Set<String> idsSet);
+
+  Long countCurrentWaitingRequests(String dailyWaitingUuid);
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/WaitingRequestRepositoryImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/WaitingRequestRepositoryImpl.java
@@ -1,9 +1,16 @@
 package table.eat.now.waiting.waiting_request.infrastructure.persistence;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import table.eat.now.waiting.waiting_request.domain.criteria.CurrentWaitingRequestCriteria;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
+import table.eat.now.waiting.waiting_request.domain.info.Paginated;
 import table.eat.now.waiting.waiting_request.domain.repository.WaitingRequestRepository;
 import table.eat.now.waiting.waiting_request.infrastructure.persistence.jpa.JpaWaitingRequestRepository;
 import table.eat.now.waiting.waiting_request.infrastructure.persistence.redis.RedisWaitingRequestRepositoryImpl;
@@ -54,5 +61,51 @@ public class WaitingRequestRepositoryImpl implements WaitingRequestRepository {
   @Override
   public boolean dequeueWaitingRequest(String dailyWaitingUuid, String waitingRequestUuid) {
     return redisRepository.removeWaitingRequest(dailyWaitingUuid, waitingRequestUuid);
+  }
+
+  @Override
+  public Set<String> getIdsInRange(String dailyWaitingUuid, long start, long end) {
+    return redisRepository.getIdsInRange(dailyWaitingUuid, start, end);
+  }
+
+  @Override
+  public Paginated<WaitingRequest> getCurrentWaitingRequests(
+      CurrentWaitingRequestCriteria criteria) {
+
+    int size = criteria.size();
+    int start =  criteria.page() * size;
+    long end = start + size - 1;
+
+    Set<String> idsSet = redisRepository.getIdsInRange(criteria.dailyWaitingUuid(), start, end);
+    Map<String ,WaitingRequest> requestsMap =
+        jpaRepository.findByWaitingRequestUuidInAndDeletedAtIsNull(idsSet)
+            .stream()
+            .collect(Collectors.toMap(
+                WaitingRequest::getWaitingRequestUuid,
+                Function.identity()
+            ));
+
+    List<WaitingRequest> requests = idsSet.stream()
+        .map(requestsMap::get)
+        .toList();
+
+    long total = 0;
+    if (requests.size() < size) {
+      total = start + requests.size();
+    } else {
+      total = redisRepository.countCurrentWaitingRequests(criteria.dailyWaitingUuid());
+    }
+    int totalPages = (int) ((total + size - 1) / size);
+    return Paginated.of(requests, total, totalPages, criteria.page(), size);
+  }
+
+  @Override
+  public List<WaitingRequest> findByWaitingRequestUuidInAndDeletedAtIsNull(Set<String> idsSet) {
+    return jpaRepository.findByWaitingRequestUuidInAndDeletedAtIsNull(idsSet);
+  }
+
+  @Override
+  public Long countCurrentWaitingRequests(String dailyWaitingUuid) {
+    return redisRepository.countCurrentWaitingRequests(dailyWaitingUuid);
   }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/jpa/JpaWaitingRequestRepository.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/jpa/JpaWaitingRequestRepository.java
@@ -1,6 +1,8 @@
 package table.eat.now.waiting.waiting_request.infrastructure.persistence.jpa;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
@@ -15,4 +17,6 @@ public interface JpaWaitingRequestRepository
       String dailyWaitingUuid, String phone);
 
   Optional<WaitingRequest> findByWaitingRequestUuidAndDeletedAtIsNull(String waitingRequestUuid);
+
+  List<WaitingRequest> findByWaitingRequestUuidInAndDeletedAtIsNull(Set<String> idsSet);
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/redis/RedisWaitingRequestRepository.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/redis/RedisWaitingRequestRepository.java
@@ -1,5 +1,7 @@
 package table.eat.now.waiting.waiting_request.infrastructure.persistence.redis;
 
+import java.util.Set;
+
 public interface RedisWaitingRequestRepository {
 
   Long increaseSequence(String dailyWaitingUuid);
@@ -11,4 +13,8 @@ public interface RedisWaitingRequestRepository {
   Long getRank(String dailyWaitingUuid, String waitingRequestUuid);
 
   boolean removeWaitingRequest(String dailyWaitingUuid, String waitingRequestUuid);
+
+  Set<String> getIdsInRange(String dailyWaitingUuid, long start, long end);
+
+  Long countCurrentWaitingRequests(String dailyWaitingUuid);
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/redis/RedisWaitingRequestRepositoryImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/redis/RedisWaitingRequestRepositoryImpl.java
@@ -1,5 +1,10 @@
 package table.eat.now.waiting.waiting_request.infrastructure.persistence.redis;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -37,5 +42,23 @@ public class RedisWaitingRequestRepositoryImpl implements RedisWaitingRequestRep
   public boolean removeWaitingRequest(String dailyWaitingUuid, String waitingRequestUuid) {
     Long count = redisTemplate.opsForZSet().remove(WAITING_ZSET_PREFIX + dailyWaitingUuid, waitingRequestUuid);
     return count != null && count > 0;
+  }
+
+  @Override
+  public Set<String> getIdsInRange(String dailyWaitingUuid, long start, long end) {
+
+    return Optional.ofNullable(redisTemplate
+            .opsForZSet()
+            .range(WAITING_ZSET_PREFIX + dailyWaitingUuid, start, end))
+        .orElse(Collections.emptySet())
+        .stream()
+        .filter(o -> o instanceof String)
+        .map(o -> (String) o)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  @Override
+  public Long countCurrentWaitingRequests(String dailyWaitingUuid) {
+    return redisTemplate.opsForZSet().zCard(WAITING_ZSET_PREFIX + dailyWaitingUuid);
   }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestAdminController.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestAdminController.java
@@ -2,19 +2,24 @@ package table.eat.now.waiting.waiting_request.presentation;
 
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import table.eat.now.common.aop.annotation.AuthCheck;
 import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.waiting_request.application.dto.response.GetWaitingRequestInfo;
+import table.eat.now.waiting.waiting_request.application.dto.response.PageResult;
 import table.eat.now.waiting.waiting_request.application.service.WaitingRequestService;
 import table.eat.now.waiting.waiting_request.presentation.dto.response.GetWaitingRequestResponse;
+import table.eat.now.waiting.waiting_request.presentation.dto.response.GetWaitingRequestsResponse;
 
 @RequiredArgsConstructor
 @RequestMapping("/admin/v1/waiting-requests")
@@ -44,5 +49,18 @@ public class WaitingRequestAdminController {
     GetWaitingRequestInfo info =
         waitingRequestService.getWaitingRequestAdmin(userInfo, waitingRequestUuid.toString());
     return ResponseEntity.ok().body(GetWaitingRequestResponse.from(info));
+  }
+
+  @AuthCheck(roles = {UserRole.MASTER, UserRole.OWNER, UserRole.STAFF})
+  @GetMapping
+  public ResponseEntity<GetWaitingRequestsResponse> getWaitingRequests(
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @RequestParam UUID dailyWaitingUuid,
+      @PageableDefault Pageable pageable
+  ) {
+
+    PageResult<GetWaitingRequestInfo> info =
+        waitingRequestService.getWaitingRequestsAdmin(userInfo, dailyWaitingUuid.toString(), pageable);
+    return ResponseEntity.ok().body(GetWaitingRequestsResponse.from(info));
   }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiController.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiController.java
@@ -57,7 +57,7 @@ public class WaitingRequestApiController {
   }
 
   @PatchMapping("/{waitingRequestUuid}/postpone")
-  public ResponseEntity<GetWaitingRequestResponse> postponeWaitingRequest(
+  public ResponseEntity<Void> postponeWaitingRequest(
       @CurrentUserInfo CurrentUserInfoDto userInfo,
       @PathVariable UUID waitingRequestUuid,
       @RequestParam @Valid @Pattern(regexp = "^[0-9]{8,15}$") String phone

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/dto/response/GetWaitingRequestsResponse.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/dto/response/GetWaitingRequestsResponse.java
@@ -1,0 +1,60 @@
+package table.eat.now.waiting.waiting_request.presentation.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import table.eat.now.waiting.waiting_request.application.dto.response.GetWaitingRequestInfo;
+import table.eat.now.waiting.waiting_request.application.dto.response.PageResult;
+
+@Builder
+public record GetWaitingRequestsResponse(
+    List<GetWaitingRequestResponse> waitingRequests,
+    long totalElements,
+    int totalPages,
+    int pageNumber,
+    int pageSize
+) {
+
+  public static GetWaitingRequestsResponse from(PageResult<GetWaitingRequestInfo> info) {
+    return GetWaitingRequestsResponse.builder()
+        .waitingRequests(info.contents()
+            .stream()
+            .map(GetWaitingRequestResponse::from)
+            .toList())
+        .totalElements(info.totalElements())
+        .totalPages(info.totalPages())
+        .pageNumber(info.pageNumber())
+        .pageSize(info.pageSize())
+        .build();
+  }
+
+  @Builder
+  record GetWaitingRequestResponse(
+      String waitingRequestUuid,
+      String dailyWaitingUuid,
+      String restaurantUuid,
+      String restaurantName,
+      String phone,
+      String slackId,
+      int seatSize,
+      Integer sequence,
+      Long rank,
+      long estimatedWaitingMin
+  ) {
+
+    public static GetWaitingRequestResponse from(
+        GetWaitingRequestInfo info) {
+      return GetWaitingRequestResponse.builder()
+          .waitingRequestUuid(info.waitingRequestUuid())
+          .dailyWaitingUuid(info.dailyWaitingUuid())
+          .restaurantUuid(info.restaurantUuid())
+          .restaurantName(info.restaurantName())
+          .phone(info.phone())
+          .slackId(info.slackId())
+          .seatSize(info.seatSize())
+          .sequence(info.sequence())
+          .rank(info.rank())
+          .estimatedWaitingMin(info.estimatedWaitingMin())
+          .build();
+    }
+  }
+}

--- a/waiting/src/main/resources/properties/kafka.yml
+++ b/waiting/src/main/resources/properties/kafka.yml
@@ -7,8 +7,8 @@ kafka:
   topic:
     waiting-request:
       partitions: 3
-      replicas: 3
-      min-insync-replicas: 2
+      replicas: 1
+      min-insync-replicas: 1
 
 ---
 spring:
@@ -20,8 +20,8 @@ kafka:
   topic:
     waiting-request:
       partitions: 3
-      replicas: 3
-      min-insync-replicas: 2
+      replicas: 1
+      min-insync-replicas: 1
 
 ---
 spring:

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/fixture/GetWaitingRequestInfoFixture.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/fixture/GetWaitingRequestInfoFixture.java
@@ -1,0 +1,33 @@
+package table.eat.now.waiting.waiting_request.fixture;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import table.eat.now.waiting.waiting_request.application.dto.response.GetWaitingRequestInfo;
+
+public class GetWaitingRequestInfoFixture {
+
+  public static GetWaitingRequestInfo create(int i, String dailyWaitingUuid, String restaurantUuid) {
+    return GetWaitingRequestInfo.builder()
+        .waitingRequestUuid(UUID.randomUUID().toString())
+        .dailyWaitingUuid(dailyWaitingUuid)
+        .restaurantUuid(restaurantUuid)
+        .restaurantName("혜주네 식당")
+        .phone("01000000000")
+        .slackId("slackId@example.com")
+        .seatSize(i % 5)
+        .sequence(i)
+        .rank((long) i)
+        .estimatedWaitingMin(i * 20L)
+        .build();
+  }
+
+  public static List<GetWaitingRequestInfo> createList(int start, int end) {
+    var dailyWaitingUuid = UUID.randomUUID().toString();
+    var restaurantUuid = UUID.randomUUID().toString();
+
+    return IntStream.range(start, end)
+        .mapToObj(i -> GetWaitingRequestInfoFixture.create(i, dailyWaitingUuid, restaurantUuid))
+        .toList();
+  }
+}

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/fixture/WaitingRequestFixture.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/fixture/WaitingRequestFixture.java
@@ -1,6 +1,9 @@
 package table.eat.now.waiting.waiting_request.fixture;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
 
 public class WaitingRequestFixture {
@@ -8,6 +11,19 @@ public class WaitingRequestFixture {
   public static WaitingRequest create(String dailyWaitingUuid, String restaurantUuid, String phone, int i) {
     return WaitingRequest.of(
         UUID.randomUUID().toString(), dailyWaitingUuid, restaurantUuid,
-        2L, i, phone, "slack@example.com", 3);
+        (long) i, i, phone, "slack@example.com", i % 5);
+  }
+
+  public static List<WaitingRequest> createList(
+      String dailyWaitingUuid, String restaurantUuid, int size) {
+
+    return IntStream.range(0, size)
+        .mapToObj(i -> WaitingRequestFixture.create(dailyWaitingUuid, restaurantUuid, getRandomPhone(), i))
+        .toList();
+  }
+
+  private static String getRandomPhone() {
+    int random = ThreadLocalRandom.current().nextInt(0, 100_000_000);
+    return String.format("010%08d", random);
   }
 }

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestAdminControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestAdminControllerTest.java
@@ -15,14 +15,16 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.ControllerTestSupport;
-import table.eat.now.waiting.waiting_request.application.dto.response.GetWaitingRequestInfo;
+import table.eat.now.waiting.waiting_request.application.dto.response.PageResult;
 import table.eat.now.waiting.waiting_request.application.service.WaitingRequestService;
+import table.eat.now.waiting.waiting_request.fixture.GetWaitingRequestInfoFixture;
 
 @WebMvcTest(WaitingRequestAdminController.class)
 class WaitingRequestAdminControllerTest extends ControllerTestSupport {
@@ -58,18 +60,7 @@ class WaitingRequestAdminControllerTest extends ControllerTestSupport {
   void getWaitingRequest() throws Exception {
     // given
     var userInfo = CurrentUserInfoDto.of(2L, UserRole.STAFF);
-    var info = GetWaitingRequestInfo.builder()
-        .waitingRequestUuid(UUID.randomUUID().toString())
-        .dailyWaitingUuid(UUID.randomUUID().toString())
-        .restaurantUuid(UUID.randomUUID().toString())
-        .restaurantName("혜주네 식당")
-        .phone("01000000000")
-        .slackId("slackId@example.com")
-        .seatSize(3)
-        .sequence(10)
-        .rank(2L)
-        .estimatedWaitingMin(21L)
-        .build();
+    var info = GetWaitingRequestInfoFixture.create(2, UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
     given(waitingRequestService.getWaitingRequestAdmin(
         eq(userInfo), eq(info.waitingRequestUuid())))
@@ -88,6 +79,37 @@ class WaitingRequestAdminControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.dailyWaitingUuid").value(info.dailyWaitingUuid()))
         .andExpect(jsonPath("$.restaurantUuid").value(info.restaurantUuid()))
         .andExpect(jsonPath("$.restaurantName").value(info.restaurantName()))
+        .andDo(print());
+  }
+
+  @DisplayName("STAFF 사용자의 대기 요청 목록 조회 검증 - 200 응답")
+  @Test
+  void getWaitingRequests() throws Exception {
+
+    // given
+    var userInfo = CurrentUserInfoDto.of(2L, UserRole.STAFF);
+    var pageable = PageRequest.of(0, 10);
+    var requests = GetWaitingRequestInfoFixture.createList(0, 10);
+    var dailyWaitingUuid = requests.get(0).dailyWaitingUuid();
+    var page = PageResult.of(requests, 100, 10, 1, 10);
+    given(waitingRequestService.getWaitingRequestsAdmin(
+        eq(userInfo), eq(dailyWaitingUuid), eq(pageable)))
+        .willReturn(page);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        get("/admin/v1/waiting-requests")
+            .param("dailyWaitingUuid", dailyWaitingUuid)
+            .header("Authorization", "Bearer {ACCESS_TOKEN}")
+            .header(USER_ID_HEADER, userInfo.userId())
+            .header(USER_ROLE_HEADER, userInfo.role()));
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalElements").value(page.totalElements()))
+        .andExpect(jsonPath("$.pageNumber").value(page.pageNumber()))
+        .andExpect(jsonPath("$.waitingRequests[0].dailyWaitingUuid").value(dailyWaitingUuid))
+        .andExpect(jsonPath("$.waitingRequests.size()").value(10))
         .andDo(print());
   }
 }

--- a/waiting/src/test/waiting.http
+++ b/waiting/src/test/waiting.http
@@ -30,6 +30,12 @@ Content-Type: application/json
 X-User-Id: 3
 X-User-Role: STAFF
 
+### 대기 요청 목록 조회 # 임시
+PATCH localhost:8086/admin/v1/waiting-requests?dailyWaitingUuid=00000000-0000-0000-0000-000000000001
+Content-Type: application/json
+X-User-Id: 3
+X-User-Role: STAFF
+
 ### 대기 요청 조회 admin # 임시
 GET localhost:8086/admin/v1/waiting-requests/{{waitingRequestUuid}}
 Content-Type: application/json


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #142

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 현재 대기 고객 목록 조회 기능 구현 및 테스트

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 관리자용 대기 요청 목록을 페이지네이션 형태로 조회할 수 있는 API가 추가되었습니다.
  - 대기 요청 목록 응답에 전체 건수, 전체 페이지 수, 현재 페이지, 페이지 크기 등 페이지네이션 정보를 포함합니다.

- **API 변경**
  - 대기 요청 연기(postpone) API의 응답이 본문 없는 200 OK로 변경되었습니다.

- **버그 수정 및 개선**
  - 테스트 및 Fixture 코드가 추가 및 개선되어, 대기 요청 목록 API의 동작이 검증됩니다.

- **설정**
  - local/test 환경의 Kafka 토픽 복제본(replica) 수가 1로 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->