### PR TITLE
[coupon] 내부 사용자 쿠폰 목록 조회 api 구현

### DIFF
--- a/coupon/src/main/java/table/eat/now/coupon/coupon/presentation/dto/response/GetCouponsResponseI.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/presentation/dto/response/GetCouponsResponseI.java
@@ -1,14 +1,16 @@
 package table.eat.now.coupon.coupon.presentation.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import table.eat.now.coupon.coupon.application.dto.response.GetCouponsInfoI;
 import table.eat.now.coupon.coupon.application.dto.response.GetCouponsInfoI.GetCouponInfoI;
 
 @Builder
 public record GetCouponsResponseI(
-    List<GetCouponResponseI> coupons
+    Map<String, GetCouponResponseI> coupons
 ) {
 
   public static GetCouponsResponseI from(GetCouponsInfoI coupons) {
@@ -16,9 +18,13 @@ public record GetCouponsResponseI(
         .coupons(coupons.coupons()
             .stream()
             .map(GetCouponResponseI::from)
-            .toList())
+            .collect(Collectors.toMap(
+                GetCouponResponseI::couponUuid,
+                Function.identity()
+            )))
         .build();
   }
+
 
   @Builder
   public record GetCouponResponseI(

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/client/CouponClient.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/client/CouponClient.java
@@ -1,0 +1,11 @@
+package table.eat.now.coupon.user_coupon.application.client;
+
+import java.util.Map;
+import java.util.Set;
+import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
+
+public interface CouponClient {
+
+  Map<String, GetCouponInfoI> getCouponsByCouponUuids(Set<String> couponUuids);
+
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/client/dto/response/GetCouponInfoI.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/client/dto/response/GetCouponInfoI.java
@@ -1,0 +1,26 @@
+package table.eat.now.coupon.user_coupon.application.client.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record GetCouponInfoI(
+    Long couponId,
+    String couponUuid,
+    String name,
+    String type,
+    String label,
+    LocalDateTime issueStartAt,
+    LocalDateTime issueEndAt,
+    LocalDateTime expireAt,
+    Integer validDays,
+    Integer count,
+    Boolean allowDuplicate,
+    Integer minPurchaseAmount,
+    Integer amount,
+    Integer percent,
+    Integer maxDiscountAmount,
+    LocalDateTime createdAt,
+    Long createdBy
+) {
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/dto/response/GetUserCouponInfoI.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/dto/response/GetUserCouponInfoI.java
@@ -25,7 +25,7 @@ public record GetUserCouponInfoI(
   public static GetUserCouponInfoI from(UserCoupon userCoupon, GetCouponInfoI getCouponInfoI) {
     return GetUserCouponInfoI.builder()
         .id(userCoupon.getId())
-        .userCouponUuid(userCoupon.getCouponUuid())
+        .userCouponUuid(userCoupon.getUserCouponUuid())
         .couponUuid(userCoupon.getCouponUuid())
         .coupon(getCouponInfoI)
         .userId(userCoupon.getUserId())

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/dto/response/GetUserCouponInfoI.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/dto/response/GetUserCouponInfoI.java
@@ -1,0 +1,42 @@
+package table.eat.now.coupon.user_coupon.application.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
+import table.eat.now.coupon.user_coupon.domain.entity.UserCoupon;
+
+@Builder
+public record GetUserCouponInfoI(
+    Long id,
+    String userCouponUuid,
+    String couponUuid,
+    GetCouponInfoI coupon,
+    Long userId,
+    String reservationUuid,
+    String name,
+    String status,
+    LocalDateTime expiresAt,
+    LocalDateTime preemptAt,
+    LocalDateTime usedAt,
+    LocalDateTime createdAt,
+    Long createdBy
+) {
+
+  public static GetUserCouponInfoI from(UserCoupon userCoupon, GetCouponInfoI getCouponInfoI) {
+    return GetUserCouponInfoI.builder()
+        .id(userCoupon.getId())
+        .userCouponUuid(userCoupon.getCouponUuid())
+        .couponUuid(userCoupon.getCouponUuid())
+        .coupon(getCouponInfoI)
+        .userId(userCoupon.getUserId())
+        .reservationUuid(userCoupon.getReservationUuid())
+        .name(userCoupon.getName())
+        .status(userCoupon.getStatus().toString())
+        .expiresAt(userCoupon.getExpiresAt())
+        .preemptAt(userCoupon.getPreemptAt())
+        .usedAt(userCoupon.getUsedAt())
+        .createdAt(userCoupon.getCreatedAt())
+        .createdBy(userCoupon.getCreatedBy())
+        .build();
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponService.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponService.java
@@ -1,10 +1,13 @@
 package table.eat.now.coupon.user_coupon.application.service;
 
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.domain.Pageable;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.coupon.user_coupon.application.dto.request.IssueUserCouponCommand;
 import table.eat.now.coupon.user_coupon.application.dto.request.PreemptUserCouponCommand;
 import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfo;
+import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfoI;
 import table.eat.now.coupon.user_coupon.application.dto.response.PageResponse;
 
 public interface UserCouponService {
@@ -20,4 +23,6 @@ public interface UserCouponService {
       CurrentUserInfoDto userInfoDto, Pageable pageable);
 
   void cancelUserCoupons(String reservationUuid);
+
+  List<GetUserCouponInfoI> getUserCouponsInternalBy(Set<String> userCouponUuids);
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImpl.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImpl.java
@@ -110,7 +110,8 @@ public class UserCouponServiceImpl implements UserCouponService {
     return userCoupons.stream()
         .map(userCoupon -> GetUserCouponInfoI.from(
             userCoupon,
-            couponsMap.get(userCoupon.getCouponUuid())))
+            couponsMap.getOrDefault(userCoupon.getCouponUuid(), null))
+        )
         .toList();
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/domain/repository/UserCouponRepository.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/domain/repository/UserCouponRepository.java
@@ -15,6 +15,8 @@ public interface UserCouponRepository {
 
   Optional<UserCoupon> findByUserCouponUuidAndDeletedAtIsNullWithLock(String userCouponUuid);
 
+  List<UserCoupon> findByUserCouponUuidInAndDeletedAtIsNull(Set<String> userCouponUuids);
+
   List<UserCoupon> findByUserCouponUuidsInAndDeletedAtIsNullWithLock(Set<String> userCouponUuids);
 
   void releasePreemptionAfter10m(LocalDateTime tenMinutesAgo);
@@ -25,5 +27,4 @@ public interface UserCouponRepository {
   <S extends UserCoupon> List<S> saveAll(Iterable<S> userCoupons);
 
   List<UserCoupon> findByReservationUuid(String reservationUuid);
-
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/CouponClientImpl.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/CouponClientImpl.java
@@ -1,0 +1,20 @@
+package table.eat.now.coupon.user_coupon.infrastructure.client;
+
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import table.eat.now.coupon.user_coupon.application.client.CouponClient;
+import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
+import table.eat.now.coupon.user_coupon.infrastructure.client.feign.CouponFeignClient;
+
+@RequiredArgsConstructor
+@Component
+public class CouponClientImpl implements CouponClient {
+  private final CouponFeignClient couponFeignClient;
+
+  @Override
+  public Map<String, GetCouponInfoI> getCouponsByCouponUuids(Set<String> couponUuids) {
+    return couponFeignClient.getCouponsInternal(couponUuids).getBody().toInfo();
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/CouponFeignClient.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/CouponFeignClient.java
@@ -1,0 +1,16 @@
+package table.eat.now.coupon.user_coupon.infrastructure.client.feign;
+
+import java.util.Set;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import table.eat.now.coupon.user_coupon.infrastructure.client.feign.dto.response.GetCouponsResponseI;
+import table.eat.now.coupon.user_coupon.infrastructure.client.feign.config.InternalFeignConfig;
+
+@FeignClient(name="coupon", configuration = InternalFeignConfig.class)
+public interface CouponFeignClient {
+
+  @GetMapping("/internal/v1/coupons")
+  ResponseEntity<GetCouponsResponseI> getCouponsInternal(@RequestParam Set<String> couponUuids);
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/CouponFeignClient.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/CouponFeignClient.java
@@ -5,12 +5,12 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import table.eat.now.coupon.user_coupon.infrastructure.client.feign.dto.response.GetCouponsResponseI;
+import table.eat.now.coupon.user_coupon.infrastructure.client.feign.dto.response.GetCouponsFeignResponse;
 import table.eat.now.coupon.user_coupon.infrastructure.client.feign.config.InternalFeignConfig;
 
 @FeignClient(name="coupon", configuration = InternalFeignConfig.class)
 public interface CouponFeignClient {
 
   @GetMapping("/internal/v1/coupons")
-  ResponseEntity<GetCouponsResponseI> getCouponsInternal(@RequestParam Set<String> couponUuids);
+  ResponseEntity<GetCouponsFeignResponse> getCouponsInternal(@RequestParam Set<String> couponUuids);
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/config/FeignConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/config/FeignConfig.java
@@ -1,0 +1,10 @@
+package table.eat.now.coupon.user_coupon.infrastructure.client.feign.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("table.eat.now.coupon.user_coupon.infrastructure.client.feign")
+public class FeignConfig {
+
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/config/InternalFeignClientErrorDecoder.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/config/InternalFeignClientErrorDecoder.java
@@ -1,0 +1,102 @@
+package table.eat.now.coupon.user_coupon.infrastructure.client.feign.config;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Request;
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+import table.eat.now.common.exception.CustomException;
+import table.eat.now.common.exception.ErrorResponse;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class InternalFeignClientErrorDecoder {
+
+  private final ObjectMapper objectMapper;
+
+  public ErrorDecoder decoder() {
+
+    return (methodKey, response) -> {
+
+      if (response.status() == 503 || response.status() == 429) {
+        return new RetryableException(
+            response.status(),
+            "서비스에 일시적으로 문제가 발생하였습니다. 재시도를 수행합니다.",
+            response.request().httpMethod(),
+            1000L,
+            response.request()
+        );
+      }
+      ErrorResponse errorResponse = extractError(response);
+      loggingError(methodKey, response, errorResponse);
+
+      throw CustomException.of(
+          HttpStatus.valueOf(response.status()),
+          errorResponse.message()
+      );
+    };
+  }
+
+  private ErrorResponse extractError(Response response) {
+    try (InputStream responseBodyStream = response.body().asInputStream()) {
+      String body = StreamUtils.copyToString(responseBodyStream, StandardCharsets.UTF_8);
+      return objectMapper.readValue(body, ErrorResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void loggingError(String methodKey, Response response, ErrorResponse errorResponse) {
+    Request request = response.request();
+
+    log.error(""" 
+				\s
+				    Request Fail: {}
+				    URL: {} {}
+				    Status: {}
+				    Request Header: {}
+				    Request Body: {}
+				    Response Body: {}
+				\s""",
+        methodKey,
+        request.httpMethod(),
+        request.url(),
+        response.status(),
+        extractRequestHeader(request),
+        extractRequestBody(request),
+        errorResponse
+    );
+  }
+
+  private static String extractRequestHeader(Request request) {
+    Map<String, Collection<String>> headers = request.headers();
+
+    if (Objects.nonNull(headers)) {
+      return headers.toString();
+    }
+    return EMPTY;
+  }
+
+  private static String extractRequestBody(Request request) {
+    byte[] body = request.body();
+
+    if (Objects.nonNull(body)) {
+      new String(body, StandardCharsets.UTF_8);
+    }
+    return EMPTY;
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/config/InternalFeignConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/config/InternalFeignConfig.java
@@ -1,13 +1,21 @@
 package table.eat.now.coupon.user_coupon.infrastructure.client.feign.config;
 
 import feign.RequestInterceptor;
+import feign.Retryer;
+import feign.codec.ErrorDecoder;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import table.eat.now.common.constant.UserInfoConstant;
 
+@RequiredArgsConstructor
+@Configuration
 public class InternalFeignConfig {
+
+  private final InternalFeignClientErrorDecoder feignClientErrorDecoder;
 
   @Bean
   public RequestInterceptor requestInterceptor() {
@@ -26,5 +34,15 @@ public class InternalFeignConfig {
         }
       }
     };
+  }
+
+  @Bean
+  public Retryer feignRetryer() {
+    return new Retryer.Default(1000, 2000, 3);
+  }
+
+  @Bean
+  public ErrorDecoder errorDecoder() {
+    return feignClientErrorDecoder.decoder(); // 필요에 따라 구현
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/config/InternalFeignConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/config/InternalFeignConfig.java
@@ -1,0 +1,30 @@
+package table.eat.now.coupon.user_coupon.infrastructure.client.feign.config;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import table.eat.now.common.constant.UserInfoConstant;
+
+public class InternalFeignConfig {
+
+  @Bean
+  public RequestInterceptor requestInterceptor() {
+
+    return requestTemplate -> {
+      ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+      if (attributes != null) {
+        HttpServletRequest request = attributes.getRequest();
+        String userIdStr = request.getHeader(UserInfoConstant.USER_ID_HEADER);
+        String userRoleStr = request.getHeader(UserInfoConstant.USER_ROLE_HEADER);
+        if (userIdStr != null) {
+          requestTemplate.header(UserInfoConstant.USER_ID_HEADER, userIdStr);
+        }
+        if (userRoleStr != null) {
+          requestTemplate.header(UserInfoConstant.USER_ROLE_HEADER, userRoleStr);
+        }
+      }
+    };
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/dto/response/GetCouponsFeignResponse.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/dto/response/GetCouponsFeignResponse.java
@@ -8,8 +8,8 @@ import lombok.Builder;
 import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
 
 @Builder
-public record GetCouponsResponseI(
-    Map<String, GetCouponResponseI> coupons
+public record GetCouponsFeignResponse(
+    Map<String, GetCouponFeignResponse> coupons
 ) {
 
   public Map<String, GetCouponInfoI> toInfo() {
@@ -21,7 +21,7 @@ public record GetCouponsResponseI(
         ));
   }
   @Builder
-  public record GetCouponResponseI(
+  public record GetCouponFeignResponse(
       Long couponId,
       String couponUuid,
       String name,

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/dto/response/GetCouponsResponseI.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/client/feign/dto/response/GetCouponsResponseI.java
@@ -1,0 +1,66 @@
+package table.eat.now.coupon.user_coupon.infrastructure.client.feign.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
+
+@Builder
+public record GetCouponsResponseI(
+    Map<String, GetCouponResponseI> coupons
+) {
+
+  public Map<String, GetCouponInfoI> toInfo() {
+    return coupons.entrySet()
+        .stream()
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            e -> e.getValue().toInfo()
+        ));
+  }
+  @Builder
+  public record GetCouponResponseI(
+      Long couponId,
+      String couponUuid,
+      String name,
+      String type,
+      String label,
+      LocalDateTime issueStartAt,
+      LocalDateTime issueEndAt,
+      LocalDateTime expireAt,
+      Integer validDays,
+      Integer count,
+      Boolean allowDuplicate,
+      Integer minPurchaseAmount,
+      Integer amount,
+      Integer percent,
+      Integer maxDiscountAmount,
+      LocalDateTime createdAt,
+      Long createdBy
+  ) {
+
+    public GetCouponInfoI toInfo() {
+      return GetCouponInfoI.builder()
+          .couponId(couponId)
+          .couponUuid(couponUuid)
+          .name(name)
+          .type(type)
+          .label(label)
+          .issueStartAt(issueStartAt)
+          .issueEndAt(issueEndAt)
+          .expireAt(expireAt)
+          .validDays(validDays)
+          .count(count)
+          .allowDuplicate(allowDuplicate)
+          .minPurchaseAmount(minPurchaseAmount)
+          .amount(amount)
+          .percent(percent)
+          .maxDiscountAmount(maxDiscountAmount)
+          .createdAt(createdAt)
+          .createdBy(createdBy)
+          .build();
+    }
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/jpa/JpaUserCouponRepository.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/infrastructure/persistence/jpa/JpaUserCouponRepository.java
@@ -22,6 +22,9 @@ public interface JpaUserCouponRepository extends
   Optional<UserCoupon> findByUserCouponUuidAndDeletedAtIsNullWithLock(String userCouponUuid);
 
   @Override
+  List<UserCoupon> findByUserCouponUuidInAndDeletedAtIsNull(Set<String> userCouponUuids);
+
+  @Override
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select uc from UserCoupon uc "
       + "where uc.userCouponUuid in :userCouponUuids and uc.deletedAt is null")

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalController.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalController.java
@@ -1,18 +1,26 @@
 package table.eat.now.coupon.user_coupon.presentation;
 
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import table.eat.now.common.aop.annotation.AuthCheck;
 import table.eat.now.common.resolver.annotation.CurrentUserInfo;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfoI;
 import table.eat.now.coupon.user_coupon.application.service.UserCouponService;
 import table.eat.now.coupon.user_coupon.presentation.dto.request.PreemptUserCouponRequest;
+import table.eat.now.coupon.user_coupon.presentation.dto.response.GetUserCouponsResponseI;
 
 @RequiredArgsConstructor
 @RequestMapping("/internal/v1/user-coupons")
@@ -29,5 +37,19 @@ public class UserCouponInternalController {
 
     userCouponService.preemptUserCoupons(userInfoDto, request.toCommand());
     return ResponseEntity.ok().build();
+  }
+
+  @AuthCheck(roles = {UserRole.CUSTOMER, UserRole.MASTER})
+  @GetMapping
+  public ResponseEntity<GetUserCouponsResponseI> getUserCoupons(
+      @CurrentUserInfo CurrentUserInfoDto userInfoDto,
+      @RequestParam Set<UUID> userCouponUuids
+  ) {
+
+    List<GetUserCouponInfoI> userCouponsInfo =
+        userCouponService.getUserCouponsInternalBy(userCouponUuids.stream()
+            .map(UUID::toString)
+            .collect(Collectors.toSet()));
+    return ResponseEntity.ok().body(GetUserCouponsResponseI.from(userCouponsInfo));
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalController.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalController.java
@@ -1,6 +1,7 @@
 package table.eat.now.coupon.user_coupon.presentation;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -43,7 +44,7 @@ public class UserCouponInternalController {
   @GetMapping
   public ResponseEntity<GetUserCouponsResponseI> getUserCoupons(
       @CurrentUserInfo CurrentUserInfoDto userInfoDto,
-      @RequestParam Set<UUID> userCouponUuids
+      @RequestParam @NotEmpty Set<UUID> userCouponUuids
   ) {
 
     List<GetUserCouponInfoI> userCouponsInfo =

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/dto/response/GetUserCouponsResponse.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/dto/response/GetUserCouponsResponse.java
@@ -8,7 +8,7 @@ import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponIn
 
 @Builder
 public record GetUserCouponsResponse(
-    List<GetUserCouponResponse> coupons,
+    List<GetUserCouponResponse> userCoupons,
     long totalElements,
     int totalPages,
     int pageNumber,
@@ -17,7 +17,7 @@ public record GetUserCouponsResponse(
 
   public static GetUserCouponsResponse from(PageResponse<GetUserCouponInfo> userCouponInfos) {
     return GetUserCouponsResponse.builder()
-        .coupons(userCouponInfos.contents().stream().map(GetUserCouponResponse::from).toList())
+        .userCoupons(userCouponInfos.contents().stream().map(GetUserCouponResponse::from).toList())
         .totalElements(userCouponInfos.totalElements())
         .totalPages(userCouponInfos.totalPages())
         .pageNumber(userCouponInfos.pageNumber())

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/dto/response/GetUserCouponsResponseI.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/dto/response/GetUserCouponsResponseI.java
@@ -1,0 +1,102 @@
+package table.eat.now.coupon.user_coupon.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
+import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfoI;
+
+@Builder
+public record GetUserCouponsResponseI(
+    List<GetUserCouponResponseI> userCoupons
+) {
+
+  public static GetUserCouponsResponseI from(List<GetUserCouponInfoI> userCouponInfos) {
+    return GetUserCouponsResponseI.builder()
+        .userCoupons(userCouponInfos.stream()
+            .map(GetUserCouponResponseI::from)
+            .toList())
+        .build();
+  }
+
+  @Builder
+  record GetUserCouponResponseI(
+      Long id,
+      String userCouponUuid,
+      String couponUuid,
+      GetCouponResponseI coupon,
+      Long userId,
+      String reservationUuid,
+      String name,
+      String status,
+      LocalDateTime expiresAt,
+      LocalDateTime preemptAt,
+      LocalDateTime usedAt,
+      LocalDateTime createdAt,
+      Long createdBy
+  ) {
+
+    public static GetUserCouponResponseI from(
+        GetUserCouponInfoI infoI) {
+      return GetUserCouponResponseI.builder()
+          .id(infoI.id())
+          .userCouponUuid(infoI.userCouponUuid())
+          .couponUuid(infoI.couponUuid())
+          .coupon(GetCouponResponseI.from(infoI.coupon()))
+          .userId(infoI.userId())
+          .reservationUuid(infoI.reservationUuid())
+          .name(infoI.name())
+          .status(infoI.status())
+          .expiresAt(infoI.expiresAt())
+          .preemptAt(infoI.preemptAt())
+          .usedAt(infoI.usedAt())
+          .createdAt(infoI.createdAt())
+          .createdBy(infoI.createdBy())
+          .build();
+    }
+  }
+
+  @Builder
+  record GetCouponResponseI(
+      Long couponId,
+      String couponUuid,
+      String name,
+      String type,
+      String label,
+      LocalDateTime issueStartAt,
+      LocalDateTime issueEndAt,
+      LocalDateTime expireAt,
+      Integer validDays,
+      Integer count,
+      Boolean allowDuplicate,
+      Integer minPurchaseAmount,
+      Integer amount,
+      Integer percent,
+      Integer maxDiscountAmount,
+      LocalDateTime createdAt,
+      Long createdBy
+  ) {
+
+    public static GetCouponResponseI from(GetCouponInfoI coupon) {
+      return GetCouponResponseI.builder()
+          .couponId(coupon.couponId())
+          .couponUuid(coupon.couponUuid())
+          .name(coupon.name())
+          .type(coupon.type())
+          .label(coupon.label())
+          .issueStartAt(coupon.issueStartAt())
+          .issueEndAt(coupon.issueEndAt())
+          .expireAt(coupon.expireAt())
+          .validDays(coupon.validDays())
+          .count(coupon.count())
+          .allowDuplicate(coupon.allowDuplicate())
+          .minPurchaseAmount(coupon.minPurchaseAmount())
+          .amount(coupon.amount())
+          .percent(coupon.percent())
+          .maxDiscountAmount(coupon.maxDiscountAmount())
+          .createdAt(coupon.createdAt())
+          .createdBy(coupon.createdBy())
+          .build();
+    }
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/dto/response/GetUserCouponsResponseI.java
+++ b/coupon/src/main/java/table/eat/now/coupon/user_coupon/presentation/dto/response/GetUserCouponsResponseI.java
@@ -78,6 +78,9 @@ public record GetUserCouponsResponseI(
   ) {
 
     public static GetCouponResponseI from(GetCouponInfoI coupon) {
+      if (coupon == null) {
+        return null;
+      }
       return GetCouponResponseI.builder()
           .couponId(coupon.couponId())
           .couponUuid(coupon.couponUuid())

--- a/coupon/src/test/coupon.http
+++ b/coupon/src/test/coupon.http
@@ -98,19 +98,3 @@ X-User-Role: CUSTOMER
     }
 %}
 
-### 쿠폰 선점 요청
-PATCH http://localhost:8085/internal/v1/user-coupons/preempt
-Content-Type: application/json
-X-User-Id: 5
-X-User-Role: CUSTOMER
-
-{
-  "reservationUuid":"2847c0d1-1c72-404a-81f5-cee00d164637",
-  "userCouponUuids": ["{{userCouponUuid}}"]
-}
-
-### 사용자 쿠폰 조회 요청
-GET http://localhost:8085/api/v1/user-coupons
-Content-Type: application/json
-X-User-Id: 5
-X-User-Role: CUSTOMER

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/presentation/CouponInternalControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/presentation/CouponInternalControllerTest.java
@@ -1,5 +1,6 @@
 package table.eat.now.coupon.coupon.presentation;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -105,7 +106,7 @@ class CouponInternalControllerTest extends ControllerTestSupport {
     resultActions.andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.coupons.length()").value(3))
-        .andExpect(jsonPath("$.coupons[0].type").value("FIXED_DISCOUNT"))
+        .andExpect(jsonPath("$.coupons.*.type", hasItem("FIXED_DISCOUNT")))
         .andDo(print());
   }
 }

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/fixture/UserCouponFixture.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/fixture/UserCouponFixture.java
@@ -38,10 +38,4 @@ public class UserCouponFixture {
             .build())
         .toList();
   }
-//
-//  public static List<GetUserCouponInfoI> createGetUserCouponInfoIList(int size, Long userId) {
-//
-//
-//  }
-//
 }

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/fixture/UserCouponFixture.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/fixture/UserCouponFixture.java
@@ -38,4 +38,10 @@ public class UserCouponFixture {
             .build())
         .toList();
   }
+//
+//  public static List<GetUserCouponInfoI> createGetUserCouponInfoIList(int size, Long userId) {
+//
+//
+//  }
+//
 }

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponApiControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponApiControllerTest.java
@@ -54,8 +54,8 @@ class UserCouponApiControllerTest extends ControllerTestSupport {
 
     // then
     resultActions.andExpect(status().isOk())
-        .andExpect(jsonPath("$.coupons.length()").value(10))
-        .andExpect(jsonPath("$.coupons[0].userId").value(2L))
+        .andExpect(jsonPath("$.userCoupons.length()").value(10))
+        .andExpect(jsonPath("$.userCoupons[0].userId").value(2L))
         .andDo(print());
   }
 }

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalControllerTest.java
@@ -1,14 +1,21 @@
 package table.eat.now.coupon.user_coupon.presentation;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +26,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.coupon.helper.ControllerTestSupport;
+import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
+import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfoI;
 import table.eat.now.coupon.user_coupon.application.service.UserCouponService;
 import table.eat.now.coupon.user_coupon.presentation.dto.request.PreemptUserCouponRequest;
 
@@ -55,6 +64,64 @@ class UserCouponInternalControllerTest extends ControllerTestSupport {
 
     // then
     resultActions.andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @DisplayName("사용자 쿠폰 목록 조회 요청 - 200 응답")
+  @Test
+  void getUserCoupons() throws Exception {
+    // given
+    CurrentUserInfoDto userInfo = CurrentUserInfoDto.of(2L, UserRole.CUSTOMER);
+    List<String> userCouponUuids = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+    List<GetCouponInfoI> couponInfoIs = IntStream.range(0, 2)
+        .mapToObj(i -> GetCouponInfoI.builder()
+            .couponId((long) i)
+            .couponUuid(UUID.randomUUID().toString())
+            .type("FIXED_DISCOUNT")
+            .label("PROMOTION")
+            .allowDuplicate(false)
+            .count(1000)
+            .issueStartAt(LocalDate.now().atStartOfDay())
+            .issueEndAt(LocalDate.now().plusDays(8).atStartOfDay())
+            .amount(1000)
+            .minPurchaseAmount(10000)
+            .build())
+        .toList();
+
+    List<GetUserCouponInfoI> userCouponInfos = IntStream.range(0, 2)
+        .mapToObj(i -> GetUserCouponInfoI.builder()
+            .id((long) i)
+            .userId(2L)
+            .couponUuid(UUID.randomUUID().toString())
+            .coupon(couponInfoIs.get(i))
+            .userCouponUuid(userCouponUuids.get(i))
+            .couponUuid(couponInfoIs.get(i).couponUuid())
+            .name("test coupon name")
+            .expiresAt(LocalDate.now().plusDays(4).atStartOfDay())
+            .createdAt(LocalDate.now().minusDays(4).atStartOfDay())
+            .createdBy(2L)
+            .build())
+        .toList();
+
+    given(userCouponService.getUserCouponsInternalBy(new HashSet<>(userCouponUuids)))
+        .willReturn(userCouponInfos);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        get("/internal/v1/user-coupons")
+            .header("Authorization", "Bearer {ACCESS_TOKEN}")
+            .header(USER_ID_HEADER, userInfo.userId())
+            .header(USER_ROLE_HEADER, userInfo.role())
+            .param("userCouponUuids", userCouponUuids.get(0))
+            .param("userCouponUuids", userCouponUuids.get(1))
+            );
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andExpect(jsonPath("$.userCoupons.size()").value(userCouponUuids.size()))
+        .andExpect(jsonPath("$.userCoupons[0].coupon.couponUuid").value(couponInfoIs.get(0).couponUuid()))
+        .andExpect(jsonPath("$.userCoupons[0].userId").value(userInfo.userId()))
         .andDo(print());
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
   zookeeper:
     container_name: ten-zookeeper
     image: bitnami/zookeeper:latest
-    platform: linux/amd64
+    platform: linux/arm64
     ports:
       - "2181:2181"
     environment:
@@ -71,7 +71,7 @@ services:
   kafka:
     container_name: ten-kafka
     image: bitnami/kafka:3.8.1
-    platform: linux/amd64
+    platform: linux/arm64
     ports:
       - "9092:9092"
     environment:
@@ -80,14 +80,13 @@ services:
       KAFKA_LISTENERS: INSIDE://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: false
     volumes:
       - ./kafka_data:/var/lib/kafka/data
 
   kafka-ui:
     container_name: ten-kafka-ui
     image: provectuslabs/kafka-ui:latest
-    platform: linux/amd64
+    platform: linux/arm64
     ports:
       - "8079:8080"
     environment:


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #198

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 내부 사용자 쿠폰 목록 조회 api 구현

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 내부용 사용자 쿠폰 목록 조회 API(`/internal/v1/user-coupons`)가 추가되었습니다.
  - 사용자 쿠폰 및 쿠폰 상세 정보를 포함한 새로운 응답 포맷이 도입되었습니다.

- **버그 수정**
  - 기존 쿠폰 목록 조회 시 쿠폰 타입 검증 로직이 개선되었습니다.

- **문서화**
  - 응답 필드명이 `coupons`에서 `userCoupons`로 변경되었습니다.

- **테스트**
  - 내부 사용자 쿠폰 조회 API에 대한 테스트가 추가되었습니다.
  - 기존 테스트들이 새로운 응답 구조에 맞게 수정되었습니다.

- **환경설정**
  - Docker Compose의 플랫폼이 ARM64로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->