### PR TITLE
[coupon] 예약 취소 이벤트 처리 구현 및 데드레터큐 간단 구현

### DIFF
--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponService.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponService.java
@@ -18,4 +18,6 @@ public interface UserCouponService {
 
   PageResponse<GetUserCouponInfo> getUserCouponsByUserId(
       CurrentUserInfoDto userInfoDto, Pageable pageable);
+
+  void cancelUserCoupons(String reservationUuid);
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImpl.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImpl.java
@@ -80,4 +80,12 @@ public class UserCouponServiceImpl implements UserCouponService {
         .map(GetUserCouponInfo::from);
     return PageResponse.from(userCouponInfos);
   }
+
+  @Transactional
+  @Override
+  public void cancelUserCoupons(String reservationUuid) {
+
+    List<UserCoupon> userCoupons = userCouponRepository.findByReservationUuid(reservationUuid);
+    userCoupons.forEach(UserCoupon::release);
+  }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/domain/entity/UserCoupon.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/domain/entity/UserCoupon.java
@@ -112,5 +112,6 @@ public class UserCoupon extends BaseEntity {
     this.status = UserCouponStatus.ROLLBACK;
     this.reservationUuid = null;
     this.preemptAt = null;
+    this.usedAt = null;
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/domain/repository/UserCouponRepository.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/domain/repository/UserCouponRepository.java
@@ -23,4 +23,6 @@ public interface UserCouponRepository {
       Long userId, LocalDateTime now, Pageable pageable);
 
   <S extends UserCoupon> List<S> saveAll(Iterable<S> userCoupons);
+
+  List<UserCoupon> findByReservationUuid(String reservationUuid);
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/UserCouponKafkaEventListener.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/UserCouponKafkaEventListener.java
@@ -1,0 +1,64 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka;
+
+import static table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.config.UserCouponConsumerConfig.RESERVATION_EVENT;
+import static table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.config.UserCouponConsumerConfig.RESERVATION_EVENT_DLT;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+import table.eat.now.coupon.user_coupon.application.service.UserCouponService;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto.ReservationCancelledEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserCouponKafkaEventListener {
+  private final UserCouponService userCouponService;
+
+  @KafkaListener(
+      topics = RESERVATION_EVENT,
+      containerFactory = "reservationCancelledEventKafkaListenerContainerFactory"
+  )
+  public void listenReservationCanceledEvent(
+      ConsumerRecord<String, ReservationCancelledEvent> record, Acknowledgment ack) {
+    log.info("예약 취소 이벤트 처리: {}", record);
+    try {
+      ReservationCancelledEvent canceledEvent = record.value();
+      userCouponService.cancelUserCoupons(canceledEvent.reservationUuid());
+      throw new RuntimeException("exception test!!!!!");
+      //ack.acknowledge();
+    } catch (Throwable e) {
+      log.warn("예약 취소 이벤트 처리 예외 발생: {}", record.value(), e);
+      throw e;
+    }
+  }
+
+  @KafkaListener(
+      topics = RESERVATION_EVENT_DLT,
+      containerFactory = "reservationCancelledEventDltKafkaListenerContainerFactory"
+  )
+  public void listenReservationCanceledEventDlt(
+      ConsumerRecord<String, ReservationCancelledEvent> record,
+      Acknowledgment ack,
+      @Header(KafkaHeaders.RECEIVED_PARTITION) int partitionId,
+      @Header(KafkaHeaders.OFFSET) Long offset,
+      @Header(value = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String errorMessage) {
+
+    log.info("예약 취소 이벤트 DLT 처리: key: {}, value: {}, partition : {}, offset : {}, errorMessage : {}",
+        record.key(), record.value(), partitionId, offset, errorMessage);
+    try {
+      ReservationCancelledEvent canceledEvent = record.value();
+      userCouponService.cancelUserCoupons(canceledEvent.reservationUuid());
+      ack.acknowledge();
+    } catch (Exception e) {
+      log.error("예약 취소 이벤트 DLT 처리 실패::수동 처리 필요:: "
+          + "key: {}, value: {}, partition : {}, offset : {}, errorMessage : {}",
+          record.key(), record.value(), partitionId, offset, errorMessage);
+    }
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/UserCouponKafkaEventListener.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/UserCouponKafkaEventListener.java
@@ -30,8 +30,7 @@ public class UserCouponKafkaEventListener {
     try {
       ReservationCancelledEvent canceledEvent = record.value();
       userCouponService.cancelUserCoupons(canceledEvent.reservationUuid());
-      throw new RuntimeException("exception test!!!!!");
-      //ack.acknowledge();
+      ack.acknowledge();
     } catch (Throwable e) {
       log.warn("예약 취소 이벤트 처리 예외 발생: {}", record.value(), e);
       throw e;

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/UserCouponKafkaEventListener.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/UserCouponKafkaEventListener.java
@@ -54,10 +54,12 @@ public class UserCouponKafkaEventListener {
       ReservationCancelledEvent canceledEvent = record.value();
       userCouponService.cancelUserCoupons(canceledEvent.reservationUuid());
       ack.acknowledge();
-    } catch (Exception e) {
+    } catch (Throwable e) {
       log.error("예약 취소 이벤트 DLT 처리 실패::수동 처리 필요:: "
           + "key: {}, value: {}, partition : {}, offset : {}, errorMessage : {}",
           record.key(), record.value(), partitionId, offset, errorMessage);
+    } finally {
+      ack.acknowledge();
     }
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/config/UserCouponConsumerConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/config/UserCouponConsumerConfig.java
@@ -55,6 +55,7 @@ public class UserCouponConsumerConfig {
     JsonDeserializer<T> jsonDeserializer = new JsonDeserializer<>(targetType);
     jsonDeserializer.setUseTypeHeaders(false);
     jsonDeserializer.setRemoveTypeHeaders(true);
+    jsonDeserializer.addTrustedPackages("table.eat.now.**");
 
     return new DefaultKafkaConsumerFactory<>(
         props,
@@ -81,6 +82,7 @@ public class UserCouponConsumerConfig {
         new ConcurrentKafkaListenerContainerFactory<>();
     factory.setConsumerFactory(consumerFactory);
     factory.setRecordFilterStrategy(createEventTypeFilter(eventTypeName));
+    factory.setAckDiscarded(true);
     return factory;
   }
 
@@ -128,7 +130,7 @@ public class UserCouponConsumerConfig {
 
   @Bean
   public NewTopic reservationDltTopic() {
-    return TopicBuilder.name("reservation-event-dlt")
+    return TopicBuilder.name(RESERVATION_EVENT_DLT)
         .partitions(3)
         .replicas(1)
         .config("min.insync.replicas", "1")

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/config/UserCouponConsumerConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/config/UserCouponConsumerConfig.java
@@ -1,0 +1,137 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.config;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto.EventType;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto.ReservationCancelledEvent;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto.ReservationEvent;
+
+@Configuration
+public class UserCouponConsumerConfig {
+
+  public final static String USER_COUPON_GROUP_ID = "user-coupon-group";
+  public final static String RESERVATION_EVENT = "reservation-event";
+  public final static String RESERVATION_EVENT_DLT = "reservation-event-dlt";
+
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+  @Value("${spring.kafka.consumer.auto-offset-reset}")
+  private String autoOffsetReset;
+  @Value("${spring.kafka.consumer.enable-auto-commit}")
+  private boolean enableAutoCommit;
+
+  private Map<String, Object> getCommonConsumerProps(String groupId) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
+    return props;
+  }
+
+  private <T> ConsumerFactory<String, T> createConsumerFactory(String groupId, Class<T> targetType) {
+    Map<String, Object> props = getCommonConsumerProps(groupId);
+
+    JsonDeserializer<T> jsonDeserializer = new JsonDeserializer<>(targetType);
+    jsonDeserializer.setUseTypeHeaders(false);
+    jsonDeserializer.setRemoveTypeHeaders(true);
+
+    return new DefaultKafkaConsumerFactory<>(
+        props,
+        new StringDeserializer(),
+        jsonDeserializer
+    );
+  }
+
+  private <T> RecordFilterStrategy<String, T> createEventTypeFilter(String eventTypeName) {
+    return record -> {
+      Header eventTypeHeader = record.headers().lastHeader("eventType");
+      if (eventTypeHeader == null) {
+        return true; // 헤더가 없으면 필터링
+      }
+      String eventTypeValue = new String(eventTypeHeader.value(), StandardCharsets.UTF_8);
+      return !eventTypeValue.equals(eventTypeName); // 지정된 이벤트 타입만 통과
+    };
+  }
+
+  private <T> ConcurrentKafkaListenerContainerFactory<String, T> createContainerFactory(
+      ConsumerFactory<String, T> consumerFactory, String eventTypeName) {
+
+    ConcurrentKafkaListenerContainerFactory<String, T> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(consumerFactory);
+    factory.setRecordFilterStrategy(createEventTypeFilter(eventTypeName));
+    return factory;
+  }
+
+  private <T> DefaultErrorHandler getDefaultErrorHandler(
+      KafkaTemplate<String, T> kafkaTemplate, String topicName) {
+
+    DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+        kafkaTemplate,
+        (record, ex) ->
+            new TopicPartition(topicName, record.partition()));
+
+    return new DefaultErrorHandler(
+        recoverer,
+        new FixedBackOff(1000L, 3));
+  }
+
+  @Bean
+  public ConsumerFactory<String, ReservationCancelledEvent> reservationCancelledEventConsumerFactory() {
+    return createConsumerFactory(USER_COUPON_GROUP_ID, ReservationCancelledEvent.class);
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, ReservationCancelledEvent>
+  reservationCancelledEventKafkaListenerContainerFactory(KafkaTemplate<String, ReservationEvent> kafkaTemplate) {
+    ConcurrentKafkaListenerContainerFactory<String, ReservationCancelledEvent> factory =
+        createContainerFactory(
+            reservationCancelledEventConsumerFactory(), EventType.RESERVATION_CANCELLED.toString());
+
+    DefaultErrorHandler errorHandler = getDefaultErrorHandler(kafkaTemplate, RESERVATION_EVENT_DLT);
+
+    factory.setCommonErrorHandler(errorHandler);
+    factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+    return factory;
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, ReservationCancelledEvent>
+  reservationCancelledEventDltKafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, ReservationCancelledEvent> factory =
+        createContainerFactory(
+            reservationCancelledEventConsumerFactory(), EventType.RESERVATION_CANCELLED.toString());
+    factory.getContainerProperties().setAckMode(AckMode.MANUAL);
+    return factory;
+  }
+
+  @Bean
+  public NewTopic reservationDltTopic() {
+    return TopicBuilder.name("reservation-event-dlt")
+        .partitions(3)
+        .replicas(1)
+        .config("min.insync.replicas", "1")
+        .build();
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/config/UserCouponProducerConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/config/UserCouponProducerConfig.java
@@ -1,0 +1,41 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto.ReservationEvent;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.interceptor.EventTypeHeaderInterceptor;
+
+@Configuration
+public class UserCouponProducerConfig {
+
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  @Bean
+  public ProducerFactory<String, ReservationEvent> producerFactory() {
+
+    Map<String, Object> props = new HashMap<>();
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG, "all");
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.RETRIES_CONFIG, 3);
+    props.put(org.apache.kafka.clients.producer.ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, EventTypeHeaderInterceptor.class.getName());
+
+    return new DefaultKafkaProducerFactory<>(props);
+  }
+
+  @Bean
+  public KafkaTemplate<String, ReservationEvent> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/EventType.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/EventType.java
@@ -1,0 +1,6 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto;
+
+public enum EventType {
+  RESERVATION_CANCELLED,
+  ;
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/KafkaCommonEvent.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/KafkaCommonEvent.java
@@ -1,0 +1,7 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto;
+
+public interface KafkaCommonEvent {
+
+  EventType eventType();
+
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/ReservationCancelledEvent.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/ReservationCancelledEvent.java
@@ -1,0 +1,14 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto;
+
+public record ReservationCancelledEvent(
+    EventType eventType,
+    String reservationUuid,
+    ReservationCancelledPayload payload
+
+) implements ReservationEvent {
+
+  public static ReservationCancelledEvent from(ReservationCancelledPayload payload){
+    return new ReservationCancelledEvent(EventType.RESERVATION_CANCELLED, payload.reservationUuid(), payload);
+  }
+
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/ReservationCancelledPayload.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/ReservationCancelledPayload.java
@@ -1,0 +1,32 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ReservationCancelledPayload(
+    String reservationUuid,
+
+    // 결제
+    String paymentIdempotencyKey,
+    BigDecimal cancelAmount, // 결제 취소 금액
+    String cancelReason, // 최대 200자
+
+    // 식당
+    String restaurantUuid,
+    Integer guestCount,
+
+    // 쿠폰
+    List<String> couponUuids,
+
+    // 유저
+    Long reserverId,
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    LocalDateTime processedAt
+) {
+
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/ReservationEvent.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/dto/ReservationEvent.java
@@ -1,0 +1,6 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto;
+
+public interface ReservationEvent extends KafkaCommonEvent {
+
+  String reservationUuid();
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/interceptor/EventTypeHeaderInterceptor.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/kafka/interceptor/EventTypeHeaderInterceptor.java
@@ -1,0 +1,37 @@
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.interceptor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.dto.KafkaCommonEvent;
+
+public class EventTypeHeaderInterceptor implements ProducerInterceptor<String, KafkaCommonEvent> {
+
+  private static final String EVENT_TYPE_HEADER = "eventType";
+
+  @Override
+  public ProducerRecord<String, KafkaCommonEvent> onSend(ProducerRecord<String, KafkaCommonEvent> record) {
+    KafkaCommonEvent event = record.value();
+    if (event == null || event.eventType() == null) {
+      return record;
+    }
+    record
+        .headers()
+        .add(EVENT_TYPE_HEADER, event.eventType().name().getBytes(StandardCharsets.UTF_8));
+    return record;
+  }
+
+  @Override
+  public void onAcknowledgement(RecordMetadata recordMetadata, Exception e) {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/spring/UserCouponSpringEventListener.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/spring/UserCouponSpringEventListener.java
@@ -1,4 +1,4 @@
-package table.eat.now.coupon.user_coupon.application.listener;
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.spring;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +11,7 @@ import table.eat.now.coupon.user_coupon.application.service.UserCouponService;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class UserCouponEventListener {
+public class UserCouponSpringEventListener {
   private final UserCouponService userCouponService;
 
   @Async("async-listener")

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/spring/config/AsyncConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/spring/config/AsyncConfig.java
@@ -1,4 +1,4 @@
-package table.eat.now.coupon.user_coupon.application.listener.config;
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.spring.config;
 
 import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/spring/config/AsyncEventListenerExceptionHandler.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/messaging/spring/config/AsyncEventListenerExceptionHandler.java
@@ -1,4 +1,4 @@
-package table.eat.now.coupon.user_coupon.application.listener.config;
+package table.eat.now.coupon.user_coupon.infrastructure.messaging.spring.config;
 
 import java.lang.reflect.Method;
 import lombok.extern.slf4j.Slf4j;

--- a/coupon/src/main/resources/application.yml
+++ b/coupon/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
       - classpath:properties/redis.yml
       - classpath:properties/cloud.yml
       - classpath:properties/zipkin.yml
+      - classpath:properties/kafka.yml
   profiles:
     group:
       local: local

--- a/coupon/src/main/resources/properties/kafka.yml
+++ b/coupon/src/main/resources/properties/kafka.yml
@@ -1,0 +1,24 @@
+spring:
+  config.activate.on-profile: local
+  kafka:
+    bootstrap-servers: ${LOCAL_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+
+---
+spring:
+  config.activate.on-profile: test
+  kafka:
+    bootstrap-servers: ${LOCAL_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+---
+spring:
+  config.activate.on-profile: develop
+  kafka:
+    bootstrap-servers: ${DEV_KAFKA_BOOTSTRAP_SERVERS}
+    consumer:
+      auto-offset-reset: earliest
+      enable-auto-commit: false

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/application/service/CouponServiceImplTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/application/service/CouponServiceImplTest.java
@@ -42,7 +42,7 @@ import table.eat.now.coupon.coupon.domain.entity.Coupon;
 import table.eat.now.coupon.coupon.domain.repository.CouponRepository;
 import table.eat.now.coupon.coupon.fixture.CouponFixture;
 import table.eat.now.coupon.helper.IntegrationTestSupport;
-import table.eat.now.coupon.user_coupon.application.listener.UserCouponEventListener;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.spring.UserCouponSpringEventListener;
 
 @RecordApplicationEvents
 class CouponServiceImplTest extends IntegrationTestSupport {
@@ -57,7 +57,7 @@ class CouponServiceImplTest extends IntegrationTestSupport {
   ApplicationEvents applicationEvents;
 
   @MockitoBean
-  UserCouponEventListener userCouponEventListener;
+  UserCouponSpringEventListener userCouponSpringEventListener;
 
   private List<Coupon> coupons;
 
@@ -259,6 +259,6 @@ class CouponServiceImplTest extends IntegrationTestSupport {
     // 이벤트 발행이 잘 되었는지 확인
     assertThat(applicationEvents.stream(IssueUserCouponEvent.class).count()).isEqualTo(1);
     ArgumentCaptor<IssueUserCouponEvent> captor = ArgumentCaptor.forClass(IssueUserCouponEvent.class);
-    verify(userCouponEventListener).listenIssueUserCouponEvent(captor.capture());
+    verify(userCouponSpringEventListener).listenIssueUserCouponEvent(captor.capture());
   }
 }

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/listener/UserCouponKafkaEventListenerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/listener/UserCouponKafkaEventListenerTest.java
@@ -15,13 +15,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import table.eat.now.coupon.coupon.application.dto.event.IssueUserCouponEvent;
 import table.eat.now.coupon.user_coupon.application.service.UserCouponService;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.spring.UserCouponSpringEventListener;
 
 @ExtendWith(SpringExtension.class)
-@Import({UserCouponEventListener.class})
-class UserCouponEventListenerTest {
+@Import({UserCouponSpringEventListener.class})
+class UserCouponKafkaEventListenerTest {
 
   @Autowired
-  private UserCouponEventListener userCouponEventListener;
+  private UserCouponSpringEventListener userCouponEventListener;
 
   @MockitoBean
   private UserCouponService userCouponService;

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/listener/UserCouponSpringEventListenerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/listener/UserCouponSpringEventListenerTest.java
@@ -19,10 +19,10 @@ import table.eat.now.coupon.user_coupon.infrastructure.messaging.spring.UserCoup
 
 @ExtendWith(SpringExtension.class)
 @Import({UserCouponSpringEventListener.class})
-class UserCouponKafkaEventListenerTest {
+class UserCouponSpringEventListenerTest {
 
   @Autowired
-  private UserCouponSpringEventListener userCouponEventListener;
+  private UserCouponSpringEventListener userCouponSpringEventListener;
 
   @MockitoBean
   private UserCouponService userCouponService;
@@ -48,7 +48,7 @@ class UserCouponKafkaEventListenerTest {
     doNothing().when(userCouponService).createUserCoupon(issueUserCouponEvent.toCommand());
 
     // when
-    userCouponEventListener.listenIssueUserCouponEvent(issueUserCouponEvent);
+    userCouponSpringEventListener.listenIssueUserCouponEvent(issueUserCouponEvent);
 
     // then
     verify(userCouponService).createUserCoupon(issueUserCouponEvent.toCommand());


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #173

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 예약 취소 이벤트 처리 구현
  - [x] 데드레터큐 간단 구현

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 예약 취소 시 관련 사용자 쿠폰을 자동으로 취소 및 해제하는 기능이 추가되었습니다.
    - Kafka 기반 예약 취소 이벤트 수신 및 DLT(Dead Letter Topic) 처리 기능이 도입되었습니다.
- **설정**
    - Kafka 관련 환경설정 파일이 추가되고, Spring 설정에 통합되었습니다.
- **버그 수정**
    - 쿠폰 해제 시 사용 일시가 함께 초기화되어 쿠폰 상태가 명확하게 반영됩니다.
- **테스트**
    - 예약 취소에 따른 사용자 쿠폰 취소 동작을 검증하는 테스트가 추가되었습니다.
- **리팩터**
    - 일부 클래스 및 패키지명이 변경되어 구조가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->