### PR TITLE
[notification] 알림 카프카쪽 수정

### DIFF
--- a/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/NotificationEventListener.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/NotificationEventListener.java
@@ -1,8 +1,12 @@
 package table.eat.now.notification.infrastructure.kafka;
 
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 import table.eat.now.notification.application.event.produce.NotificationScheduleSendEvent;
 import table.eat.now.notification.application.event.produce.NotificationSendEvent;
@@ -13,21 +17,78 @@ import table.eat.now.notification.application.service.NotificationService;
 @RequiredArgsConstructor
 public class NotificationEventListener {
 
+  private static final String NOTIFICATION_TOPIC_NAME = "notification-event";
   private final NotificationService notificationService;
 
   @KafkaListener(
-      topics = "notification-event",
+      topics = NOTIFICATION_TOPIC_NAME,
       containerFactory = "sendNotificationEventKafkaListenerContainerFactory"
   )
   public void handleNotificationSend(NotificationSendEvent notificationSendEvent) {
-    notificationService.consumerNotification(notificationSendEvent);
+    try {
+      notificationService.consumerNotification(notificationSendEvent);
+    } catch (Throwable e) {
+      log.error("알림 전송 이벤트 에러 발생 {}", e.getMessage());
+      throw e;
+    }
   }
 
   @KafkaListener(
-      topics = "notification-event",
+      topics = NOTIFICATION_TOPIC_NAME,
       containerFactory = "scheduleSendNotificationEventKafkaListenerContainerFactory"
   )
   public void handleNotificationScheduleSend(NotificationScheduleSendEvent event) {
-    notificationService.consumerScheduleSendNotification(event);
+    try {
+      notificationService.consumerScheduleSendNotification(event);
+    } catch (Throwable e) {
+      log.error("알림 스케줄 전송 이벤트 에러 발생 {}", e.getMessage());
+      throw e;
+    }
   }
+  @KafkaListener(
+      topics = "Notification-event-dlt",
+      containerFactory = "notificationSendEventDltKafkaListenerContainerFactory"
+  )
+  public void handleNotificationSendDlt(
+      NotificationSendEvent event,
+      Acknowledgment ack,
+      @Header(KafkaHeaders.RECEIVED_PARTITION) int partitionId,
+      @Header(KafkaHeaders.OFFSET) Long offset,
+      @Header(value = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String errorMessage) {
+    log.warn("NotificationSendEvent DLT 처리 시작 - partition: {}, offset: {}, errorMessage: {}",
+        partitionId, offset, errorMessage);
+
+    try {
+      notificationService.consumerNotification(event);
+    } catch (Throwable e) {
+      log.error("NotificationSendEvent DLT 처리 실패 - 수동 처리 필요 - partition: {}, offset: {}, error: {}",
+          partitionId, offset, e.getMessage(), e);
+    } finally {
+      ack.acknowledge();
+    }
+  }
+  @KafkaListener(
+      topics = "Notification-schedule-event-dlt",
+      containerFactory = "notificationScheduleSendEventDltKafkaListenerContainerFactory"
+  )
+  public void handleNotificationScheduleSendDlt(
+      NotificationScheduleSendEvent event,
+      Acknowledgment ack,
+      @Header(KafkaHeaders.RECEIVED_PARTITION) int partitionId,
+      @Header(KafkaHeaders.OFFSET) Long offset,
+      @Header(value = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String errorMessage
+  ) {
+    log.warn("NotificationScheduleSendEvent DLT 처리 시작 - partition: {}, offset: {}, errorMessage: {}",
+        partitionId, offset, errorMessage);
+
+    try {
+      notificationService.consumerScheduleSendNotification(event);
+    } catch (Throwable e) {
+      log.error("NotificationScheduleSendEvent DLT 처리 실패 - 수동 처리 필요 - partition: {}, offset: {}, error: {}",
+          partitionId, offset, e.getMessage(), e);
+    } finally {
+      ack.acknowledge();
+    }
+  }
+
 }

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaConsumerConfig.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaConsumerConfig.java
@@ -32,6 +32,7 @@ public class NotificationKafkaConsumerConfig {
 
   private static final String TABLE_EAT_NOW = "table.eat.now.**";
   private static final String NOTIFICATION_SEND_GROUP = "Notification-send-consumer";
+  private static final String NOTIFICATION_SCHEDULE_SEND_GROUP = "Notification-schedule-send-consumer";
   private static final String NOTIFICATION_EVENT_DLT = "Notification-event-dlt";
 
   @Value("${spring.kafka.bootstrap-servers}")
@@ -150,7 +151,7 @@ public class NotificationKafkaConsumerConfig {
   @Bean
   public ConsumerFactory<String, NotificationScheduleSendEvent> scheduleSendEventConsumerFactory() {
     return createConsumerFactory(
-        NOTIFICATION_SEND_GROUP, NotificationScheduleSendEvent.class, this::getCommonConsumerProps);
+        NOTIFICATION_SCHEDULE_SEND_GROUP, NotificationScheduleSendEvent.class, this::getCommonConsumerProps);
   }
 
   @Bean

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaConsumerConfig.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaConsumerConfig.java
@@ -3,7 +3,9 @@ package table.eat.now.notification.infrastructure.kafka.config;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,8 +15,13 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
 import table.eat.now.notification.application.event.EventType;
 import table.eat.now.notification.application.event.produce.NotificationScheduleSendEvent;
 import table.eat.now.notification.application.event.produce.NotificationSendEvent;
@@ -23,79 +30,153 @@ import table.eat.now.notification.application.event.produce.NotificationSendEven
 @Configuration
 public class NotificationKafkaConsumerConfig {
 
+  private static final String TABLE_EAT_NOW = "table.eat.now.**";
+  private static final String NOTIFICATION_SEND_GROUP = "Notification-send-consumer";
+  private static final String NOTIFICATION_EVENT_DLT = "Notification-event-dlt";
+
   @Value("${spring.kafka.bootstrap-servers}")
   private String bootstrapServers;
 
-  // 공통 기본 설정 생성 메서드
+  @Value("${spring.kafka.consumer.auto-offset-reset}")
+  private String autoOffsetReset;
+  @Value("${spring.kafka.consumer.enable-auto-commit}")
+  private boolean enableAutoCommit;
+  @Value("${spring.kafka.consumer.fetch-min-bytes}")
+  private int fetchMinBytes;
+
+  @Value("${spring.kafka.consumer.fetch-max-wait-ms}")
+  private int fetchMaxWaitMs;
+
+  @Value("${spring.kafka.consumer.max-poll-records}")
+  private int maxPollRecords;
+
+  private static <T> JsonDeserializer<T> getTJsonDeserializer(Class<T> targetType) {
+    JsonDeserializer<T> deserializer = new JsonDeserializer<>(targetType);
+    deserializer.setUseTypeHeaders(false);
+    deserializer.setRemoveTypeHeaders(true);
+    deserializer.addTrustedPackages(TABLE_EAT_NOW);
+    return deserializer;
+  }
+
   private Map<String, Object> getCommonConsumerProps(String groupId) {
     Map<String, Object> props = new HashMap<>();
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
     props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
+    props.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, fetchMinBytes);
+    props.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, fetchMaxWaitMs);
+    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
     return props;
   }
 
-  // 타입별 컨슈머 팩토리 생성 메서드
   private <T> ConsumerFactory<String, T> createConsumerFactory(
-      Class<T> targetType, String groupId) {
-    Map<String, Object> props = getCommonConsumerProps(groupId);
-
-    JsonDeserializer<T> jsonDeserializer = new JsonDeserializer<>(targetType);
-    jsonDeserializer.setUseTypeHeaders(false);
-    jsonDeserializer.setRemoveTypeHeaders(true);
+      String groupId, Class<T> targetType, Function<String, Map<String, Object>> propProvider) {
 
     return new DefaultKafkaConsumerFactory<>(
-        props,
+        propProvider.apply(groupId),
         new StringDeserializer(),
-        jsonDeserializer
+        getTJsonDeserializer(targetType)
     );
   }
 
-  // 이벤트 타입 헤더 필터 생성 메서드
   private <T> RecordFilterStrategy<String, T> createEventTypeFilter(String eventTypeName) {
     return record -> {
       Header eventTypeHeader = record.headers().lastHeader("eventType");
-      if (eventTypeHeader == null) {
-        return true; // 헤더가 없으면 필터링
-      }
+      if (eventTypeHeader == null) return true;
       String eventTypeValue = new String(eventTypeHeader.value(), StandardCharsets.UTF_8);
-      return !eventTypeValue.equals(eventTypeName); // 지정된 이벤트 타입만 통과
+      return !eventTypeValue.equals(eventTypeName);
     };
   }
 
-  // 타입별 컨테이너 팩토리 생성 메서드
-  private <T> ConcurrentKafkaListenerContainerFactory<String, T> createContainerFactory(
-      ConsumerFactory<String, T> consumerFactory, String eventTypeName) {
+  private <T> DefaultErrorHandler getDefaultErrorHandler(
+      KafkaTemplate<String, T> kafkaTemplate, String dltTopicName) {
 
-    ConcurrentKafkaListenerContainerFactory<String, T> factory =
-        new ConcurrentKafkaListenerContainerFactory<>();
+    DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+        kafkaTemplate,
+        (record, ex) -> new TopicPartition(dltTopicName, record.partition())
+    );
+
+    return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3));
+  }
+
+  private <T> ConcurrentKafkaListenerContainerFactory<String, T> createContainerFactory(
+      ConsumerFactory<String, T> consumerFactory,
+      String eventTypeName) {
+
+    ConcurrentKafkaListenerContainerFactory<String, T> factory = new ConcurrentKafkaListenerContainerFactory<>();
     factory.setConsumerFactory(consumerFactory);
     factory.setRecordFilterStrategy(createEventTypeFilter(eventTypeName));
-
+    factory.setAckDiscarded(true);
+    factory.setConcurrency(3);
     return factory;
   }
-  //NotificationSendEvent 컨슈머 팩토리
+
   @Bean
   public ConsumerFactory<String, NotificationSendEvent> sendEventConsumerFactory() {
-    return createConsumerFactory(NotificationSendEvent.class, "Notification-send-consumer");
+    return createConsumerFactory(
+        NOTIFICATION_SEND_GROUP, NotificationSendEvent.class, this::getCommonConsumerProps);
   }
 
   @Bean
   public ConcurrentKafkaListenerContainerFactory<String, NotificationSendEvent>
-  sendNotificationEventKafkaListenerContainerFactory() {
-    return createContainerFactory(sendEventConsumerFactory(), EventType.SEND.name());
+  sendNotificationEventKafkaListenerContainerFactory(KafkaTemplate<String, NotificationSendEvent> kafkaTemplate) {
+
+    ConcurrentKafkaListenerContainerFactory<String, NotificationSendEvent> factory =
+        createContainerFactory(sendEventConsumerFactory(), EventType.SEND.name());
+
+    factory.setCommonErrorHandler(getDefaultErrorHandler(kafkaTemplate, NOTIFICATION_EVENT_DLT));
+    factory.getContainerProperties().setIdleBetweenPolls(5000);
+    factory.setBatchListener(true);
+    factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+    return factory;
   }
 
-  //NotificationScheduleSendEvent 컨슈머 팩토리
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, NotificationSendEvent>
+  notificationSendEventDltKafkaListenerContainerFactory(KafkaTemplate<String, NotificationSendEvent> kafkaTemplate) {
+
+    ConcurrentKafkaListenerContainerFactory<String, NotificationSendEvent> factory =
+        createContainerFactory(sendEventConsumerFactory(), EventType.SEND.name());
+
+    factory.setCommonErrorHandler(getDefaultErrorHandler(kafkaTemplate, NOTIFICATION_EVENT_DLT));
+    factory.getContainerProperties().setIdleBetweenPolls(60000);
+    factory.setBatchListener(true);
+    factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+    return factory;
+  }
+
   @Bean
   public ConsumerFactory<String, NotificationScheduleSendEvent> scheduleSendEventConsumerFactory() {
-    return createConsumerFactory(NotificationScheduleSendEvent.class, "Notification-send-consumer");
+    return createConsumerFactory(
+        NOTIFICATION_SEND_GROUP, NotificationScheduleSendEvent.class, this::getCommonConsumerProps);
   }
 
   @Bean
   public ConcurrentKafkaListenerContainerFactory<String, NotificationScheduleSendEvent>
   scheduleSendNotificationEventKafkaListenerContainerFactory() {
-    return createContainerFactory(scheduleSendEventConsumerFactory(), EventType.SCHEDULE_SEND.name());
+
+    ConcurrentKafkaListenerContainerFactory<String, NotificationScheduleSendEvent> factory =
+        createContainerFactory(scheduleSendEventConsumerFactory(), EventType.SCHEDULE_SEND.name());
+
+    factory.getContainerProperties().setIdleBetweenPolls(5000);
+    factory.setBatchListener(true);
+    factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+    return factory;
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, NotificationScheduleSendEvent>
+  scheduleSendNotificationEventDltKafkaListenerContainerFactory(KafkaTemplate<String, NotificationScheduleSendEvent> kafkaTemplate) {
+
+    ConcurrentKafkaListenerContainerFactory<String, NotificationScheduleSendEvent> factory =
+        createContainerFactory(scheduleSendEventConsumerFactory(), EventType.SCHEDULE_SEND.name());
+
+    factory.setCommonErrorHandler(getDefaultErrorHandler(kafkaTemplate, NOTIFICATION_EVENT_DLT));
+    factory.getContainerProperties().setIdleBetweenPolls(60000);
+    factory.setBatchListener(true);
+    factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+    return factory;
   }
 }

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaConsumerConfig.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaConsumerConfig.java
@@ -128,7 +128,6 @@ public class NotificationKafkaConsumerConfig {
 
     factory.setCommonErrorHandler(getDefaultErrorHandler(kafkaTemplate, NOTIFICATION_EVENT_DLT));
     factory.getContainerProperties().setIdleBetweenPolls(5000);
-    factory.setBatchListener(true);
     factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
     return factory;
   }
@@ -143,7 +142,6 @@ public class NotificationKafkaConsumerConfig {
 
     factory.setCommonErrorHandler(getDefaultErrorHandler(kafkaTemplate, NOTIFICATION_EVENT_DLT));
     factory.getContainerProperties().setIdleBetweenPolls(60000);
-    factory.setBatchListener(true);
     factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
     return factory;
   }
@@ -162,7 +160,6 @@ public class NotificationKafkaConsumerConfig {
         createContainerFactory(scheduleSendEventConsumerFactory(), EventType.SCHEDULE_SEND.name());
 
     factory.getContainerProperties().setIdleBetweenPolls(5000);
-    factory.setBatchListener(true);
     factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
     return factory;
   }
@@ -176,7 +173,6 @@ public class NotificationKafkaConsumerConfig {
 
     factory.setCommonErrorHandler(getDefaultErrorHandler(kafkaTemplate, NOTIFICATION_EVENT_DLT));
     factory.getContainerProperties().setIdleBetweenPolls(60000);
-    factory.setBatchListener(true);
     factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
     return factory;
   }

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaTopicConfig.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaTopicConfig.java
@@ -1,6 +1,7 @@
 package table.eat.now.notification.infrastructure.kafka.config;
 
 import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
@@ -10,12 +11,19 @@ public class NotificationKafkaTopicConfig {
 
   private static final String NOTIFICATION_TOPIC_NAME = "notification-event";
 
+  @Value("${kafka.topic.promotion.partitions:3}")
+  private int partitions;
+  @Value("${kafka.topic.promotion.replicas:3}")
+  private int replicas;
+  @Value("${kafka.topic.promotion.min-insync-replicas:2}")
+  private String minInsyncReplicas;
+
   @Bean
   public NewTopic createTopic() {
     return TopicBuilder.name(NOTIFICATION_TOPIC_NAME)
-        .partitions(3)
-        .replicas(3)
-        .config("min.insync.replicas", "2")
+        .partitions(partitions)
+        .replicas(replicas)
+        .config("min.insync.replicas", minInsyncReplicas)
         .build();
   }
 

--- a/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaTopicConfig.java
+++ b/notification/src/main/java/table/eat/now/notification/infrastructure/kafka/config/NotificationKafkaTopicConfig.java
@@ -11,11 +11,11 @@ public class NotificationKafkaTopicConfig {
 
   private static final String NOTIFICATION_TOPIC_NAME = "notification-event";
 
-  @Value("${kafka.topic.promotion.partitions:3}")
+  @Value("${kafka.topic.promotion.partitions}")
   private int partitions;
-  @Value("${kafka.topic.promotion.replicas:3}")
+  @Value("${kafka.topic.promotion.replicas}")
   private int replicas;
-  @Value("${kafka.topic.promotion.min-insync-replicas:2}")
+  @Value("${kafka.topic.promotion.min-insync-replicas}")
   private String minInsyncReplicas;
 
   @Bean

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -29,8 +29,19 @@ spring:
     bootstrap-servers: localhost:9092
     consumer:
       auto-offset-reset: earliest
+      enable-auto-commit: false
+      fetch-min-bytes: 1024
+      fetch-max-wait-ms: 500
+      max-poll-records: 500
       properties:
         spring.json.trusted.packages: "*"
+kafka:
+  topic:
+    promotion:
+      partitions: 3
+      replicas: 1
+      min-insync-replicas: 1
+
   mail:
     host: smtp.gmail.com
     port: 587

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -39,8 +39,8 @@ kafka:
   topic:
     promotion:
       partitions: 3
-      replicas: 1
-      min-insync-replicas: 1
+      replicas: 3
+      min-insync-replicas: 2
 
   mail:
     host: smtp.gmail.com


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #193 

## 변경 타입
- [x] 신규 기능 추가/수정


## 변경 내용
- **as-is**
  - Dlt 추가

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] [notification] 알림 카프카쪽 수정
 

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.


## 코멘트
- dlt만 추가했습니다. 로직 수정은....아직 딱히 없어서 다른 서비스들에서 알림 받아올 때 리스너 늘어날텐데 그 때 디자인 패턴이나 처리하는 거 늘려서 수정하려 합니다! 제가 처리할 거 생기면 말씀 해주세용 알림 보낼 때 스케줄링을 통한 나중에 발송할 알림인지 즉발 알림인지 나눠서 처리해주셔야 합니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Kafka Dead Letter Topic(DLT) 지원이 추가되어, 알림 이벤트 처리 실패 시 별도의 DLT에서 재처리 및 로그 기록이 가능합니다.

- **버그 수정**
  - 알림 이벤트 처리 중 발생하는 오류가 상세하게 로깅되고, 예외가 다시 발생하도록 개선되었습니다.

- **설정**
  - Kafka 소비자 및 프로듀서 설정이 세분화되어, 오프셋 커밋, 배치 처리, 에러 핸들링, 토픽 파티션/복제본 수 등이 외부 설정으로 관리됩니다.
  - application.yml에 Kafka 관련 소비자 및 토픽 설정이 추가 및 개선되었습니다.

- **리팩터링**
  - Kafka 관련 설정 및 공통 코드가 재사용 가능하도록 구조가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->