### PR TITLE
[review] 스케줄러 분산락 설정

### DIFF
--- a/review/build.gradle
+++ b/review/build.gradle
@@ -62,6 +62,8 @@ dependencies {
 	//KAFKA
 	implementation 'org.springframework.kafka:spring-kafka'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
+	//REDISSON
+	implementation 'org.redisson:redisson:3.45.0'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/review/build.gradle
+++ b/review/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/review/src/main/java/table/eat/now/review/application/helper/LockExecutor.java
+++ b/review/src/main/java/table/eat/now/review/application/helper/LockExecutor.java
@@ -1,0 +1,6 @@
+package table.eat.now.review.application.helper;
+
+public interface LockExecutor {
+
+  void execute(String key, Runnable task);
+}

--- a/review/src/main/java/table/eat/now/review/infrastructure/redis/DistributedLockExecutor.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/redis/DistributedLockExecutor.java
@@ -1,0 +1,96 @@
+package table.eat.now.review.infrastructure.redis;
+
+import java.util.concurrent.TimeUnit;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import table.eat.now.review.application.helper.LockExecutor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DistributedLockExecutor implements LockExecutor {
+
+  private final RedissonClient redissonClient;
+
+  @Value("${distributed-lock.wait-time}")
+  private long defaultWaitTime;
+  @Value("${distributed-lock.lease-time}")
+  private long defaultLeaseTime;
+  @Value("${distributed-lock.time-unit}")
+  private TimeUnit defaultTimeUnit;
+
+  @Override
+  public void execute(String lockKey, Runnable task) {
+    tryLock(
+        LockExecutionContext.builder()
+            .lock(getLock(lockKey))
+            .key(lockKey)
+            .waitTime(defaultWaitTime)
+            .leaseTime(defaultLeaseTime)
+            .timeUnit(defaultTimeUnit)
+            .task(task)
+            .build()
+    );
+  }
+
+  private RLock getLock(String lockKey) {
+    return redissonClient.getLock(lockKey);
+  }
+
+  private void tryLock(LockExecutionContext ctx) {
+    boolean isLocked = false;
+
+    try {
+      isLocked = ctx.lock()
+          .tryLock(ctx.waitTime(), ctx.leaseTime(), ctx.timeUnit());
+
+      if (!isLocked) {
+        log.info("락 획득 실패. key={}", ctx.key());
+        return;
+      }
+      log.info("락 획득 성공");
+      ctx.task().run();
+
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.error("락 획득 중 인터럽트 발생. key={}", ctx.key(), e);
+
+    } catch (Exception e) {
+      log.error("락 실행 중 예외 발생. key={}", ctx.key(), e);
+
+    } finally {
+      unlockSafely(ctx.lock(), ctx.key(), isLocked);
+    }
+  }
+
+  private void unlockSafely(RLock lock, String lockKey, boolean isLocked) {
+    if (!isLocked) {
+      return;
+    }
+    try {
+      lock.unlock();
+    } catch (IllegalMonitorStateException e) {
+      log.warn("이미 해제된 락. key={}", lockKey);
+    } catch (Exception e) {
+      log.error("락 해제 중 예외 발생. key={}", lockKey, e);
+    }
+  }
+
+  @Builder
+  private record LockExecutionContext(
+      RLock lock,
+      String key,
+      long waitTime,
+      long leaseTime,
+      TimeUnit timeUnit,
+      Runnable task
+  ) {
+
+  }
+}
+

--- a/review/src/main/java/table/eat/now/review/infrastructure/redis/config/RedissonConfig.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/redis/config/RedissonConfig.java
@@ -1,0 +1,28 @@
+package table.eat.now.review.infrastructure.redis.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+  private static final String REDISSON_HOST_PREFIX = "redis://";
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.data.redis.port}")
+  private int redisPort;
+
+  @Bean(destroyMethod = "shutdown")
+  public RedissonClient redissonClient() {
+    Config config = new Config();
+    config.useSingleServer()
+        .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+    return Redisson.create(config);
+  }
+}

--- a/review/src/main/java/table/eat/now/review/infrastructure/redis/config/RedissonConfig.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/redis/config/RedissonConfig.java
@@ -18,11 +18,21 @@ public class RedissonConfig {
   @Value("${spring.data.redis.port}")
   private int redisPort;
 
+  @Value("${spring.data.redis.username:}")
+  private String redisUsername;
+
+  @Value("${spring.data.redis.password:}")
+  private String redisPassword;
+
   @Bean(destroyMethod = "shutdown")
   public RedissonClient redissonClient() {
     Config config = new Config();
     config.useSingleServer()
-        .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort)
+            .setUsername(redisUsername)
+            .setPassword(redisPassword)
+            .setConnectTimeout(5000)
+            .setIdleConnectionTimeout(10000);
     return Redisson.create(config);
   }
 }

--- a/review/src/main/resources/application.yml
+++ b/review/src/main/resources/application.yml
@@ -17,6 +17,12 @@ spring:
         format_sql: true
   kafka:
     bootstrap-servers: ${LOCAL_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+  data:
+    redis:
+      host: localhost
+      port: 6380
+      username: default
+#      password: systempass
 
 kafka-config:
   topic:
@@ -38,3 +44,8 @@ review:
       cron: 0 */5 * * * *
       batch-size: 100
       recent-minutes: 5
+
+distributed-lock:
+  wait-time: 0
+  lease-time: 3
+  time-unit: MINUTES

--- a/review/src/test/java/table/eat/now/review/application/scheduler/ReviewSchedulerTest.java
+++ b/review/src/test/java/table/eat/now/review/application/scheduler/ReviewSchedulerTest.java
@@ -1,16 +1,20 @@
 package table.eat.now.review.application.scheduler;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import table.eat.now.review.application.helper.LockExecutor;
 import table.eat.now.review.application.usecase.UpdateRestaurantRatingUseCase;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,6 +23,9 @@ class ReviewSchedulerTest {
   @Mock
   private UpdateRestaurantRatingUseCase updateRestaurantRatingUseCase;
 
+  @Mock
+  private LockExecutor lockExecutor;
+
   @InjectMocks
   private ReviewScheduler reviewScheduler;
 
@@ -26,26 +33,55 @@ class ReviewSchedulerTest {
   class updateRestaurantRatings_는 {
 
     @Test
-    void execute_메서드를_호출할_수_있다() {
+    void LockExecutor를_통해_락이_실행된다() {
       // when
       reviewScheduler.updateRestaurantRatings();
 
       // then
-      verify(updateRestaurantRatingUseCase, times(1)).execute();
+      verify(lockExecutor, times(1)).execute(any(), any());
     }
 
     @Test
-    void 예외가_발생해도_정상적으로_동작한다() {
+    void 전달된_Runnable이_실제로_usecase를_호출한다() {
       // given
-      doThrow(new RuntimeException("Test exception"))
-          .when(updateRestaurantRatingUseCase).execute();
+      // 람다에서 지역 변수는 final 또는 effectively final 이어야 하기때문에 AtomicBoolean
+      AtomicBoolean taskExecuted = new AtomicBoolean(false);
+
+      doAnswer(invocation -> {
+        // 두 번째 인자 (task)
+        Runnable runnable = invocation.getArgument(1);
+        // task.execute() 호출
+        runnable.run();
+        // 실행 확인을 위한 플래그 (실행시 true)
+        taskExecuted.set(true);
+        // execute 의 return 값
+        return null;
+      }).when(lockExecutor).execute(any(), any());
 
       // when
       reviewScheduler.updateRestaurantRatings();
 
       // then
       verify(updateRestaurantRatingUseCase, times(1)).execute();
+      assert taskExecuted.get();
+    }
+
+    @Test
+    void task_내부_예외가_발생해도_스케줄러는_중단되지_않는다() {
+      // given
+      doAnswer(invocation -> {
+        Runnable task = invocation.getArgument(1);
+        task.run();
+        return null;
+      }).when(lockExecutor).execute(any(), any());
+
+      doThrow(new RuntimeException("UseCase 내부 예외"))
+          .when(updateRestaurantRatingUseCase).execute();
+
+      // when & then
       assertDoesNotThrow(() -> reviewScheduler.updateRestaurantRatings());
+      verify(lockExecutor, times(1)).execute(any(), any());
+      verify(updateRestaurantRatingUseCase, times(1)).execute();
     }
   }
 }

--- a/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
+++ b/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
@@ -17,34 +17,29 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.transaction.annotation.Transactional;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.review.application.client.ReservationClient;
 import table.eat.now.review.application.client.RestaurantClient;
 import table.eat.now.review.application.client.WaitingClient;
+import table.eat.now.review.application.client.dto.GetRestaurantInfo;
+import table.eat.now.review.application.client.dto.GetRestaurantStaffInfo;
+import table.eat.now.review.application.client.dto.GetServiceInfo;
 import table.eat.now.review.application.service.dto.request.CreateReviewCommand;
 import table.eat.now.review.application.service.dto.request.SearchAdminReviewQuery;
 import table.eat.now.review.application.service.dto.request.SearchReviewQuery;
 import table.eat.now.review.application.service.dto.request.UpdateReviewCommand;
 import table.eat.now.review.application.service.dto.response.CreateReviewInfo;
-import table.eat.now.review.application.client.dto.GetRestaurantInfo;
-import table.eat.now.review.application.client.dto.GetRestaurantStaffInfo;
 import table.eat.now.review.application.service.dto.response.GetReviewInfo;
-import table.eat.now.review.application.client.dto.GetServiceInfo;
 import table.eat.now.review.application.service.dto.response.PaginatedInfo;
 import table.eat.now.review.application.service.dto.response.SearchAdminReviewInfo;
 import table.eat.now.review.application.service.dto.response.SearchReviewInfo;
 import table.eat.now.review.domain.entity.Review;
 import table.eat.now.review.domain.repository.ReviewRepository;
+import table.eat.now.review.helper.IntegrationTestSupport;
 
-@SpringBootTest
-@Transactional
-@ActiveProfiles("test")
-class ReviewServiceImplTest {
+class ReviewServiceImplTest extends IntegrationTestSupport {
 
   @Autowired
   private ReviewService reviewService;

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -19,21 +19,18 @@ import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.review.application.event.RestaurantRatingUpdateEvent;
 import table.eat.now.review.application.event.ReviewEventPublisher;
 import table.eat.now.review.domain.repository.ReviewRepository;
 import table.eat.now.review.domain.repository.search.RestaurantRatingResult;
+import table.eat.now.review.helper.IntegrationTestSupport;
 
-@SpringBootTest
-@ActiveProfiles("test")
 @TestPropertySource(properties = {
     "review.rating.update.batch-size=3"
 })
-class UpdateRestaurantRatingUseCaseTest {
+class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
 
   @MockitoBean
   private ReviewRepository reviewRepository;

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -167,7 +167,7 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
 
       doThrow(new RuntimeException("테스트 예외"))
           .when(reviewEventPublisher).publish(any(RestaurantRatingUpdateEvent.class));
-      when(reviewRepository.calculateRestaurantRatings(eq(batch2)))
+      when(reviewRepository.calculateRestaurantRatings(batch2))
           .thenReturn(result2);
 
       // when
@@ -219,9 +219,9 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
           any(LocalDateTime.class), any(LocalDateTime.class), eq(5L), eq(batchSize)))
           .thenReturn(Collections.emptyList());
 
-      when(reviewRepository.calculateRestaurantRatings(eq(Arrays.asList("1", "2", "3"))))
+      when(reviewRepository.calculateRestaurantRatings(Arrays.asList("1", "2", "3")))
           .thenReturn(result1);
-      when(reviewRepository.calculateRestaurantRatings(eq(Collections.singletonList("4"))))
+      when(reviewRepository.calculateRestaurantRatings(Collections.singletonList("4")))
           .thenReturn(result2);
 
       // when
@@ -235,8 +235,8 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
           .findRecentlyUpdatedRestaurantIds(
               any(LocalDateTime.class), any(LocalDateTime.class), anyLong(), eq(batchSize));
 
-      verify(reviewRepository).calculateRestaurantRatings(eq(Arrays.asList("1", "2", "3")));
-      verify(reviewRepository).calculateRestaurantRatings(eq(Collections.singletonList("4")));
+      verify(reviewRepository).calculateRestaurantRatings(Arrays.asList("1", "2", "3"));
+      verify(reviewRepository).calculateRestaurantRatings(Collections.singletonList("4"));
       verify(reviewRepository, times(2)).calculateRestaurantRatings(anyList());
 
       verify(reviewEventPublisher, times(4))

--- a/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
+++ b/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
@@ -1,0 +1,14 @@
+package table.eat.now.review.helper;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(RedisTestContainerExtension.class)
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+public abstract class IntegrationTestSupport {
+
+}

--- a/review/src/test/java/table/eat/now/review/helper/RedisTestContainerExtension.java
+++ b/review/src/test/java/table/eat/now/review/helper/RedisTestContainerExtension.java
@@ -1,0 +1,24 @@
+package table.eat.now.review.helper;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class RedisTestContainerExtension implements BeforeAllCallback {
+
+  private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
+  private static final int REDIS_PORT = 6379;
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    GenericContainer<?> REDIS_CONTAINER =
+        new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
+            .withExposedPorts(REDIS_PORT);
+    //.withCommand("redis-server --requirepass systempass");
+    REDIS_CONTAINER.start();
+
+    System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+    System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+  }
+}

--- a/review/src/test/java/table/eat/now/review/helper/RedisTestContainerExtension.java
+++ b/review/src/test/java/table/eat/now/review/helper/RedisTestContainerExtension.java
@@ -12,13 +12,12 @@ public class RedisTestContainerExtension implements BeforeAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    GenericContainer<?> REDIS_CONTAINER =
-        new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
-            .withExposedPorts(REDIS_PORT);
-    //.withCommand("redis-server --requirepass systempass");
-    REDIS_CONTAINER.start();
+    GenericContainer<?> redisContainer =
+        new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE)).withExposedPorts(REDIS_PORT);
 
-    System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
-    System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+    redisContainer.start();
+
+    System.setProperty("spring.data.redis.host", redisContainer.getHost());
+    System.setProperty("spring.data.redis.port", redisContainer.getMappedPort(6379).toString());
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #190

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용
- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 스케줄러 분산락 설정
  - [x] 스케줄러 테스트 코드 수정

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.


## 코멘트
<img width="1365" alt="스크린샷 2025-04-23 오후 2 40 50" src="https://github.com/user-attachments/assets/27bf3c53-b3c4-4962-8fbd-54f08fd25610" />
<img width="1449" alt="스크린샷 2025-04-23 오후 2 41 00" src="https://github.com/user-attachments/assets/6e23b232-71ff-4bf4-9c4f-f2930a2c7803" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 분산 락 기능이 도입되어, 레스토랑 평점 갱신 작업이 동시에 여러 번 실행되지 않도록 개선되었습니다.
    - Redis 및 Redisson 기반의 분산 락 구성이 추가되었습니다.

- **버그 수정**
    - 레스토랑 평점 갱신 작업 중 예외 발생 시에도 서비스가 정상적으로 동작하도록 안정성이 향상되었습니다.

- **테스트**
    - 분산 락 적용 및 예외 처리 관련 테스트가 추가되어 신뢰성이 강화되었습니다.

- **환경설정**
    - Redis 연결 정보 및 분산 락 관련 설정이 application.yml에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->