### PR TITLE
[promotion] 프로모션 -> 쿠폰 이벤트 발행 단건으로 수정

### DIFF
--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/produce/PromotionUserCouponSaveEvent.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/produce/PromotionUserCouponSaveEvent.java
@@ -1,26 +1,27 @@
 package table.eat.now.promotion.promotion.application.event.produce;
 
 
-
-import java.util.List;
 import lombok.Builder;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.promotion.promotion.application.event.EventType;
 import table.eat.now.promotion.promotion.application.event.PromotionEvent;
+import table.eat.now.promotion.promotion.domain.entity.Promotion;
+
 @Builder
 public record PromotionUserCouponSaveEvent(
     EventType eventType,
-    List<PromotionUserSavePayload> payloads,
+    PromotionUserSavePayload payloads,
     CurrentUserInfoDto userInfo,
     String couponUuid
 ) implements PromotionEvent {
 
-  public static PromotionUserCouponSaveEvent of(PromotionUserSaveEvent event, String couponUuid) {
+  public static PromotionUserCouponSaveEvent of(Promotion promotion, CurrentUserInfoDto userInfo) {
     return PromotionUserCouponSaveEvent.builder()
-        .eventType(event.eventType())
-        .payloads(event.payloads())
-        .userInfo(event.userInfo())
-        .couponUuid(couponUuid)
+        .eventType(EventType.SUCCEED)
+        .payloads(PromotionUserSavePayload.from(promotion.getId(), promotion.getCouponUuid()))
+        .userInfo(userInfo)
+        .couponUuid(promotion.getCouponUuid())
         .build();
   }
+
 }

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/produce/PromotionUserCouponSaveEvent.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/produce/PromotionUserCouponSaveEvent.java
@@ -10,7 +10,7 @@ import table.eat.now.promotion.promotion.domain.entity.Promotion;
 @Builder
 public record PromotionUserCouponSaveEvent(
     EventType eventType,
-    PromotionUserSavePayload payloads,
+    PromotionUserSavePayload payload,
     CurrentUserInfoDto userInfo,
     String couponUuid
 ) implements PromotionEvent {
@@ -18,7 +18,7 @@ public record PromotionUserCouponSaveEvent(
   public static PromotionUserCouponSaveEvent of(Promotion promotion, CurrentUserInfoDto userInfo) {
     return PromotionUserCouponSaveEvent.builder()
         .eventType(EventType.SUCCEED)
-        .payloads(PromotionUserSavePayload.from(promotion.getId(), promotion.getCouponUuid()))
+        .payload(PromotionUserSavePayload.from(promotion.getId(), promotion.getCouponUuid()))
         .userInfo(userInfo)
         .couponUuid(promotion.getCouponUuid())
         .build();

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/produce/PromotionUserSavePayload.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/event/produce/PromotionUserSavePayload.java
@@ -14,4 +14,10 @@ public record PromotionUserSavePayload(
         .promotionUuid(dto.promotionUuid())
         .build();
   }
+  public static PromotionUserSavePayload from(Long userId, String promotionUuid) {
+    return PromotionUserSavePayload.builder()
+        .userId(userId)
+        .promotionUuid(promotionUuid)
+        .build();
+  }
 }

--- a/promotion/src/main/java/table/eat/now/promotion/promotion/application/service/PromotionServiceImpl.java
+++ b/promotion/src/main/java/table/eat/now/promotion/promotion/application/service/PromotionServiceImpl.java
@@ -157,12 +157,11 @@ public class PromotionServiceImpl implements PromotionService{
           savePayloadList, createCurrentUserInfoDto());
 
       promotionEventPublisher.publish(promotionUserSaveEvent);
-
-      Promotion promotion = findByPromotion(info.promotionUuid());
-
-      promotionEventPublisher.publish(PromotionUserCouponSaveEvent.of(
-          promotionUserSaveEvent, promotion.getCouponUuid()));
     }
+    Promotion promotion = findByPromotion(info.promotionUuid());
+
+    promotionEventPublisher.publish(PromotionUserCouponSaveEvent.of(
+        promotion, createCurrentUserInfoDto()));
     return true;
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #172 

## 변경 타입
- [x] 리팩토링


## 변경 내용
- **as-is**
  - promotion -> coupon 발행 이벤트가 list형태 였음

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 프로모션 -> 쿠폰 이벤트 발행 단건으로 수정

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.


## 코멘트
- 확인 해주시구 이상한 거 있음 말씀해 주세요!!! 아직 이벤트 타입을 못 정했습니다ㅠ 하온님이 만드시면 그거 보고 따라갈게요! 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 쿠폰 저장 이벤트 처리 방식이 개선되어 이벤트 발행 시 불필요한 중복 데이터가 제거되었습니다.

- **리팩터링**
  - 이벤트 생성 및 발행 로직이 간소화되어 코드의 일관성과 유지보수성이 향상되었습니다.

- **테스트**
  - 이벤트 발행 검증 방식이 명확하게 개선되어 테스트 신뢰성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->