### PR TITLE
[review] 레스토랑 평점 업데이트 카프카 배치로 처리, 단건 모아서 보내기

### DIFF
--- a/review/src/main/java/table/eat/now/review/application/event/EventType.java
+++ b/review/src/main/java/table/eat/now/review/application/event/EventType.java
@@ -1,5 +1,5 @@
 package table.eat.now.review.application.event;
 
 public enum EventType {
-  RATING_UPDATE
+  RATING_UPDATED
 }

--- a/review/src/main/java/table/eat/now/review/application/event/RestaurantRatingUpdateEvent.java
+++ b/review/src/main/java/table/eat/now/review/application/event/RestaurantRatingUpdateEvent.java
@@ -2,8 +2,6 @@ package table.eat.now.review.application.event;
 
 import static table.eat.now.review.application.event.EventType.RATING_UPDATED;
 
-import java.util.UUID;
-
 public record RestaurantRatingUpdateEvent(
     EventType eventType,
     String restaurantUuid,
@@ -13,7 +11,7 @@ public record RestaurantRatingUpdateEvent(
   public static RestaurantRatingUpdateEvent of(RestaurantRatingUpdatePayload payload) {
     return new RestaurantRatingUpdateEvent(
         RATING_UPDATED,
-        UUID.randomUUID().toString(),
+        payload.restaurantUuid(),
         payload
     );
   }

--- a/review/src/main/java/table/eat/now/review/application/event/RestaurantRatingUpdateEvent.java
+++ b/review/src/main/java/table/eat/now/review/application/event/RestaurantRatingUpdateEvent.java
@@ -1,20 +1,21 @@
 package table.eat.now.review.application.event;
 
-import static table.eat.now.review.application.event.EventType.RATING_UPDATE;
+import static table.eat.now.review.application.event.EventType.RATING_UPDATED;
 
 import java.util.UUID;
 
 public record RestaurantRatingUpdateEvent(
     EventType eventType,
-    String eventId,
+    String restaurantUuid,
     RestaurantRatingUpdatePayload payload
 ) implements ReviewEvent {
 
   public static RestaurantRatingUpdateEvent of(RestaurantRatingUpdatePayload payload) {
     return new RestaurantRatingUpdateEvent(
-        RATING_UPDATE,
+        RATING_UPDATED,
         UUID.randomUUID().toString(),
-        payload);
+        payload
+    );
   }
 }
 

--- a/review/src/main/java/table/eat/now/review/application/event/RestaurantRatingUpdatePayload.java
+++ b/review/src/main/java/table/eat/now/review/application/event/RestaurantRatingUpdatePayload.java
@@ -1,20 +1,20 @@
 package table.eat.now.review.application.event;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 import table.eat.now.review.domain.repository.search.RestaurantRatingResult;
 
 public record RestaurantRatingUpdatePayload(
-    List<RestaurantRatingResult> ratingUpdates,
-    int updateCount,
+    String restaurantUuid,
+    BigDecimal averageRating,
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     LocalDateTime processedAt
 ) {
-  public static RestaurantRatingUpdatePayload from(List<RestaurantRatingResult> ratingUpdates) {
+  public static RestaurantRatingUpdatePayload from(RestaurantRatingResult ratingUpdates) {
     return new RestaurantRatingUpdatePayload(
-        ratingUpdates,
-        ratingUpdates != null ? ratingUpdates.size() : 0,
+        ratingUpdates.restaurantUuid(),
+        ratingUpdates.averageRating(),
         LocalDateTime.now()
     );
   }

--- a/review/src/main/java/table/eat/now/review/application/event/ReviewEvent.java
+++ b/review/src/main/java/table/eat/now/review/application/event/ReviewEvent.java
@@ -2,5 +2,5 @@ package table.eat.now.review.application.event;
 
 public interface ReviewEvent {
   EventType eventType();
-  String eventId();
+  String restaurantUuid();
 }

--- a/review/src/main/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCase.java
+++ b/review/src/main/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCase.java
@@ -130,9 +130,13 @@ public class UpdateRestaurantRatingUseCase {
     private void calculateAndPublishRatings(List<String> restaurantIds) {
       List<RestaurantRatingResult> results =
           reviewRepository.calculateRestaurantRatings(restaurantIds);
+
       if (!results.isEmpty()) {
-        reviewEventPublisher.publish(
-            RestaurantRatingUpdateEvent.of(RestaurantRatingUpdatePayload.from(results)));
+        results.forEach(result -> reviewEventPublisher.publish(
+            RestaurantRatingUpdateEvent.of(
+                RestaurantRatingUpdatePayload.from(result)
+            )
+        ));
         logPublish(results);
       }
     }

--- a/review/src/main/java/table/eat/now/review/domain/repository/search/RestaurantRatingResult.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/search/RestaurantRatingResult.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 public record RestaurantRatingResult(
-    String restaurantId,
+    String restaurantUuid,
     BigDecimal averageRating
 ) {
 

--- a/review/src/main/java/table/eat/now/review/infrastructure/kafka/KafkaReviewProducer.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/kafka/KafkaReviewProducer.java
@@ -13,12 +13,12 @@ import table.eat.now.review.application.event.ReviewEventPublisher;
 @RequiredArgsConstructor
 public class KafkaReviewProducer implements ReviewEventPublisher {
 
-  private final KafkaTemplate<String, ReviewEvent> kafkaTemplate;
+  private final KafkaTemplate<String, ReviewEvent> batchKafkaTemplate;
   private final String reviewTopic;
 
   @Override
   public void publish(RestaurantRatingUpdateEvent ratingUpdateEvent) {
-    kafkaTemplate.send(reviewTopic, ratingUpdateEvent.eventId() ,ratingUpdateEvent);
+    batchKafkaTemplate.send(reviewTopic, ratingUpdateEvent.restaurantUuid() ,ratingUpdateEvent);
     logEvent(ratingUpdateEvent);
   }
 

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -137,7 +137,7 @@ class UpdateRestaurantRatingUseCaseTest {
       verify(reviewRepository, times(3))
           .calculateRestaurantRatings(anyList());
 
-      verify(reviewEventPublisher, times(3))
+      verify(reviewEventPublisher, times(7))
           .publish(any(RestaurantRatingUpdateEvent.class));
     }
 
@@ -240,7 +240,7 @@ class UpdateRestaurantRatingUseCaseTest {
       verify(reviewRepository).calculateRestaurantRatings(eq(Collections.singletonList("4")));
       verify(reviewRepository, times(2)).calculateRestaurantRatings(anyList());
 
-      verify(reviewEventPublisher, times(2))
+      verify(reviewEventPublisher, times(4))
           .publish(any(RestaurantRatingUpdateEvent.class));
     }
 
@@ -322,7 +322,7 @@ class UpdateRestaurantRatingUseCaseTest {
       verify(reviewRepository, times(1))
           .calculateRestaurantRatings(anyList());
 
-      verify(reviewEventPublisher, times(1))
+      verify(reviewEventPublisher, times(3))
           .publish(any(RestaurantRatingUpdateEvent.class));
     }
   }

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -3,13 +3,13 @@ server:
 
 spring:
   config:
-    import: optional:file:.env[.properties]
+    import: optional:file:.env.user[.properties]
   application:
     name: user
   datasource:
-    url: ${USER_DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
@@ -28,7 +28,7 @@ eureka:
   instance:
     prefer-ip-address: true
 
-JWT:
-  SECRET: ${JWT_SECRET}
-  ACCESS:
-    EXPIRATION: ${JWT_ACCESS_EXPIRATION}
+jwt:
+  secret: ${JWT_SECRET}
+  access:
+    expiration: ${JWT_ACCESS_EXPIRATION}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #176 

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용
- **as-is**
  - 이벤트 페이로드 리스트, 한번의 이벤트로 업데이트 처리

- **to-be**(변경 후 설명을 여기에 작성)
  - 단건 이벤트 카프카 배치로 처리 (0.1초마다 모아서 처리, 또는 약250건의 이벤트 모아서처리)

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.

## 코멘트
<img width="1359" alt="스크린샷 2025-04-22 오전 1 41 39" src="https://github.com/user-attachments/assets/415ef19b-f001-4156-9296-c37000aeabe7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 레스토랑 평점 업데이트 이벤트가 개별 레스토랑 단위로 발행됩니다.

- **버그 수정**
    - 레스토랑 식별자가 restaurantId에서 restaurantUuid로 일관성 있게 변경되었습니다.

- **리팩터링**
    - 이벤트 및 페이로드 구조가 단순화되고, 관련 메서드 및 필드명이 명확하게 개선되었습니다.
    - Kafka 프로듀서 구성에 배치 전용 템플릿이 추가되어 성능이 향상되었습니다.

- **테스트**
    - 이벤트 발행 횟수에 대한 테스트 케이스가 실제 동작에 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->