### PR TITLE
[payment] 결제 부분취소 구현

### DIFF
--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/CancelPgPaymentCommand.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/CancelPgPaymentCommand.java
@@ -1,10 +1,21 @@
 package table.eat.now.payment.payment.application.client.dto;
 
+import java.math.BigDecimal;
+
 public record CancelPgPaymentCommand(
     String paymentKey,
-    String cancelReason
+    String cancelReason,
+    BigDecimal cancelAmount
 ) {
-  public static CancelPgPaymentCommand of(String paymentKey, String cancelReason) {
-    return new CancelPgPaymentCommand(paymentKey, cancelReason);
+  public static CancelPgPaymentCommand of(
+      String paymentKey,
+      String cancelReason,
+      BigDecimal cancelAmount
+  ) {
+    return new CancelPgPaymentCommand(
+        paymentKey,
+        cancelReason,
+        cancelAmount
+    );
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/CancelPgPaymentInfo.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/client/dto/CancelPgPaymentInfo.java
@@ -1,15 +1,24 @@
 package table.eat.now.payment.payment.application.client.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import table.eat.now.payment.payment.domain.entity.CancelPayment;
 
 public record CancelPgPaymentInfo(
     String paymentKey,
     String cancelReason,
+    BigDecimal cancelAmount,
+    BigDecimal balanceAmount,
     LocalDateTime cancelledAt
 ) {
 
-  public CancelPayment toCancel(){
-    return new CancelPayment(paymentKey,cancelReason,cancelledAt);
+  public CancelPayment toCancel() {
+    return new CancelPayment(
+        paymentKey,
+        cancelReason,
+        cancelAmount,
+        balanceAmount,
+        cancelledAt
+    );
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/dto/request/CancelPaymentCommand.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/dto/request/CancelPaymentCommand.java
@@ -1,9 +1,11 @@
 package table.eat.now.payment.payment.application.dto.request;
 
+import java.math.BigDecimal;
+
 public record CancelPaymentCommand(
     String reservationUuid,
     String idempotencyKey,
+    BigDecimal cancelAmount,
     String cancelReason
 ) {
-
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEventPublisher.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/PaymentEventPublisher.java
@@ -2,9 +2,9 @@ package table.eat.now.payment.payment.application.event;
 
 public interface PaymentEventPublisher {
 
-  void publish(PaymentSuccessEvent createdEvent);
+  void publish(ReservationPaymentSucceedEvent createdEvent);
 
-  void publish(PaymentFailedEvent failedEvent);
+  void publish(ReservationPaymentFailedEvent failedEvent);
 
-  void publish(PaymentCanceledEvent canceledEvent);
+  void publish(ReservationPaymentCancelledEvent canceledEvent);
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentCancelledEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentCancelledEvent.java
@@ -4,17 +4,16 @@ import static table.eat.now.payment.payment.application.event.EventType.RESERVAT
 
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 
-public record PaymentCanceledEvent(
+public record ReservationPaymentCancelledEvent(
     EventType eventType,
     String paymentUuid,
-    PaymentCanceledPayload payload,
+    ReservationPaymentCancelledPayload payload,
     CurrentUserInfoDto userInfo
 ) implements PaymentEvent {
 
-  public static PaymentCanceledEvent of(
-      PaymentCanceledPayload payload, CurrentUserInfoDto userInfo) {
-    return new PaymentCanceledEvent(
+  public static ReservationPaymentCancelledEvent of(
+      ReservationPaymentCancelledPayload payload, CurrentUserInfoDto userInfo) {
+    return new ReservationPaymentCancelledEvent(
         RESERVATION_PAYMENT_CANCEL_SUCCEED, payload.paymentUuid(), payload, userInfo);
   }
-
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentCancelledPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentCancelledPayload.java
@@ -1,16 +1,19 @@
 package table.eat.now.payment.payment.application.event;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import table.eat.now.payment.payment.domain.entity.Payment;
 
-public record PaymentCanceledPayload(
+public record ReservationPaymentCancelledPayload(
     String idempotencyKey,
     String paymentUuid,
     String paymentStatus,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     LocalDateTime cancelledAt
 ) {
-  public static PaymentCanceledPayload from(Payment payment) {
-    return new PaymentCanceledPayload(
+  public static ReservationPaymentCancelledPayload from(Payment payment) {
+    return new ReservationPaymentCancelledPayload(
         payment.getIdentifier().getIdempotencyKey(),
         payment.getIdentifier().getPaymentUuid(),
         payment.getPaymentStatus().name(),

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentFailedEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentFailedEvent.java
@@ -4,16 +4,16 @@ import static table.eat.now.payment.payment.application.event.EventType.RESERVAT
 
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 
-public record PaymentFailedEvent(
+public record ReservationPaymentFailedEvent(
     EventType eventType,
     String paymentUuid,
-    PaymentFailedPayload payload,
+    ReservationPaymentFailedPayload payload,
     CurrentUserInfoDto userInfo
 ) implements PaymentEvent {
 
-  public static PaymentFailedEvent of(
-      PaymentFailedPayload payload, CurrentUserInfoDto userInfo) {
-    return new PaymentFailedEvent(
+  public static ReservationPaymentFailedEvent of(
+      ReservationPaymentFailedPayload payload, CurrentUserInfoDto userInfo) {
+    return new ReservationPaymentFailedEvent(
         RESERVATION_PAYMENT_FAILED, payload.paymentUuid(), payload, userInfo);
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentFailedPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentFailedPayload.java
@@ -1,17 +1,19 @@
 package table.eat.now.payment.payment.application.event;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import table.eat.now.payment.payment.domain.entity.Payment;
 
-public record PaymentFailedPayload(
+public record ReservationPaymentFailedPayload(
     String paymentUuid,
     String paymentKey,
     String cancelReason,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     LocalDateTime cancelledAt,
     String paymentStatus
 ) {
-  public static PaymentFailedPayload from(Payment payment, String cancelReason) {
-    return new PaymentFailedPayload(
+  public static ReservationPaymentFailedPayload from(Payment payment, String cancelReason) {
+    return new ReservationPaymentFailedPayload(
         payment.getIdentifier().getPaymentUuid(),
         payment.getPaymentKey(),
         cancelReason,

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentSucceedEvent.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentSucceedEvent.java
@@ -5,17 +5,17 @@ import static table.eat.now.payment.payment.application.event.EventType.RESERVAT
 
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 
-public record PaymentSuccessEvent(
+public record ReservationPaymentSucceedEvent(
     EventType eventType,
     String paymentUuid,
-    PaymentSuccessPayload payload,
+    ReservationPaymentSucceedPayload payload,
     CurrentUserInfoDto userInfo
 ) implements PaymentEvent {
 
-  public static PaymentSuccessEvent of(
-      PaymentSuccessPayload payload, CurrentUserInfoDto userInfo) {
+  public static ReservationPaymentSucceedEvent of(
+      ReservationPaymentSucceedPayload payload, CurrentUserInfoDto userInfo) {
 
-    return new PaymentSuccessEvent(
+    return new ReservationPaymentSucceedEvent(
         RESERVATION_PAYMENT_SUCCEED, payload.paymentUuid(), payload, userInfo);
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentSucceedPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/event/ReservationPaymentSucceedPayload.java
@@ -1,24 +1,27 @@
 package table.eat.now.payment.payment.application.event;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import table.eat.now.payment.payment.domain.entity.Payment;
 
 @Builder
-public record PaymentSuccessPayload(
+public record ReservationPaymentSucceedPayload(
     String paymentUuid,
     String idempotencyKey,
     String paymentStatus,
     BigDecimal originalAmount,
     BigDecimal discountAmount,
     BigDecimal totalAmount,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     LocalDateTime createdAt,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     LocalDateTime approvedAt
 ) {
 
-  public static PaymentSuccessPayload from(Payment payment) {
-    return PaymentSuccessPayload.builder()
+  public static ReservationPaymentSucceedPayload from(Payment payment) {
+    return ReservationPaymentSucceedPayload.builder()
         .paymentUuid(payment.getIdentifier().getPaymentUuid())
         .idempotencyKey(payment.getIdentifier().getIdempotencyKey())
         .paymentStatus(payment.getPaymentStatus().name())

--- a/payment/src/main/java/table/eat/now/payment/payment/application/exception/PaymentErrorCode.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/application/exception/PaymentErrorCode.java
@@ -12,7 +12,9 @@ public enum PaymentErrorCode implements ErrorCode {
   PAYMENT_AMOUNT_MISMATCH("결제 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
   RESERVATION_NOT_PENDING("결제 대기 상태의 예약만 결제할 수 있습니다.", HttpStatus.BAD_REQUEST),
   PAYMENT_APPROVAL_FAILED("결제 승인에 실패했습니다.", HttpStatus.BAD_REQUEST),
-  PAYMENT_ACCESS_DENIED("해당 결제 정보를 조회할 권한이 없습니다.", HttpStatus.FORBIDDEN)
+  PAYMENT_ACCESS_DENIED("해당 결제 정보를 조회할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  CANCEL_AMOUNT_EXCEED_BALANCE("취소 금액은 잔액보다 클 수 없습니다.", HttpStatus.CONFLICT),
+  PAYMENT_ALREADY_CANCELLED("이미 취소된 결제입니다.", HttpStatus.CONFLICT),
   ;
 
   private final String message;

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/CancelPayment.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/CancelPayment.java
@@ -1,10 +1,13 @@
 package table.eat.now.payment.payment.domain.entity;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public record CancelPayment(
     String paymentKey,
     String cancelReason,
+    BigDecimal cancelAmount,
+    BigDecimal balanceAmount,
     LocalDateTime cancelledAt
 ) {
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/Payment.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/Payment.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import table.eat.now.common.domain.BaseEntity;
@@ -83,6 +84,10 @@ public class Payment extends BaseEntity {
 
   public String getIdempotencyKey() {
     return this.identifier.getIdempotencyKey();
+  }
+
+  public BigDecimal getBalancedAmount() {
+    return this.amount.getBalanceAmount();
   }
 
   private Payment(PaymentReference reference, PaymentAmount amount) {

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/Payment.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/Payment.java
@@ -76,7 +76,7 @@ public class Payment extends BaseEntity {
 
   public void cancel(CancelPayment cancelPayment) {
     validatePaymentKey(cancelPayment.paymentKey());
-
+    this.amount = this.amount.cancel(cancelPayment.cancelAmount(), cancelPayment.balanceAmount());
     this.paymentStatus = validateStatus(PaymentStatus.CANCELED);
     this.cancelledAt = cancelPayment.cancelledAt();
   }

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentAmount.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentAmount.java
@@ -18,9 +18,15 @@ public class PaymentAmount {
   @Column(name = "total_amount", precision = 8)
   private BigDecimal totalAmount;
 
+  @Column(name = "cancel_amount", precision = 8)
+  private BigDecimal cancelAmount;
+
+  @Column(name = "balance_amount", precision = 8)
+  private BigDecimal balanceAmount;
+
   public static PaymentAmount create(BigDecimal originalAmount) {
     validateAmount(originalAmount);
-    return new PaymentAmount(originalAmount, null, null);
+    return new PaymentAmount(originalAmount, null, null, null, null);
   }
 
   private static void validateAmount(BigDecimal amount) {
@@ -49,7 +55,23 @@ public class PaymentAmount {
     validateDiscountAmount(discountAmount);
     validateTotalAmount(discountAmount, totalAmount);
 
-    return new PaymentAmount(this.originalAmount, discountAmount, totalAmount);
+    return new PaymentAmount(
+        this.originalAmount,
+        discountAmount,
+        totalAmount,
+        BigDecimal.ZERO,
+        totalAmount
+    );
+  }
+
+  public PaymentAmount cancel(BigDecimal cancelAmount, BigDecimal balanceAmount) {
+    return new PaymentAmount(
+        this.originalAmount,
+        discountAmount,
+        totalAmount,
+        cancelAmount,
+        balanceAmount
+    );
   }
 
   private void validateDiscountAmount(BigDecimal discountAmount) {
@@ -74,11 +96,13 @@ public class PaymentAmount {
     }
   }
 
-  private PaymentAmount(
-      BigDecimal originalAmount, BigDecimal discountAmount, BigDecimal totalAmount) {
+  private PaymentAmount(BigDecimal originalAmount, BigDecimal discountAmount,
+      BigDecimal totalAmount, BigDecimal cancelAmount, BigDecimal balanceAmount) {
     this.originalAmount = originalAmount;
     this.discountAmount = discountAmount;
     this.totalAmount = totalAmount;
+    this.cancelAmount = cancelAmount;
+    this.balanceAmount = balanceAmount;
   }
 
   protected PaymentAmount() {

--- a/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentAmount.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/domain/entity/PaymentAmount.java
@@ -59,7 +59,7 @@ public class PaymentAmount {
         this.originalAmount,
         discountAmount,
         totalAmount,
-        BigDecimal.ZERO,
+        null,
         totalAmount
     );
   }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/request/CancelTossPayRequest.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/request/CancelTossPayRequest.java
@@ -1,11 +1,13 @@
 package table.eat.now.payment.payment.infrastructure.client.dto.request;
 
+import java.math.BigDecimal;
 import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentCommand;
 
 public record CancelTossPayRequest(
-    String cancelReason
+    String cancelReason,
+    BigDecimal cancelAmount
 ) {
   public static CancelTossPayRequest from(CancelPgPaymentCommand command) {
-    return new CancelTossPayRequest(command.cancelReason());
+    return new CancelTossPayRequest(command.cancelReason(), command.cancelAmount());
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/response/CancelTossPayResponse.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/dto/response/CancelTossPayResponse.java
@@ -2,6 +2,7 @@ package table.eat.now.payment.payment.infrastructure.client.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentInfo;
@@ -9,22 +10,27 @@ import table.eat.now.payment.payment.application.client.dto.CancelPgPaymentInfo;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record CancelTossPayResponse(
     String paymentKey,
-    List<Cancel> cancels
+    List<Cancel> cancels,
+    BigDecimal balanceAmount
 ) {
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record Cancel(
       String cancelReason,
+      BigDecimal cancelAmount,
+      BigDecimal balanceAmount,
       @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
       LocalDateTime canceledAt
   ) {
   }
 
   public CancelPgPaymentInfo toInfo(){
-    Cancel latestCancel = cancels.get(0);
+    Cancel cancelledResult = cancels.get(0);
     return new CancelPgPaymentInfo(
         paymentKey,
-        latestCancel.cancelReason,
-        latestCancel.canceledAt
+        cancelledResult.cancelReason,
+        cancelledResult.cancelAmount,
+        balanceAmount,
+        cancelledResult.canceledAt
     );
   }
 }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/pg/TossPaymentClient.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/client/pg/TossPaymentClient.java
@@ -75,6 +75,7 @@ public class TossPaymentClient {
     try {
       return supplier.get();
     } catch (HttpClientErrorException e) {
+      log.error(e.getMessage(), e);
       HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
       throw CustomException.of(status, extractErrorMessage(e));
     } catch (Exception e) {

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/KafkaPaymentProducer.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/KafkaPaymentProducer.java
@@ -4,11 +4,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
-import table.eat.now.payment.payment.application.event.PaymentCanceledEvent;
+import table.eat.now.payment.payment.application.event.ReservationPaymentCancelledEvent;
 import table.eat.now.payment.payment.application.event.PaymentEvent;
 import table.eat.now.payment.payment.application.event.PaymentEventPublisher;
-import table.eat.now.payment.payment.application.event.PaymentFailedEvent;
-import table.eat.now.payment.payment.application.event.PaymentSuccessEvent;
+import table.eat.now.payment.payment.application.event.ReservationPaymentFailedEvent;
+import table.eat.now.payment.payment.application.event.ReservationPaymentSucceedEvent;
 
 @Slf4j
 @Component
@@ -19,19 +19,19 @@ public class KafkaPaymentProducer implements PaymentEventPublisher {
   private final String paymentTopic;
 
   @Override
-  public void publish(PaymentSuccessEvent successEvent) {
+  public void publish(ReservationPaymentSucceedEvent successEvent) {
     kafkaTemplate.send(paymentTopic, successEvent.paymentUuid() ,successEvent);
     logEvent(successEvent);
   }
 
   @Override
-  public void publish(PaymentFailedEvent failedEvent) {
+  public void publish(ReservationPaymentFailedEvent failedEvent) {
     kafkaTemplate.send(paymentTopic, failedEvent.paymentUuid() ,failedEvent);
     logEvent(failedEvent);
   }
 
   @Override
-  public void publish(PaymentCanceledEvent canceledEvent) {
+  public void publish(ReservationPaymentCancelledEvent canceledEvent) {
     kafkaTemplate.send(paymentTopic, canceledEvent.paymentUuid() , canceledEvent);
     logEvent(canceledEvent);
   }

--- a/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/ReservationCancelledPayload.java
+++ b/payment/src/main/java/table/eat/now/payment/payment/infrastructure/kafka/event/ReservationCancelledPayload.java
@@ -25,6 +25,11 @@ public record ReservationCancelledPayload(
 )  {
 
   public CancelPaymentCommand toCommand() {
-    return new CancelPaymentCommand(reservationUuid, paymentIdempotencyKey, cancelReason);
+    return new CancelPaymentCommand(
+        reservationUuid,
+        paymentIdempotencyKey,
+        cancelAmount,
+        cancelReason
+    );
   }
 }

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:

--- a/payment/src/test/http/api.http
+++ b/payment/src/test/http/api.http
@@ -60,8 +60,8 @@ Content-Type: application/json
 X-User-Id: 123
 X-User-Role: CUSTOMER
 
-### 토스페이 거래내역 상세조회
-GET https://api.tosspayments.com/v1/payments/orders/00000000-0000-0000-0000-000000000027
+### 토스페이 거래내역 상세조회 (부분취소 결과입니다! - 토스로의 요청이라 확인 바로 가능합니다~!)
+GET https://api.tosspayments.com/v1/payments/orders/00000000-0000-0000-0000-000000000047
 Authorization: Basic dGVzdF9za19BTG5RdkRkMlZKR2s0eUdLR1E5TnJNajdYNDFtOg
 Content-Type: application/json
 

--- a/payment/src/test/http/view.http
+++ b/payment/src/test/http/view.http
@@ -3,8 +3,8 @@ POST localhost:8088/internal/v1/payments
 Content-Type: application/json
 
 {
-  "reservationUuid": "00000000-0000-0000-0000-000000000018",
-  "restaurantUuid": "9882a539-0380-4a5d-bec4-da49d37f06e5",
+  "reservationUuid": "00000000-0000-0000-0000-000000000047",
+  "restaurantUuid": "restaur-0000-0000-0000-000000000047",
   "customerId": 123,
   "reservationName": "하이들하신가",
   "originalAmount": 45000

--- a/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentAmountTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentAmountTest.java
@@ -193,4 +193,95 @@ class PaymentAmountTest {
       assertThat(exception.getMessage()).contains("금액은 정수여야 합니다");
     }
   }
+
+  @Nested
+  class cancel_은 {
+
+    @Test
+    void 전액_취소를_할_수_있다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount)
+          .confirm(discountAmount, totalAmount);
+      BigDecimal cancelAmount = BigDecimal.valueOf(9000);
+      BigDecimal balanceAmount = BigDecimal.ZERO;
+
+      //when
+      PaymentAmount cancelledAmount = assertDoesNotThrow(() ->
+          paymentAmount.cancel(cancelAmount, balanceAmount));
+
+      //then
+      assertThat(cancelledAmount).isNotNull();
+      assertThat(cancelledAmount.getOriginalAmount()).isEqualTo(originalAmount);
+      assertThat(cancelledAmount.getDiscountAmount()).isEqualTo(discountAmount);
+      assertThat(cancelledAmount.getTotalAmount()).isEqualTo(totalAmount);
+      assertThat(cancelledAmount.getCancelAmount()).isEqualTo(cancelAmount);
+      assertThat(cancelledAmount.getBalanceAmount()).isEqualTo(balanceAmount);
+    }
+
+    @Test
+    void 부분_취소를_할_수_있다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount)
+          .confirm(discountAmount, totalAmount);
+      BigDecimal cancelAmount = BigDecimal.valueOf(5000);
+      BigDecimal balanceAmount = BigDecimal.valueOf(4000);
+
+      //when
+      PaymentAmount cancelledAmount = assertDoesNotThrow(() ->
+          paymentAmount.cancel(cancelAmount, balanceAmount));
+
+      //then
+      assertThat(cancelledAmount).isNotNull();
+      assertThat(cancelledAmount.getOriginalAmount()).isEqualTo(originalAmount);
+      assertThat(cancelledAmount.getDiscountAmount()).isEqualTo(discountAmount);
+      assertThat(cancelledAmount.getTotalAmount()).isEqualTo(totalAmount);
+      assertThat(cancelledAmount.getCancelAmount()).isEqualTo(cancelAmount);
+      assertThat(cancelledAmount.getBalanceAmount()).isEqualTo(balanceAmount);
+    }
+
+    @Test
+    void 취소_금액과_잔액이_null인_경우_정상적으로_처리된다() {
+      //given
+      BigDecimal originalAmount = BigDecimal.valueOf(10000);
+      BigDecimal discountAmount = BigDecimal.valueOf(1000);
+      BigDecimal totalAmount = BigDecimal.valueOf(9000);
+      PaymentAmount paymentAmount = PaymentAmount.create(originalAmount)
+          .confirm(discountAmount, totalAmount);
+
+      //when
+      PaymentAmount cancelledAmount = assertDoesNotThrow(() ->
+          paymentAmount.cancel(null, null));
+
+      //then
+      assertThat(cancelledAmount).isNotNull();
+      assertThat(cancelledAmount.getOriginalAmount()).isEqualTo(originalAmount);
+      assertThat(cancelledAmount.getDiscountAmount()).isEqualTo(discountAmount);
+      assertThat(cancelledAmount.getTotalAmount()).isEqualTo(totalAmount);
+      assertThat(cancelledAmount.getCancelAmount()).isNull();
+      assertThat(cancelledAmount.getBalanceAmount()).isNull();
+    }
+
+    @Test
+    void 원래금액이_null인_경우_취소할_수_있다() {
+      //given
+      PaymentAmount paymentAmount = PaymentAmount.create(BigDecimal.valueOf(10000));
+      BigDecimal cancelAmount = BigDecimal.valueOf(10000);
+      BigDecimal balanceAmount = BigDecimal.ZERO;
+
+      //when
+      PaymentAmount cancelledAmount = assertDoesNotThrow(() ->
+          paymentAmount.cancel(cancelAmount, balanceAmount));
+
+      //then
+      assertThat(cancelledAmount).isNotNull();
+      assertThat(cancelledAmount.getCancelAmount()).isEqualTo(cancelAmount);
+      assertThat(cancelledAmount.getBalanceAmount()).isEqualTo(balanceAmount);
+    }
+  }
 }

--- a/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/domain/entity/PaymentTest.java
@@ -150,4 +150,149 @@ class PaymentTest {
     PaymentAmount validAmount = PaymentAmount.create(BigDecimal.valueOf(10000));
     return Payment.create(validReference, validAmount);
   }
+
+  @Nested
+  class cancel_은 {
+
+    @Test
+    void 유효한_입력값으로_결제를_취소할_수_있다() {
+      //given
+      Payment payment = createApprovedPayment();
+      String paymentKey = payment.getPaymentKey();
+      BigDecimal cancelAmount = BigDecimal.valueOf(9000);
+      BigDecimal balanceAmount = BigDecimal.ZERO;
+      CancelPayment cancelCommand = new CancelPayment(
+          paymentKey,
+          "하온님의 변심",
+          cancelAmount,
+          balanceAmount,
+          LocalDateTime.now()
+      );
+
+      //when
+      assertDoesNotThrow(() -> payment.cancel(cancelCommand));
+
+      //then
+      assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELED);
+      assertThat(payment.getCancelledAt()).isNotNull();
+      assertThat(payment.getAmount().getCancelAmount()).isEqualTo(cancelAmount);
+      assertThat(payment.getAmount().getBalanceAmount()).isEqualTo(balanceAmount);
+    }
+
+    @Test
+    void 부분_취소를_할_수_있다() {
+      //given
+      Payment payment = createApprovedPayment();
+      String paymentKey = "payment_key_123456";
+      BigDecimal cancelAmount = BigDecimal.valueOf(5000);
+      BigDecimal balanceAmount = BigDecimal.valueOf(4000);
+      CancelPayment cancelCommand = new CancelPayment(
+          paymentKey,
+          "지은님의 부분 환불 요청",
+          cancelAmount,
+          balanceAmount,
+          LocalDateTime.now()
+      );
+
+      //when
+      assertDoesNotThrow(() -> payment.cancel(cancelCommand));
+
+      //then
+      assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELED);
+      assertThat(payment.getCancelledAt()).isNotNull();
+      assertThat(payment.getAmount().getCancelAmount()).isEqualTo(cancelAmount);
+      assertThat(payment.getAmount().getBalanceAmount()).isEqualTo(balanceAmount);
+    }
+
+    @Test
+    void paymentKey가_null이면_IllegalArgumentException을_던진다() {
+      //given
+      Payment payment = createApprovedPayment();
+      BigDecimal cancelAmount = BigDecimal.valueOf(9000);
+      BigDecimal balanceAmount = BigDecimal.ZERO;
+      CancelPayment cancelCommand = new CancelPayment(
+          null,
+          "지훈님의 미용실 갈 돈 모으기",
+          cancelAmount,
+          balanceAmount,
+          LocalDateTime.now()
+      );
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              payment.cancel(cancelCommand));
+
+      assertThat(exception.getMessage()).contains("paymentKey는 null이거나 빈 값일 수 없습니다");
+    }
+
+    @Test
+    void paymentKey가_일치하지_않으면_취소할_수_있다() {
+      //given
+      Payment payment = createApprovedPayment();
+      String differentPaymentKey = "different_payment_key_123456";
+      BigDecimal cancelAmount = BigDecimal.valueOf(9000);
+      BigDecimal balanceAmount = BigDecimal.ZERO;
+      CancelPayment cancelCommand = new CancelPayment(
+          differentPaymentKey,
+          "하온님의 변심",
+          cancelAmount,
+          balanceAmount,
+          LocalDateTime.now()
+      );
+
+      //when
+      assertDoesNotThrow(() -> payment.cancel(cancelCommand));
+    }
+
+    @Test
+    void 이미_취소된_결제는_다시_취소할_수_없다() {
+      //given
+      Payment payment = createCancelledPayment();
+      String paymentKey = "payment_key_123456";
+      BigDecimal cancelAmount = BigDecimal.valueOf(9000);
+      BigDecimal balanceAmount = BigDecimal.ZERO;
+      CancelPayment cancelCommand = new CancelPayment(
+          paymentKey,
+          "지훈님의 돈복사",
+          cancelAmount,
+          balanceAmount,
+          LocalDateTime.now()
+      );
+
+      //when & then
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () ->
+              payment.cancel(cancelCommand));
+
+      assertThat(exception.getMessage()).contains("해당 상태로 변경할 수 없습니다");
+    }
+  }
+
+  private Payment createApprovedPayment() {
+    Payment payment = createValidPayment();
+    String paymentKey = "payment_key_123456";
+    BigDecimal discountAmount = BigDecimal.valueOf(1000);
+    BigDecimal totalAmount = BigDecimal.valueOf(9000);
+    ConfirmPayment confirmCommand =
+        new ConfirmPayment(paymentKey, discountAmount, totalAmount, LocalDateTime.now());
+    payment.confirm(confirmCommand);
+    return payment;
+  }
+
+  private Payment createCancelledPayment() {
+    Payment payment = createApprovedPayment();
+    String paymentKey = "payment_key_123456";
+    BigDecimal cancelAmount = BigDecimal.valueOf(9000);
+    BigDecimal balanceAmount = BigDecimal.ZERO;
+    CancelPayment cancelCommand = new CancelPayment(
+        paymentKey,
+        "고객 요청에 의한 취소",
+        cancelAmount,
+        balanceAmount,
+        LocalDateTime.now()
+    );
+    payment.cancel(cancelCommand);
+    return payment;
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #167 

## 변경 타입
- [x] 신규 기능 추가/수정
- [x] 버그 수정
- [x] 리팩토링

## 변경 내용
- **as-is**
  - 이벤트 타입이 심플했습니다.
  - 전액취소만 가능했습니다 (취소금액 받지x)
  - 취소 파라미터 순서가 달라 취소에서 오류가 발생했습니다

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 이벤트타입을 구체화했습니다.
  - [x] 부분 취소를 구현했습니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.

## 코멘트
- 예약취소 이벤트를 성공적으로 컨슈밍했습니다!.
- 결제 취소 이후 취소 성공 이벤트를 전송합니다. (
- 현재는 `@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS"`을 적용한 상태입니다
<img width="984" alt="스크린샷 2025-04-21 오후 4 33 38" src="https://github.com/user-attachments/assets/b67483cb-d5a8-49f3-a6c4-fe62c0e48f0e" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 결제 취소 시 취소 금액 및 잔액 정보를 추가로 처리하도록 개선되었습니다.

- **버그 수정**
  - 결제 취소 및 부분 취소 시 금액 정보가 정확하게 반영되도록 수정되었습니다.

- **리팩터링**
  - 결제 이벤트 관련 클래스를 예약 결제 전용 이벤트로 명확하게 구분하였습니다.
  - 이벤트 페이로드 및 관련 메서드 명칭이 예약 결제 용어로 변경되었습니다.

- **테스트**
  - 결제 취소 및 부분 취소, 예외 상황 등 다양한 케이스에 대한 테스트가 추가되었습니다.

- **환경설정**
  - 데이터베이스 스키마 자동 갱신 방식이 변경되어, 기존 데이터가 삭제되지 않고 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->