### PR TITLE
[waiting] 대기 취소/ 상태 변화 / 내부 단건 조회 기능 구현

### DIFF
--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/response/GetWaitingRequestInfo.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/response/GetWaitingRequestInfo.java
@@ -9,27 +9,31 @@ public record GetWaitingRequestInfo(
     String dailyWaitingUuid,
     String restaurantUuid,
     String restaurantName,
+    Long userId,
     String phone,
     String slackId,
     int seatSize,
     Integer sequence,
+    String status,
     Long rank,
-    long estimatedWaitingMin
+    Long estimatedWaitingMin
 ) {
 
   public static GetWaitingRequestInfo from(
-      WaitingRequest waitingRequest, String restaurantName, Long rank, long estimatedWaitingSec) {
+      WaitingRequest waitingRequest, String restaurantName, Long rank, Long estimatedWaitingMin) {
     return GetWaitingRequestInfo.builder()
         .waitingRequestUuid(waitingRequest.getWaitingRequestUuid())
         .dailyWaitingUuid(waitingRequest.getDailyWaitingUuid())
         .restaurantUuid(waitingRequest.getRestaurantUuid())
         .restaurantName(restaurantName)
+        .userId(waitingRequest.getUserId())
         .phone(waitingRequest.getPhone())
         .slackId(waitingRequest.getSlackId())
         .seatSize(waitingRequest.getSeatSize())
         .sequence(waitingRequest.getSequence())
+        .status(waitingRequest.getStatus().toString())
         .rank(rank)
-        .estimatedWaitingMin(estimatedWaitingSec/60)
+        .estimatedWaitingMin(estimatedWaitingMin)
         .build();
   }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/response/PageResult.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/dto/response/PageResult.java
@@ -60,12 +60,13 @@ public record PageResult<T>(
         .totalElements(page.totalElements())
         .totalPages(page.totalPages())
         .pageNumber(page.pageNumber())
+        .pageSize(page.pageSize())
         .build();
   }
 
   public <U> PageResult<U> map(Function<T, U> mapper) {
 
-    return PageResult.from(this, this.contents.<T>stream()
+    return PageResult.from(this, this.contents.stream()
         .map(t -> mapper.apply(t))
         .toList());
   }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestCreatedInfo.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestCreatedInfo.java
@@ -10,11 +10,11 @@ public record WaitingRequestCreatedInfo(
     String restaurantName,
     Long sequence,
     Long remainingCount,
-    long estimatedWaitingMin
+    Long estimatedWaitingMin
 ) {
   public static WaitingRequestCreatedInfo of(
       String waitingRequestUuid, String phone, String slackId, String restaurantName,
-      Long sequence, Long remainingCount, long estimatedWaitingSec) {
+      Long sequence, Long remainingCount, Long estimatedWaitingMin) {
 
     return WaitingRequestCreatedInfo.builder()
         .waitingRequestUuid(waitingRequestUuid)
@@ -23,7 +23,7 @@ public record WaitingRequestCreatedInfo(
         .restaurantName(restaurantName)
         .sequence(sequence)
         .remainingCount(remainingCount)
-        .estimatedWaitingMin(estimatedWaitingSec/60)
+        .estimatedWaitingMin(estimatedWaitingMin)
         .build();
   }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestPostponedInfo.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/event/dto/WaitingRequestPostponedInfo.java
@@ -14,7 +14,7 @@ public record WaitingRequestPostponedInfo(
 ) {
   public static WaitingRequestPostponedInfo of(
       String waitingRequestUuid, String phone, String slackId, String restaurantName,
-      Long sequence, Long remainingCount, long estimatedWaitingSec) {
+      Long sequence, Long remainingCount, Long estimatedWaitingMin) {
 
     return WaitingRequestPostponedInfo.builder()
         .waitingRequestUuid(waitingRequestUuid)
@@ -23,7 +23,7 @@ public record WaitingRequestPostponedInfo(
         .restaurantName(restaurantName)
         .sequence(sequence)
         .remainingCount(remainingCount)
-        .estimatedWaitingMin(estimatedWaitingSec/60)
+        .estimatedWaitingMin(estimatedWaitingMin)
         .build();
   }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestService.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestService.java
@@ -16,9 +16,16 @@ public interface WaitingRequestService {
   GetWaitingRequestInfo getWaitingRequest(
       CurrentUserInfoDto userInfo, String waitingRequestUuid, String phone);
 
-  GetWaitingRequestInfo getWaitingRequestAdmin(CurrentUserInfoDto userInfo, String string);
+  GetWaitingRequestInfo getWaitingRequestAdmin(CurrentUserInfoDto userInfo, String waitingRequestUuid);
+
+  GetWaitingRequestInfo getWaitingRequestInternal(CurrentUserInfoDto userInfo, String waitingRequestUuid);
 
   void postponeWaitingRequest(CurrentUserInfoDto userInfo, String waitingRequestUuid, String phone);
 
-  PageResult<GetWaitingRequestInfo> getWaitingRequestsAdmin(CurrentUserInfoDto userInfo, String dailyWaitingUuid, Pageable pageable);
+  void cancelWaitingRequest(CurrentUserInfoDto userInfo, String waitingRequestUuid, String phone);
+
+  void updateWaitingRequestStatusAdmin(CurrentUserInfoDto userInfo, String waitingRequestUuid, String type);
+
+  PageResult<GetWaitingRequestInfo> getCurrentWaitingRequestsAdmin(CurrentUserInfoDto userInfo, String dailyWaitingUuid, Pageable pageable);
+
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestServiceImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestServiceImpl.java
@@ -50,12 +50,13 @@ public class WaitingRequestServiceImpl implements WaitingRequestService {
 
     String waitingRequestUuid = UUID.randomUUID().toString();
     Long sequence = generateSequence(command.dailyWaitingUuid());
-    Long rank = enqueueWaitingRequestAndGetRank(command.dailyWaitingUuid(), waitingRequestUuid);
-    Long estimatedWaitingMin = rank == null ? null : dailyWaitingInfo.avgWaitingSec() * (rank + 1L);
 
     WaitingRequest waitingRequest = command.toEntity(
         waitingRequestUuid, dailyWaitingInfo.restaurantUuid(), userInfo.userId(), sequence);
     waitingRequestRepository.save(waitingRequest);
+
+    Long rank = enqueueWaitingRequestAndGetRank(command.dailyWaitingUuid(), waitingRequestUuid);
+    Long estimatedWaitingMin = rank == null ? null : dailyWaitingInfo.avgWaitingSec() * (rank + 1L) /60;
 
     notifyWaitingRequestCreated(
         command, waitingRequestUuid, dailyWaitingInfo.restaurantName(),

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingRequest.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingRequest.java
@@ -92,4 +92,13 @@ public class WaitingRequest extends BaseEntity {
     WaitingRequestHistory waitingRequestHistory = WaitingRequestHistory.of(this.status);
     addHistory(waitingRequestHistory);
   }
+
+  public void updateStatus(String type) {
+    WaitingStatus waitingStatus = WaitingStatus.valueOf(type.toUpperCase());
+    this.updateStatus(waitingStatus);
+  }
+
+  public boolean isWaiting() {
+    return this.status.isWaiting();
+  }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingStatus.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/domain/entity/WaitingStatus.java
@@ -22,4 +22,8 @@ public enum WaitingStatus {
   public boolean isPossibleToUpdate(WaitingStatus status) {
     return updateRule.test(status);
   }
+
+  public boolean isWaiting() {
+    return this == WAITING;
+  }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/WaitingRequestRepositoryImpl.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/infrastructure/persistence/WaitingRequestRepositoryImpl.java
@@ -90,7 +90,7 @@ public class WaitingRequestRepositoryImpl implements WaitingRequestRepository {
         .toList();
 
     long total = 0;
-    if (requests.size() < size) {
+    if (!requests.isEmpty() && requests.size() < size) {
       total = start + requests.size();
     } else {
       total = redisRepository.countCurrentWaitingRequests(criteria.dailyWaitingUuid());

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestAdminController.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestAdminController.java
@@ -1,11 +1,14 @@
 package table.eat.now.waiting.waiting_request.presentation;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,14 +56,26 @@ public class WaitingRequestAdminController {
 
   @AuthCheck(roles = {UserRole.MASTER, UserRole.OWNER, UserRole.STAFF})
   @GetMapping
-  public ResponseEntity<GetWaitingRequestsResponse> getWaitingRequests(
+  public ResponseEntity<GetWaitingRequestsResponse> getCurrentWaitingRequestsAdmin(
       @CurrentUserInfo CurrentUserInfoDto userInfo,
       @RequestParam UUID dailyWaitingUuid,
       @PageableDefault Pageable pageable
   ) {
 
     PageResult<GetWaitingRequestInfo> info =
-        waitingRequestService.getWaitingRequestsAdmin(userInfo, dailyWaitingUuid.toString(), pageable);
+        waitingRequestService.getCurrentWaitingRequestsAdmin(userInfo, dailyWaitingUuid.toString(), pageable);
     return ResponseEntity.ok().body(GetWaitingRequestsResponse.from(info));
+  }
+
+  @AuthCheck(roles = {UserRole.MASTER, UserRole.OWNER, UserRole.STAFF})
+  @PatchMapping("/{waitingRequestUuid}/status")
+  public ResponseEntity<Void> updateWaitingRequestStatus(
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @PathVariable UUID waitingRequestUuid,
+      @RequestParam @Valid @Pattern(regexp = "^(?i)(SEATED|LEAVED|NO_SHOW)$") String type
+  ) {
+
+    waitingRequestService.updateWaitingRequestStatusAdmin(userInfo, waitingRequestUuid.toString(), type);
+    return ResponseEntity.ok().build();
   }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiController.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiController.java
@@ -66,4 +66,15 @@ public class WaitingRequestApiController {
     waitingRequestService.postponeWaitingRequest(userInfo, waitingRequestUuid.toString(), phone);
     return ResponseEntity.ok().build();
   }
+
+  @PatchMapping("/{waitingRequestUuid}/cancel")
+  public ResponseEntity<Void> cancelWaitingRequest(
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @PathVariable UUID waitingRequestUuid,
+      @RequestParam @Valid @Pattern(regexp = "^[0-9]{8,15}$") String phone
+  ) {
+
+    waitingRequestService.cancelWaitingRequest(userInfo, waitingRequestUuid.toString(), phone);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestInternalController.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestInternalController.java
@@ -1,0 +1,35 @@
+package table.eat.now.waiting.waiting_request.presentation;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import table.eat.now.common.aop.annotation.AuthCheck;
+import table.eat.now.common.resolver.annotation.CurrentUserInfo;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.waiting.waiting_request.application.dto.response.GetWaitingRequestInfo;
+import table.eat.now.waiting.waiting_request.application.service.WaitingRequestService;
+import table.eat.now.waiting.waiting_request.presentation.dto.response.GetWaitingRequestResponse;
+
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/waiting-requests")
+@RestController
+public class WaitingRequestInternalController {
+  private final WaitingRequestService waitingRequestService;
+
+  @AuthCheck(roles = {UserRole.MASTER, UserRole.CUSTOMER})
+  @GetMapping("/{waitingRequestUuid}")
+  public ResponseEntity<GetWaitingRequestResponse> getWaitingRequestInternal(
+      @CurrentUserInfo CurrentUserInfoDto userInfo,
+      @PathVariable UUID waitingRequestUuid
+  ) {
+
+    GetWaitingRequestInfo info =
+        waitingRequestService.getWaitingRequestInternal(userInfo, waitingRequestUuid.toString());
+    return ResponseEntity.ok().body(GetWaitingRequestResponse.from(info));
+  }
+}

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/dto/response/GetWaitingRequestResponse.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/dto/response/GetWaitingRequestResponse.java
@@ -9,12 +9,14 @@ public record GetWaitingRequestResponse(
     String dailyWaitingUuid,
     String restaurantUuid,
     String restaurantName,
+    Long userId,
     String phone,
     String slackId,
     int seatSize,
+    String status,
     Integer sequence,
     Long rank,
-    long estimatedWaitingMin
+    Long estimatedWaitingMin
 ) {
 
   public static GetWaitingRequestResponse from(GetWaitingRequestInfo info) {
@@ -23,9 +25,11 @@ public record GetWaitingRequestResponse(
         .dailyWaitingUuid(info.dailyWaitingUuid())
         .restaurantUuid(info.restaurantUuid())
         .restaurantName(info.restaurantName())
+        .userId(info.userId())
         .phone(info.phone())
         .slackId(info.slackId())
         .seatSize(info.seatSize())
+        .status(info.status())
         .sequence(info.sequence())
         .rank(info.rank())
         .estimatedWaitingMin(info.estimatedWaitingMin())

--- a/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/dto/response/GetWaitingRequestsResponse.java
+++ b/waiting/src/main/java/table/eat/now/waiting/waiting_request/presentation/dto/response/GetWaitingRequestsResponse.java
@@ -33,12 +33,14 @@ public record GetWaitingRequestsResponse(
       String dailyWaitingUuid,
       String restaurantUuid,
       String restaurantName,
+      Long userId,
       String phone,
       String slackId,
       int seatSize,
+      String status,
       Integer sequence,
       Long rank,
-      long estimatedWaitingMin
+      Long estimatedWaitingMin
   ) {
 
     public static GetWaitingRequestResponse from(
@@ -48,9 +50,11 @@ public record GetWaitingRequestsResponse(
           .dailyWaitingUuid(info.dailyWaitingUuid())
           .restaurantUuid(info.restaurantUuid())
           .restaurantName(info.restaurantName())
+          .userId(info.userId())
           .phone(info.phone())
           .slackId(info.slackId())
           .seatSize(info.seatSize())
+          .status(info.status())
           .sequence(info.sequence())
           .rank(info.rank())
           .estimatedWaitingMin(info.estimatedWaitingMin())

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestServiceImplTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestServiceImplTest.java
@@ -339,7 +339,7 @@ class WaitingRequestServiceImplTest extends IntegrationTestSupport {
 
   @DisplayName("admin 대기 요청 목록 조회")
   @Nested
-  class getWaitingRequestsAdmin {
+  class getCurrentWaitingRequestsAdmin {
 
     private List<WaitingRequest> waitingRequests;
     private GetDailyWaitingInfo dailyWaitingInfo;
@@ -385,7 +385,7 @@ class WaitingRequestServiceImplTest extends IntegrationTestSupport {
       Pageable pageable = PageRequest.of(0, 10);
 
       // when
-      PageResult<GetWaitingRequestInfo> pageResult = waitingRequestService.getWaitingRequestsAdmin(
+      PageResult<GetWaitingRequestInfo> pageResult = waitingRequestService.getCurrentWaitingRequestsAdmin(
           userInfo, waitingRequest.getDailyWaitingUuid(), pageable);
 
       // then
@@ -395,6 +395,119 @@ class WaitingRequestServiceImplTest extends IntegrationTestSupport {
       assertThat(pageResult.contents().get(0).waitingRequestUuid()).isEqualTo(waitingRequest.getWaitingRequestUuid());
       assertThat(pageResult.contents().get(1).waitingRequestUuid()).isEqualTo(waitingRequests.get(0).getWaitingRequestUuid());
       assertThat(pageResult.contents().get(2).waitingRequestUuid()).isEqualTo(waitingRequests.get(1).getWaitingRequestUuid());
+    }
+  }
+
+  @DisplayName("대기 요청 취소 처리 검증")
+  @Nested
+  class cancelWaitingRequest {
+
+    @Transactional
+    @DisplayName("성공")
+    @Test
+    void success() {
+      // given
+      // when, then
+      assertThatNoException().isThrownBy(() -> waitingRequestService.cancelWaitingRequest(
+          null, waitingRequest.getWaitingRequestUuid(), waitingRequest.getPhone()));
+
+      WaitingRequest modified = waitingRequestRepository.findByWaitingRequestUuidAndDeletedAtIsNull(
+              waitingRequest.getWaitingRequestUuid())
+          .orElseThrow(
+              () -> CustomException.from(WaitingRequestErrorCode.INVALID_WAITING_REQUEST_UUID));
+      assertThat(modified.getStatus()).isEqualTo(WaitingStatus.CANCELED);
+
+      var histories = modified.getHistories();
+      assertThat(histories.get(0).getStatus()).isEqualTo(WaitingStatus.CANCELED);
+    }
+  }
+
+  @DisplayName("admin 대기 요청 상태 변경 처리 검증")
+  @Nested
+  class updateWaitingRequestStatusAdmin {
+
+    @BeforeEach
+    void setUp() {
+      GetRestaurantInfo restaurantInfo = GetRestaurantInfo.builder()
+          .restaurantUuid(UUID.randomUUID().toString())
+          .ownerId(3L)
+          .staffId(4L)
+          .build();
+
+      given(restaurantClient.getRestaurantInfo(any())).willReturn(restaurantInfo);
+    }
+
+    @Transactional
+    @DisplayName("성공")
+    @Test
+    void success() {
+      // given
+      CurrentUserInfoDto userInfo = CurrentUserInfoDto.of(4L, UserRole.STAFF);
+      var type = "SEATED";
+
+      // when, then
+      assertThatNoException().isThrownBy(() ->
+          waitingRequestService.updateWaitingRequestStatusAdmin(
+              userInfo, waitingRequest.getWaitingRequestUuid(), type));
+
+      WaitingRequest modified = waitingRequestRepository.findByWaitingRequestUuidAndDeletedAtIsNull(
+              waitingRequest.getWaitingRequestUuid())
+          .orElseThrow(
+              () -> CustomException.from(WaitingRequestErrorCode.INVALID_WAITING_REQUEST_UUID));
+
+      assertThat(modified.getStatus()).isEqualTo(WaitingStatus.valueOf(type));
+
+      var histories = modified.getHistories();
+      assertThat(histories.get(0).getStatus()).isEqualTo(WaitingStatus.valueOf(type));
+    }
+  }
+
+  @DisplayName("내부 대기 요청 조회 검증")
+  @Nested
+  class getWaitingRequestInternal {
+
+    private GetDailyWaitingInfo dailyWaitingInfo;
+
+    @BeforeEach
+    void setUp() {
+      dailyWaitingInfo = GetDailyWaitingInfo.builder()
+          .dailyWaitingUuid(waitingRequest.getDailyWaitingUuid())
+          .restaurantUuid(waitingRequest.getRestaurantUuid())
+          .waitingDate(LocalDate.now())
+          .avgWaitingSec(600L)
+          .status("AVAILABLE")
+          .build();
+      given(waitingClient.getDailyWaitingInfo(waitingRequest.getDailyWaitingUuid())).willReturn(dailyWaitingInfo);
+    }
+
+    @DisplayName("성공")
+    @Test
+    void success() {
+      // given
+      CurrentUserInfoDto userInfo = CurrentUserInfoDto.of(1L, UserRole.CUSTOMER);
+
+      // when
+      GetWaitingRequestInfo info = waitingRequestService.getWaitingRequestInternal(
+          userInfo, waitingRequest.getWaitingRequestUuid());
+
+      // then
+      Long rank = waitingRequestRepository.getRank(info.dailyWaitingUuid(), info.waitingRequestUuid());
+
+      assertThat(info.seatSize()).isEqualTo(waitingRequest.getSeatSize());
+      assertThat(info.rank()).isEqualTo(rank);
+    }
+
+    @DisplayName("해당 대기 고객이 아닌 경우 실패")
+    @Test
+    void failWhenNotAuthorizedCustomer() {
+      // given
+      CurrentUserInfoDto userInfo = CurrentUserInfoDto.of(2L, UserRole.CUSTOMER);
+
+      // when, then
+      assertThatThrownBy(() -> waitingRequestService.getWaitingRequestInternal(
+          userInfo, waitingRequest.getWaitingRequestUuid()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage(WaitingRequestErrorCode.UNAUTH_REQUEST.getMessage());
     }
   }
 }

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/fixture/GetWaitingRequestInfoFixture.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/fixture/GetWaitingRequestInfoFixture.java
@@ -7,27 +7,30 @@ import table.eat.now.waiting.waiting_request.application.dto.response.GetWaiting
 
 public class GetWaitingRequestInfoFixture {
 
-  public static GetWaitingRequestInfo create(int i, String dailyWaitingUuid, String restaurantUuid) {
+  public static GetWaitingRequestInfo create(int i, String dailyWaitingUuid, String restaurantUuid, String status) {
     return GetWaitingRequestInfo.builder()
         .waitingRequestUuid(UUID.randomUUID().toString())
         .dailyWaitingUuid(dailyWaitingUuid)
         .restaurantUuid(restaurantUuid)
         .restaurantName("혜주네 식당")
+        .userId(2L)
         .phone("01000000000")
         .slackId("slackId@example.com")
-        .seatSize(i % 5)
-        .sequence(i)
-        .rank((long) i)
-        .estimatedWaitingMin(i * 20L)
+        .seatSize(i % 4 + 1)
+        .sequence(i + 1)
+        .status(status)
+        .rank(!"WAITING".equals(status) ? null : (long) i)
+        .estimatedWaitingMin(!"WAITING".equals(status) ? null : (i + 1) * 20L)
         .build();
   }
 
   public static List<GetWaitingRequestInfo> createList(int start, int end) {
     var dailyWaitingUuid = UUID.randomUUID().toString();
     var restaurantUuid = UUID.randomUUID().toString();
+    var statusList = List.of("WAITING", "SEATED", "LEAVED");
 
     return IntStream.range(start, end)
-        .mapToObj(i -> GetWaitingRequestInfoFixture.create(i, dailyWaitingUuid, restaurantUuid))
+      .mapToObj(i -> GetWaitingRequestInfoFixture.create(i, dailyWaitingUuid, restaurantUuid, statusList.get(i % 3)))
         .toList();
   }
 }

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiControllerTest.java
@@ -25,8 +25,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.ControllerTestSupport;
-import table.eat.now.waiting.waiting_request.application.dto.response.GetWaitingRequestInfo;
 import table.eat.now.waiting.waiting_request.application.service.WaitingRequestService;
+import table.eat.now.waiting.waiting_request.fixture.GetWaitingRequestInfoFixture;
 import table.eat.now.waiting.waiting_request.presentation.dto.request.CreateWaitingRequestRequest;
 
 @WebMvcTest(WaitingRequestApiController.class)
@@ -71,18 +71,8 @@ class WaitingRequestApiControllerTest extends ControllerTestSupport {
   @Test
   void getWaitingRequest() throws Exception {
     // given
-    var info = GetWaitingRequestInfo.builder()
-        .waitingRequestUuid(UUID.randomUUID().toString())
-        .dailyWaitingUuid(UUID.randomUUID().toString())
-        .restaurantUuid(UUID.randomUUID().toString())
-        .restaurantName("혜주네 식당")
-        .phone("01000000000")
-        .slackId("slackId@example.com")
-        .seatSize(3)
-        .sequence(10)
-        .rank(2L)
-        .estimatedWaitingMin(21L)
-        .build();
+    var info = GetWaitingRequestInfoFixture.create(
+        2, UUID.randomUUID().toString(), UUID.randomUUID().toString(), "WAITING");
 
     given(waitingRequestService.getWaitingRequest(
         any(), eq(info.waitingRequestUuid()), eq(info.phone())))
@@ -115,6 +105,26 @@ class WaitingRequestApiControllerTest extends ControllerTestSupport {
     // when
     ResultActions resultActions = mockMvc.perform(
         patch("/api/v1/waiting-requests/{waitingRequestUuid}/postpone", waitingRequestUuid)
+            .param("phone", phone));
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @DisplayName("대기 취소 요청 검증 - 200 응답")
+  @Test
+  void cancelWaitingRequest() throws Exception {
+    // given
+    var waitingRequestUuid = UUID.randomUUID().toString();
+    var phone = "01000000000";
+
+    doNothing().when(waitingRequestService)
+        .cancelWaitingRequest(null, waitingRequestUuid, phone);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        patch("/api/v1/waiting-requests/{waitingRequestUuid}/cancel", waitingRequestUuid)
             .param("phone", phone));
 
     // then

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestInternalControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestInternalControllerTest.java
@@ -1,0 +1,59 @@
+package table.eat.now.waiting.waiting_request.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
+import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.waiting.helper.ControllerTestSupport;
+import table.eat.now.waiting.waiting_request.application.service.WaitingRequestService;
+import table.eat.now.waiting.waiting_request.fixture.GetWaitingRequestInfoFixture;
+
+@WebMvcTest(WaitingRequestInternalController.class)
+class WaitingRequestInternalControllerTest extends ControllerTestSupport {
+
+  @MockitoBean
+  private WaitingRequestService waitingRequestService;
+
+  @DisplayName("대기 요청 내부 조회 - 200 성공")
+  @Test
+  void getWaitingRequestInternal() throws Exception {
+    // given
+    var userInfo = CurrentUserInfoDto.of(2L, UserRole.CUSTOMER);
+    var info = GetWaitingRequestInfoFixture.create(
+        2, UUID.randomUUID().toString(), UUID.randomUUID().toString(), "SEATED");
+
+    given(waitingRequestService.getWaitingRequestInternal(
+        any(), eq(info.waitingRequestUuid()))).willReturn(info);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        get("/internal/v1/waiting-requests/{waitingRequestUuid}", info.waitingRequestUuid())
+            .header("Authorization", "Bearer {ACCESS_TOKEN}")
+            .header(USER_ID_HEADER, userInfo.userId())
+            .header(USER_ROLE_HEADER, userInfo.role()));
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andExpect(jsonPath("$.waitingRequestUuid").value(info.waitingRequestUuid()))
+        .andExpect(jsonPath("$.dailyWaitingUuid").value(info.dailyWaitingUuid()))
+        .andExpect(jsonPath("$.restaurantUuid").value(info.restaurantUuid()))
+        .andExpect(jsonPath("$.restaurantName").value(info.restaurantName()))
+        .andExpect(jsonPath("$.status").value(info.status()))
+        .andExpect(jsonPath("$.rank").value(info.rank()))
+        .andDo(print());
+  }
+}

--- a/waiting/src/test/waiting.http
+++ b/waiting/src/test/waiting.http
@@ -24,19 +24,19 @@ X-User-Role: CUSTOMER
   }
 %}
 
-### 대기 입장 요청  # 임시
+### 대기 입장 요청  # 테스트전
 POST localhost:8086/admin/v1/waiting-requests/{{waitingRequestUuid}}/entrance
 Content-Type: application/json
 X-User-Id: 3
 X-User-Role: STAFF
 
-### 대기 요청 목록 조회 # 임시
-PATCH localhost:8086/admin/v1/waiting-requests?dailyWaitingUuid=00000000-0000-0000-0000-000000000001
+### 대기 요청 목록 조회 # 테스트전
+GET localhost:8086/admin/v1/waiting-requests?dailyWaitingUuid=00000000-0000-0000-0000-000000000001
 Content-Type: application/json
 X-User-Id: 3
 X-User-Role: STAFF
 
-### 대기 요청 조회 admin # 임시
+### 대기 요청 조회 admin # 테스트전
 GET localhost:8086/admin/v1/waiting-requests/{{waitingRequestUuid}}
 Content-Type: application/json
 X-User-Id: 3
@@ -49,3 +49,19 @@ Content-Type: application/json
 ### 대기 연기 요청
 PATCH localhost:8086/api/v1/waiting-requests/{{waitingRequestUuid}}/postpone?phone=01000000000
 Content-Type: application/json
+
+### 대기 취소 요청
+PATCH localhost:8086/api/v1/waiting-requests/{{waitingRequestUuid}}/cancel?phone=01000000000
+Content-Type: application/json
+
+### 대기 상태 변경 요청 admin # 테스트전
+PATCH localhost:8086/admin/v1/waiting-requests/{{waitingRequestUuid}}/status?type=LEAVED
+Content-Type: application/json
+X-User-Id: 3
+X-User-Role: STAFF
+
+### 대기 요청 내부 조회
+GET localhost:8086/internal/v1/waiting-requests/{{waitingRequestUuid}}
+Content-Type: application/json
+X-User-Id: 2
+X-User-Role: CUSTOMER


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #151

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**
  - [x] 대기 취소/ 상태 변화 / 내부 단건 조회 기능 구현 및 테스트

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 대기 요청 취소 API 및 내부 대기 요청 조회 API가 추가되었습니다.
  - 관리자용 대기 요청 상태 변경 API가 추가되었습니다.

- **기능 개선**
  - 대기 요청 정보 응답에 userId와 status 필드가 추가되었습니다.
  - 대기 예상 시간이 분 단위(Long)로 일관성 있게 변경되었습니다.
  - 관리자 대기 요청 목록/상세 조회, 상태 변경 등 관리 기능이 확장되었습니다.

- **버그 수정**
  - 대기 요청 목록 조회 시 총 개수 계산 로직이 개선되었습니다.

- **테스트**
  - 신규 API 및 기능에 대한 단위/통합 테스트가 추가 및 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->