### PR TITLE
[coupon] 쿠폰 선점 기능 수정

### DIFF
--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -43,9 +43,11 @@ dependencies {
     implementation project(':common')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson:3.45.0'
 
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/redis/config/CouponRedisConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/redis/config/CouponRedisConfig.java
@@ -9,7 +9,7 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-public class RedisConfig {
+public class CouponRedisConfig {
 
   @Value("${spring.data.redis.host}")
   private String host;

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/aop/DistributedLockAspect.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/aop/DistributedLockAspect.java
@@ -39,7 +39,7 @@ public class DistributedLockAspect {
       try {
         return joinPoint.proceed();
       } catch (Throwable e) {
-        throw new RuntimeException(e);
+        throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
       }
     };
   }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/aop/DistributedLockAspect.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/aop/DistributedLockAspect.java
@@ -1,0 +1,46 @@
+package table.eat.now.coupon.user_coupon.application.aop;
+
+import java.util.List;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import table.eat.now.coupon.user_coupon.application.aop.annotation.DistributedLock;
+import table.eat.now.coupon.user_coupon.application.aop.dto.LockTime;
+import table.eat.now.coupon.user_coupon.application.utils.DistributedLockKeyGenerator;
+import table.eat.now.coupon.user_coupon.application.utils.LockProvider;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAspect {
+
+  private final LockProvider lockProvider;
+
+  @Around("@annotation(distributedLock)")
+  public Object lock(final ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+
+    List<String> keys = DistributedLockKeyGenerator.generateKeys(
+        distributedLock.key(), signature.getParameterNames(), joinPoint.getArgs());
+    LockTime lockTime = LockTime.from(distributedLock);
+
+    return lockProvider.execute(keys, lockTime, proceedAsSupplier(joinPoint));
+  }
+
+  private Supplier<Object> proceedAsSupplier(ProceedingJoinPoint joinPoint) {
+    return () -> {
+      try {
+        return joinPoint.proceed();
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/aop/annotation/DistributedLock.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/aop/annotation/DistributedLock.java
@@ -1,0 +1,34 @@
+package table.eat.now.coupon.user_coupon.application.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+  /**
+   * 락의 이름
+   */
+  String key();
+
+  /**
+   * 락의 시간 단위
+   */
+  TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+  /**
+   * 락을 기다리는 시간 (default - 5s)
+   * 락 획득을 위해 waitTime 만큼 대기한다
+   */
+  long waitTime() default 5L;
+
+  /**
+   * 락 임대 시간 (default - 3s)
+   * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+   */
+  long leaseTime() default 3L;
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/aop/dto/LockTime.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/aop/dto/LockTime.java
@@ -1,0 +1,21 @@
+package table.eat.now.coupon.user_coupon.application.aop.dto;
+
+import java.util.concurrent.TimeUnit;
+import lombok.Builder;
+import table.eat.now.coupon.user_coupon.application.aop.annotation.DistributedLock;
+
+@Builder
+public record LockTime(
+    long waitTime,
+    long leaseTime,
+    TimeUnit timeUnit
+) {
+
+  public static LockTime from(DistributedLock distributedLock) {
+    return LockTime.builder()
+        .waitTime(distributedLock.waitTime())
+        .leaseTime(distributedLock.leaseTime())
+        .timeUnit(distributedLock.timeUnit())
+        .build();
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/dto/request/PreemptUserCouponCommand.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/dto/request/PreemptUserCouponCommand.java
@@ -1,10 +1,12 @@
 package table.eat.now.coupon.user_coupon.application.dto.request;
 
+import java.util.Set;
 import lombok.Builder;
 
 @Builder
 public record PreemptUserCouponCommand(
-    String reservationUuid
+    String reservationUuid,
+    Set<String> userCouponUuids
 ) {
 
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/exception/UserCouponErrorCode.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/exception/UserCouponErrorCode.java
@@ -1,15 +1,18 @@
 package table.eat.now.coupon.user_coupon.application.exception;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import table.eat.now.common.exception.type.ErrorCode;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum UserCouponErrorCode implements ErrorCode {
   INVALID_USER_COUPON_UUID(
       "존재하지 않는 사용자 쿠폰 아이디입니다.", HttpStatus.NOT_FOUND),
+  NON_LOCK_KEY(
+      "쿠폰 사용을 위한 잠금키 정보가 부정확합니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   ;
 
   private final String message;

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponService.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponService.java
@@ -11,9 +11,9 @@ public interface UserCouponService {
 
   void createUserCoupon(IssueUserCouponCommand command);
 
-  void preemptUserCoupon(CurrentUserInfoDto userInfoDto, PreemptUserCouponCommand command);
+  void preemptUserCoupons(CurrentUserInfoDto userInfoDto, PreemptUserCouponCommand command);
 
-  void preemptUserCouponWithDistributedLock(
+  void preemptUserCouponsWithDistributedLock(
       CurrentUserInfoDto userInfoDto, PreemptUserCouponCommand command);
 
   PageResponse<GetUserCouponInfo> getUserCouponsByUserId(

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponService.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponService.java
@@ -2,16 +2,19 @@ package table.eat.now.coupon.user_coupon.application.service;
 
 import org.springframework.data.domain.Pageable;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
-import table.eat.now.coupon.user_coupon.application.dto.response.PageResponse;
 import table.eat.now.coupon.user_coupon.application.dto.request.IssueUserCouponCommand;
 import table.eat.now.coupon.user_coupon.application.dto.request.PreemptUserCouponCommand;
 import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfo;
+import table.eat.now.coupon.user_coupon.application.dto.response.PageResponse;
 
 public interface UserCouponService {
 
   void createUserCoupon(IssueUserCouponCommand command);
 
-  void preemptUserCoupon(CurrentUserInfoDto userInfoDto, String userCouponUuid, PreemptUserCouponCommand command);
+  void preemptUserCoupon(CurrentUserInfoDto userInfoDto, PreemptUserCouponCommand command);
+
+  void preemptUserCouponWithDistributedLock(
+      CurrentUserInfoDto userInfoDto, PreemptUserCouponCommand command);
 
   PageResponse<GetUserCouponInfo> getUserCouponsByUserId(
       CurrentUserInfoDto userInfoDto, Pageable pageable);

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImpl.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.coupon.user_coupon.application.aop.annotation.DistributedLock;
 import table.eat.now.coupon.user_coupon.application.dto.request.IssueUserCouponCommand;
 import table.eat.now.coupon.user_coupon.application.dto.request.PreemptUserCouponCommand;
 import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfo;
@@ -31,17 +32,43 @@ public class UserCouponServiceImpl implements UserCouponService {
   @Transactional
   @Override
   public void preemptUserCoupon(
-      CurrentUserInfoDto userInfoDto, String userCouponUuid, PreemptUserCouponCommand command) {
+      CurrentUserInfoDto userInfoDto, PreemptUserCouponCommand command) {
 
-    UserCoupon userCoupon =
-        userCouponRepository.findByUserCouponUuidAndDeletedAtIsNullWithLock(userCouponUuid)
-            .orElseThrow(() -> CustomException.from(UserCouponErrorCode.INVALID_USER_COUPON_UUID));
+    command.userCouponUuids()
+        .stream()
+        .sorted()
+        .forEach(userCouponUuid -> {
+          UserCoupon userCoupon =
+              userCouponRepository.findByUserCouponUuidAndDeletedAtIsNullWithLock(userCouponUuid)
+                  .orElseThrow(() -> CustomException.from(UserCouponErrorCode.INVALID_USER_COUPON_UUID));
 
-    if (userInfoDto.role() == UserRole.CUSTOMER) {
-      userCoupon.isOwnedBy(userInfoDto.userId());
-    }
-    userCoupon.isValidToPreempt(command.reservationUuid());
-    userCoupon.preempt(command.reservationUuid());
+          if (userInfoDto.role() == UserRole.CUSTOMER) {
+            userCoupon.isOwnedBy(userInfoDto.userId());
+          }
+          userCoupon.isValidToPreempt(command.reservationUuid());
+          userCoupon.preempt(command.reservationUuid());
+        });
+  }
+
+  @DistributedLock(key = "#command.userCouponUuids")
+  @Override
+  public void preemptUserCouponWithDistributedLock(
+      CurrentUserInfoDto userInfoDto, PreemptUserCouponCommand command) {
+
+    command.userCouponUuids()
+        .stream()
+        .sorted()
+        .forEach(userCouponUuid -> {
+          UserCoupon userCoupon =
+              userCouponRepository.findByUserCouponUuidAndDeletedAtIsNull(userCouponUuid)
+                  .orElseThrow(() -> CustomException.from(UserCouponErrorCode.INVALID_USER_COUPON_UUID));
+
+          if (userInfoDto.role() == UserRole.CUSTOMER) {
+            userCoupon.isOwnedBy(userInfoDto.userId());
+          }
+          userCoupon.isValidToPreempt(command.reservationUuid());
+          userCoupon.preempt(command.reservationUuid());
+        });
   }
 
   @Override

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/usecase/ReleaseUserCouponUsecase.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/usecase/ReleaseUserCouponUsecase.java
@@ -15,6 +15,6 @@ public class ReleaseUserCouponUsecase {
   @Transactional
   public void execute() {
     LocalDateTime tenMinutesAgo = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES).minusMinutes(10);
-    userCouponRepository.releasePreemptionsAfter10m(tenMinutesAgo);
+    userCouponRepository.releasePreemptionAfter10m(tenMinutesAgo);
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/CustomSpringELParser.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/CustomSpringELParser.java
@@ -1,0 +1,33 @@
+package table.eat.now.coupon.user_coupon.application.utils;
+
+import java.util.Set;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+
+  private CustomSpringELParser() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static Set<?> getDynamicValueSet(
+      String spel, String[] parameterNames, Object[] args) {
+
+    ExpressionParser parser = new SpelExpressionParser();
+    StandardEvaluationContext context = getStandardEvaluationContext(parameterNames, args);
+
+    return parser.parseExpression(spel).getValue(context, Set.class);
+  }
+
+  private static StandardEvaluationContext getStandardEvaluationContext(
+      String[] parameterNames, Object[] args) {
+
+    StandardEvaluationContext context = new StandardEvaluationContext();
+
+    for (int i = 0; i < parameterNames.length; i++) {
+      context.setVariable(parameterNames[i], args[i]);
+    }
+    return context;
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/CustomSpringELParser.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/CustomSpringELParser.java
@@ -1,6 +1,7 @@
 package table.eat.now.coupon.user_coupon.application.utils;
 
-import java.util.Set;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -11,17 +12,30 @@ public class CustomSpringELParser {
     throw new IllegalStateException("Utility class");
   }
 
-  public static Set<?> getDynamicValueSet(
-      String spel, String[] parameterNames, Object[] args) {
+  private static final ExpressionParser PARSER = new SpelExpressionParser();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    ExpressionParser parser = new SpelExpressionParser();
-    StandardEvaluationContext context = getStandardEvaluationContext(parameterNames, args);
+  public static <T> T parseExpression(
+      String spel, String[] parameterNames, Object[] args, TypeReference<T> typeReference) {
 
-    return parser.parseExpression(spel).getValue(context, Set.class);
+    try {
+      StandardEvaluationContext context = getStandardEvaluationContext(parameterNames, args);
+      Object rawValue = PARSER.parseExpression(spel).getValue(context, Object.class);
+      return OBJECT_MAPPER.convertValue(rawValue, typeReference);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("SpEL 표현식 평가 중 오류가 발생했습니다: " + e.getMessage());
+    }
   }
 
   private static StandardEvaluationContext getStandardEvaluationContext(
       String[] parameterNames, Object[] args) {
+
+    if (parameterNames == null || args == null) {
+      throw new IllegalArgumentException("매개변수 이름이나 인자가 null일 수 없습니다");
+    }
+    if (parameterNames.length != args.length) {
+      throw new IllegalArgumentException("매개변수 이름 배열과 인자 배열의 길이가 일치해야 합니다");
+    }
 
     StandardEvaluationContext context = new StandardEvaluationContext();
 

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/DistributedLockKeyGenerator.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/DistributedLockKeyGenerator.java
@@ -1,0 +1,34 @@
+package table.eat.now.coupon.user_coupon.application.utils;
+
+import java.util.Collections;
+import java.util.List;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.coupon.user_coupon.application.exception.UserCouponErrorCode;
+
+public class DistributedLockKeyGenerator {
+  private DistributedLockKeyGenerator() {
+    throw new IllegalStateException("Utility class");
+  }
+  private static final String COUPON_LOCK_PREFIX = "user:coupon:lock:";
+
+  public static List<String> generateKeys(
+      final String spelExpression,
+      final String[] parameterNames,
+      final Object[] args) {
+
+    if (spelExpression == null) {
+      return Collections.singletonList(COUPON_LOCK_PREFIX);
+    }
+
+    final List<String> keys = CustomSpringELParser.getDynamicValueSet(spelExpression, parameterNames, args)
+        .stream()
+        .map(val ->
+            COUPON_LOCK_PREFIX + val.toString())
+        .toList();
+
+    if (keys.isEmpty()) {
+      throw CustomException.from(UserCouponErrorCode.NON_LOCK_KEY);
+    }
+    return keys;
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/DistributedLockKeyGenerator.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/DistributedLockKeyGenerator.java
@@ -1,7 +1,9 @@
 package table.eat.now.coupon.user_coupon.application.utils;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.coupon.user_coupon.application.exception.UserCouponErrorCode;
 
@@ -20,10 +22,10 @@ public class DistributedLockKeyGenerator {
       return Collections.singletonList(COUPON_LOCK_PREFIX);
     }
 
-    final List<String> keys = CustomSpringELParser.getDynamicValueSet(spelExpression, parameterNames, args)
+    List<String> keys = CustomSpringELParser.parseExpression(
+        spelExpression, parameterNames, args, new TypeReference<Set<String>>() {})
         .stream()
-        .map(val ->
-            COUPON_LOCK_PREFIX + val.toString())
+        .map(val -> COUPON_LOCK_PREFIX + val)
         .toList();
 
     if (keys.isEmpty()) {

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/LockProvider.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/LockProvider.java
@@ -1,0 +1,10 @@
+package table.eat.now.coupon.user_coupon.application.utils;
+
+import java.util.List;
+import java.util.function.Supplier;
+import table.eat.now.coupon.user_coupon.application.aop.dto.LockTime;
+
+public interface LockProvider {
+
+  <T> T execute(List<String> keys, LockTime lockTime, Supplier<T> supplier);
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/TransactionHelper.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/utils/TransactionHelper.java
@@ -1,0 +1,15 @@
+package table.eat.now.coupon.user_coupon.application.utils;
+
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionHelper {
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public <T> T execute(final Supplier<T> supplier) {
+    return supplier.get();
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/domain/repository/UserCouponRepository.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/domain/repository/UserCouponRepository.java
@@ -3,6 +3,7 @@ package table.eat.now.coupon.user_coupon.domain.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import table.eat.now.coupon.user_coupon.domain.entity.UserCoupon;
@@ -14,7 +15,9 @@ public interface UserCouponRepository {
 
   Optional<UserCoupon> findByUserCouponUuidAndDeletedAtIsNullWithLock(String userCouponUuid);
 
-  void releasePreemptionsAfter10m(LocalDateTime tenMinutesAgo);
+  List<UserCoupon> findByUserCouponUuidsInAndDeletedAtIsNullWithLock(Set<String> userCouponUuids);
+
+  void releasePreemptionAfter10m(LocalDateTime tenMinutesAgo);
 
   Page<UserCoupon> findByUserIdAndExpiresAtAfterAndDeletedAtIsNull(
       Long userId, LocalDateTime now, Pageable pageable);

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/exception/UserCouponInfraErrorCode.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/exception/UserCouponInfraErrorCode.java
@@ -1,0 +1,20 @@
+package table.eat.now.coupon.user_coupon.infrastructure.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import table.eat.now.common.exception.type.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum UserCouponInfraErrorCode implements ErrorCode {
+  LOCK_PROBLEM(
+      "쿠폰 사용을 위한 잠금키에 문제가 발생하였습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
+  INVALID_TRANSACTION_WITH_LOCK(
+      "기존 트랜잭션이 존재하지 않은 경우에만 Lock을 사용할 수 있습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  ;
+
+  private final String message;
+  private final HttpStatus status;
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/jpa/JpaUserCouponRepository.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/jpa/JpaUserCouponRepository.java
@@ -2,7 +2,9 @@ package table.eat.now.coupon.user_coupon.infrastructure.persistence.jpa;
 
 import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,13 +15,21 @@ import table.eat.now.coupon.user_coupon.domain.repository.UserCouponRepository;
 public interface JpaUserCouponRepository extends
     JpaRepository<UserCoupon, Long>, UserCouponRepository {
 
+  @Override
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select uc from UserCoupon uc "
       + "where uc.userCouponUuid = :userCouponUuid and uc.deletedAt is null")
   Optional<UserCoupon> findByUserCouponUuidAndDeletedAtIsNullWithLock(String userCouponUuid);
 
+  @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select uc from UserCoupon uc "
+      + "where uc.userCouponUuid in :userCouponUuids and uc.deletedAt is null")
+  List<UserCoupon> findByUserCouponUuidsInAndDeletedAtIsNullWithLock(Set<String> userCouponUuids);
+
+  @Override
   @Modifying
   @Query("update UserCoupon uc set uc.status = 'ROLLBACK', uc.preemptAt = null, uc.reservationUuid = null "
       + "where uc.deletedAt is null and uc.usedAt is null and uc.preemptAt <= :tenMinutesAgo")
-  void releasePreemptionsAfter10m(LocalDateTime tenMinutesAgo);
+  void releasePreemptionAfter10m(LocalDateTime tenMinutesAgo);
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/redis/RedissonLockProvider.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/redis/RedissonLockProvider.java
@@ -1,0 +1,65 @@
+package table.eat.now.coupon.user_coupon.infrastructure.persistence.redis;
+
+import java.util.List;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.coupon.user_coupon.application.aop.dto.LockTime;
+import table.eat.now.coupon.user_coupon.application.utils.LockProvider;
+import table.eat.now.coupon.user_coupon.application.utils.TransactionHelper;
+import table.eat.now.coupon.user_coupon.infrastructure.exception.UserCouponInfraErrorCode;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedissonLockProvider implements LockProvider {
+  private final RedissonClient redissonClient;
+  private final TransactionHelper transactionHelper;
+
+  @Override
+  public <T> T execute(List<String> keys, LockTime lockTime, Supplier<T> proceedingSupplier) {
+
+    RLock rLock = getRLock(keys);
+    //validateTransaction();
+    try {
+      boolean available = rLock.tryLock(lockTime.waitTime(), lockTime.leaseTime(), lockTime.timeUnit());
+      if (!available) {
+        throw new InterruptedException();
+      }
+      return transactionHelper.execute(proceedingSupplier);
+
+    } catch (InterruptedException e) {
+      log.error("Redisson Lock 획득 실패 오류 {}", e.getMessage());
+      throw new CustomException(UserCouponInfraErrorCode.LOCK_PROBLEM);
+    } finally {
+      unlock(keys, rLock);
+    }
+  }
+
+  private RLock getRLock(List<String> keys) {
+    if (keys.size() == 1) {
+      return redissonClient.getLock(keys.get(0));
+    }
+    return redissonClient.getMultiLock(keys.stream().map(redissonClient::getLock).toArray(RLock[]::new));
+  }
+
+  private void unlock(List<String> keys, RLock rLock) {
+    try {
+      rLock.unlock();
+    } catch (IllegalMonitorStateException e) {
+      log.info("이미 해제된 Redisson Lock 오류 {}", keys);
+    }
+  }
+
+  private void validateTransaction() {
+    if(TransactionSynchronizationManager.isActualTransactionActive()) {
+      // 커넥션 풀 과부하가 생기는 경우 대비
+      throw CustomException.from(UserCouponInfraErrorCode.INVALID_TRANSACTION_WITH_LOCK);
+    }
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/redis/config/UserCouponRedisConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/redis/config/UserCouponRedisConfig.java
@@ -1,0 +1,35 @@
+package table.eat.now.coupon.user_coupon.infrastructure.persistence.redis.config;
+
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class UserCouponRedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+//  @Value("${spring.data.redis.password}")
+//  private String password;
+
+  private static final String REDISSON_HOST_PREFIX = "redis://";
+
+  @Bean
+  public RedissonClient redissonClient() {
+    RedissonClient redisson = null;
+    Config config = new Config();
+    config.useSingleServer()
+        .setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+        //.setPassword(password);
+    redisson = Redisson.create(config);
+    return redisson;
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/redis/config/UserCouponRedisConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/redis/config/UserCouponRedisConfig.java
@@ -24,12 +24,10 @@ public class UserCouponRedisConfig {
 
   @Bean
   public RedissonClient redissonClient() {
-    RedissonClient redisson = null;
     Config config = new Config();
     config.useSingleServer()
         .setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
         //.setPassword(password);
-    redisson = Redisson.create(config);
-    return redisson;
+    return Redisson.create(config);
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalController.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalController.java
@@ -22,12 +22,12 @@ public class UserCouponInternalController {
 
   @AuthCheck(roles = {UserRole.CUSTOMER, UserRole.MASTER})
   @PatchMapping("/preempt")
-  public ResponseEntity<Void> preemptUserCoupon(
+  public ResponseEntity<Void> preemptUserCoupons(
       @CurrentUserInfo CurrentUserInfoDto userInfoDto,
       @RequestBody @Valid PreemptUserCouponRequest request
   ) {
 
-    userCouponService.preemptUserCoupon(userInfoDto, request.toCommand());
+    userCouponService.preemptUserCoupons(userInfoDto, request.toCommand());
     return ResponseEntity.ok().build();
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalController.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalController.java
@@ -1,11 +1,9 @@
 package table.eat.now.coupon.user_coupon.presentation;
 
 import jakarta.validation.Valid;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,14 +21,13 @@ public class UserCouponInternalController {
   private final UserCouponService userCouponService;
 
   @AuthCheck(roles = {UserRole.CUSTOMER, UserRole.MASTER})
-  @PatchMapping("/{userCouponUuid}/preempt")
+  @PatchMapping("/preempt")
   public ResponseEntity<Void> preemptUserCoupon(
       @CurrentUserInfo CurrentUserInfoDto userInfoDto,
-      @PathVariable UUID userCouponUuid,
-      @Valid @RequestBody PreemptUserCouponRequest request
+      @RequestBody @Valid PreemptUserCouponRequest request
   ) {
 
-    userCouponService.preemptUserCoupon(userInfoDto, userCouponUuid.toString(), request.toCommand());
+    userCouponService.preemptUserCoupon(userInfoDto, request.toCommand());
     return ResponseEntity.ok().build();
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/dto/request/PreemptUserCouponRequest.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/dto/request/PreemptUserCouponRequest.java
@@ -1,18 +1,23 @@
 package table.eat.now.coupon.user_coupon.presentation.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import table.eat.now.coupon.user_coupon.application.dto.request.PreemptUserCouponCommand;
 
 @Builder
 public record PreemptUserCouponRequest(
-    @NotNull UUID reservationUuid
+    @NotNull UUID reservationUuid,
+    @NotEmpty Set<UUID> userCouponUuids
 ) {
 
   public PreemptUserCouponCommand toCommand() {
     return PreemptUserCouponCommand.builder()
         .reservationUuid(reservationUuid.toString())
+        .userCouponUuids(userCouponUuids.stream().map(UUID::toString).collect(Collectors.toSet()))
         .build();
   }
 }

--- a/coupon/src/test/coupon.http
+++ b/coupon/src/test/coupon.http
@@ -76,7 +76,7 @@ X-User-Id: 1
 X-User-Role: MASTER
 
 ### 가용 쿠폰 조회
-GET localhost:8085/api/v1/coupons/available?time=2025-04-11T00:00:00
+GET localhost:8085/api/v1/coupons/available?time=2025-04-21T00:00:00
 Content-Type: application/json
 
 > {%
@@ -86,7 +86,7 @@ Content-Type: application/json
 ### 쿠폰 발급 요청
 POST localhost:8085/api/v1/coupons/{{availableCouponUuid}}/issue
 Content-Type: application/json
-X-User-Id: 2
+X-User-Id: 5
 X-User-Role: CUSTOMER
 
 > {%
@@ -99,17 +99,18 @@ X-User-Role: CUSTOMER
 %}
 
 ### 쿠폰 선점 요청
-PATCH http://localhost:8085/internal/v1/user-coupons/{{userCouponUuid}}/preempt
+PATCH http://localhost:8085/internal/v1/user-coupons/preempt
 Content-Type: application/json
-X-User-Id: 2
+X-User-Id: 5
 X-User-Role: CUSTOMER
 
 {
-  "reservationUuid":"2847c0d1-1c72-404a-81f5-cee00d164637"
+  "reservationUuid":"2847c0d1-1c72-404a-81f5-cee00d164637",
+  "userCouponUuids": ["{{userCouponUuid}}"]
 }
 
 ### 사용자 쿠폰 조회 요청
 GET http://localhost:8085/api/v1/user-coupons
 Content-Type: application/json
-X-User-Id: 2
+X-User-Id: 5
 X-User-Role: CUSTOMER

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/application/service/CouponServiceImplTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/application/service/CouponServiceImplTest.java
@@ -170,7 +170,6 @@ class CouponServiceImplTest extends IntegrationTestSupport {
     assertThat(coupons.totalElements()).isEqualTo(9);
   }
 
-
   @DisplayName("쿠폰 다건 조회 검증 - 조회 성공")
   @Test
   void getCouponsInternal() {

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImplTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImplTest.java
@@ -171,7 +171,7 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
         userInfo, pageable);
 
     assertThat(getUserCoupons.contents().get(0).userId()).isEqualTo(2L);
-    assertThat(getUserCoupons.totalElements()).isEqualTo(10);
+    assertThat(getUserCoupons.totalElements()).isEqualTo(20);
     assertThat(getUserCoupons.pageSize()).isEqualTo(pageable.getPageSize());
   }
 

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImplTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImplTest.java
@@ -84,7 +84,7 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
 
   @DisplayName("일반 사용자 쿠폰 선점시 비관락 적용한 경우 검증")
   @Nested
-  class preemptUserCoupon {
+  class preemptUserCoupons {
 
     @DisplayName("선점 성공")
     @Test
@@ -99,7 +99,7 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
           .build();
 
       // when
-      userCouponService.preemptUserCoupon(userInfo, command);
+      userCouponService.preemptUserCoupons(userInfo, command);
 
       // then
       UserCoupon userCoupon =
@@ -132,7 +132,7 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
                 .reservationUuid(UUID.randomUUID().toString())
                 .userCouponUuids(Set.of(userCouponUuid, userCouponUuid2))
                 .build();
-            userCouponService.preemptUserCoupon(userInfo, command);
+            userCouponService.preemptUserCoupons(userInfo, command);
           } catch (Exception e) {
             log.error(e.getMessage());
             errorCount.incrementAndGet();
@@ -173,7 +173,7 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
 
   @DisplayName("일반 사용자 쿠폰 선점시 분산락 적용한 경우 검증")
   @Nested
-  class preemptUserCouponWithDistributedLock {
+  class preemptUserCouponsWithDistributedLock {
 
     @DisplayName("선점 성공")
     @Test
@@ -189,7 +189,7 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
 
       // when, then
       assertThatNoException()
-          .isThrownBy(() -> userCouponService.preemptUserCouponWithDistributedLock(userInfo, command));
+          .isThrownBy(() -> userCouponService.preemptUserCouponsWithDistributedLock(userInfo, command));
 
       UserCoupon userCoupon =
           userCouponRepository.findByUserCouponUuidAndDeletedAtIsNull(userCouponUuid)
@@ -221,7 +221,7 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
                 .reservationUuid(UUID.randomUUID().toString())
                 .userCouponUuids(Set.of(userCouponUuid, userCouponUuid2))
                 .build();
-            userCouponService.preemptUserCouponWithDistributedLock(userInfo, command);
+            userCouponService.preemptUserCouponsWithDistributedLock(userInfo, command);
           } catch (Exception e) {
             log.error(e.getMessage());
             errorCount.incrementAndGet();

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImplTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImplTest.java
@@ -148,12 +148,8 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
       UserCoupon preemptCoupon =
           userCouponRepository.findByUserCouponUuidAndDeletedAtIsNull(userCouponUuid)
               .orElseThrow(() -> CustomException.from(UserCouponErrorCode.INVALID_USER_COUPON_UUID));
-      UserCoupon failedToPreemptCoupon =
-          userCouponRepository.findByUserCouponUuidAndDeletedAtIsNull(userCoupons.get(2).getUserCouponUuid())
-              .orElseThrow(() -> CustomException.from(UserCouponErrorCode.INVALID_USER_COUPON_UUID));
 
       assertThat(preemptCoupon.getStatus()).isEqualTo(UserCouponStatus.PREEMPT);
-      assertThat(failedToPreemptCoupon.getStatus()).isEqualTo(UserCouponStatus.ISSUED);
       assertThat(errorCount.get()).isEqualTo(9);
     }
   }
@@ -241,12 +237,8 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
       UserCoupon preemptCoupon =
           userCouponRepository.findByUserCouponUuidAndDeletedAtIsNull(userCouponUuid)
               .orElseThrow(() -> CustomException.from(UserCouponErrorCode.INVALID_USER_COUPON_UUID));
-      UserCoupon failedToPreemptCoupon =
-          userCouponRepository.findByUserCouponUuidAndDeletedAtIsNull(userCoupons.get(2).getUserCouponUuid())
-              .orElseThrow(() -> CustomException.from(UserCouponErrorCode.INVALID_USER_COUPON_UUID));
 
       assertThat(preemptCoupon.getStatus()).isEqualTo(UserCouponStatus.PREEMPT);
-      assertThat(failedToPreemptCoupon.getStatus()).isEqualTo(UserCouponStatus.ISSUED);
       assertThat(errorCount.get()).isEqualTo(9);
     }
   }

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalControllerTest.java
@@ -42,7 +42,7 @@ class UserCouponInternalControllerTest extends ControllerTestSupport {
         .userCouponUuids(Set.of(UUID.randomUUID(), UUID.randomUUID()))
         .build();
 
-    doNothing().when(userCouponService).preemptUserCoupon(userInfo, request.toCommand());
+    doNothing().when(userCouponService).preemptUserCoupons(userInfo, request.toCommand());
 
     // when
     ResultActions resultActions = mockMvc.perform(

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,16 +37,16 @@ class UserCouponInternalControllerTest extends ControllerTestSupport {
   void preemptUserCoupon() throws Exception {
     // given
     CurrentUserInfoDto userInfo = CurrentUserInfoDto.of(2L, UserRole.CUSTOMER);
-    String userCouponUuid = UUID.randomUUID().toString();
     PreemptUserCouponRequest request = PreemptUserCouponRequest.builder()
         .reservationUuid(UUID.randomUUID())
+        .userCouponUuids(Set.of(UUID.randomUUID(), UUID.randomUUID()))
         .build();
 
-    doNothing().when(userCouponService).preemptUserCoupon(userInfo, userCouponUuid, request.toCommand());
+    doNothing().when(userCouponService).preemptUserCoupon(userInfo, request.toCommand());
 
     // when
     ResultActions resultActions = mockMvc.perform(
-        patch("/internal/v1/user-coupons/{userCouponUuid}/preempt", userCouponUuid)
+        patch("/internal/v1/user-coupons/preempt")
             .header("Authorization", "Bearer {ACCESS_TOKEN}")
             .header(USER_ID_HEADER, userInfo.userId())
             .header(USER_ROLE_HEADER, userInfo.role())

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestServiceImplTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/service/WaitingRequestServiceImplTest.java
@@ -402,7 +402,7 @@ class WaitingRequestServiceImplTest extends IntegrationTestSupport {
   @Nested
   class cancelWaitingRequest {
 
-    @Transactional
+    @Transactional // 레이지 로딩을 위해 적용
     @DisplayName("성공")
     @Test
     void success() {


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #170

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 쿠폰 선점 단건만 처리 가능

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 쿠폰 다건 선점 가능하도록 수정
  - [x] 분산락 구현 추가

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 분산 락 기반의 쿠폰 선점 기능이 추가되었습니다. 여러 쿠폰을 한 번에 선점할 수 있도록 API와 요청/응답 구조가 확장되었습니다.
  - 분산 락 처리를 위한 어노테이션, AOP, 유틸리티, Redisson 연동 설정이 도입되었습니다.

- **기능 개선**
  - 쿠폰 선점 API가 단일 쿠폰에서 다중 쿠폰 처리 방식으로 변경되었습니다.
  - 쿠폰 선점 관련 에러 코드가 추가 및 개선되었습니다.

- **버그 수정**
  - 일부 테스트 및 API 요청 형식이 최신 구조에 맞게 수정되었습니다.

- **테스트**
  - 분산 락과 비관적 락 환경에서의 동시성 테스트가 추가 및 구조화되었습니다.

- **문서/스타일**
  - 코드 내 일부 주석 및 클래스 명칭이 명확하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->