### PR TITLE
[restaurant] 내부 목록 조회

### DIFF
--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantService.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantService.java
@@ -6,11 +6,14 @@ package table.eat.now.restaurant.restaurant.application.service;
 
 import table.eat.now.restaurant.restaurant.application.service.dto.request.CreateRestaurantCommand;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantCriteria;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.ModifyRestaurantCommand;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.CreateRestaurantInfo;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.GetRestaurantInfo;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.GetRestaurantSimpleInfo;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.ModifyRestaurantInfo;
+import table.eat.now.restaurant.restaurant.application.service.dto.response.PaginatedInfo;
+import table.eat.now.restaurant.restaurant.application.service.dto.response.SearchRestaurantsInfo;
 
 public interface RestaurantService {
 
@@ -18,9 +21,11 @@ public interface RestaurantService {
 
   GetRestaurantInfo getRestaurant(GetRestaurantCriteria criteria);
 
+  GetRestaurantSimpleInfo getRestaurantByStaffId(Long staffId);
+
+  PaginatedInfo<SearchRestaurantsInfo> searchRestaurants(GetRestaurantsCriteria criteria);
+
   void increaseOrDecreaseTimeSlotGuestCount(String restaurantTimeSlotUuid, int delta);
 
   ModifyRestaurantInfo modifyRestaurant(ModifyRestaurantCommand command);
-
-  GetRestaurantSimpleInfo getRestaurantByStaffId(Long staffId);
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantServiceImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantServiceImpl.java
@@ -18,6 +18,7 @@ import table.eat.now.restaurant.restaurant.application.exception.RestaurantError
 import table.eat.now.restaurant.restaurant.application.exception.RestaurantTimeSlotErrorCode;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.CreateRestaurantCommand;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantCriteria;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.ModifyRestaurantCommand;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.ModifyRestaurantCommand.MenuCommand;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.ModifyRestaurantCommand.TimeSlotCommand;
@@ -25,6 +26,8 @@ import table.eat.now.restaurant.restaurant.application.service.dto.response.Crea
 import table.eat.now.restaurant.restaurant.application.service.dto.response.GetRestaurantInfo;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.GetRestaurantSimpleInfo;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.ModifyRestaurantInfo;
+import table.eat.now.restaurant.restaurant.application.service.dto.response.PaginatedInfo;
+import table.eat.now.restaurant.restaurant.application.service.dto.response.SearchRestaurantsInfo;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
 import table.eat.now.restaurant.restaurant.domain.entity.RestaurantMenu;
 import table.eat.now.restaurant.restaurant.domain.entity.RestaurantTimeSlot;
@@ -80,6 +83,18 @@ public class RestaurantServiceImpl implements RestaurantService {
   }
 
   @Override
+  public GetRestaurantSimpleInfo getRestaurantByStaffId(Long staffId) {
+    Restaurant restaurant = getRestaurantByStaffOrOwnerId(staffId);
+    return GetRestaurantSimpleInfo.from(restaurant);
+  }
+
+  @Override
+  public PaginatedInfo<SearchRestaurantsInfo> searchRestaurants(GetRestaurantsCriteria criteria) {
+    return PaginatedInfo.from(restaurantRepository.searchRestaurants(criteria))
+        .mapWithIndex((restaurant, idx) -> SearchRestaurantsInfo.from(restaurant, idx));
+  }
+
+  @Override
   @Transactional
   public void increaseOrDecreaseTimeSlotGuestCount(String restaurantTimeSlotUuid, int delta) {
     RestaurantTimeSlot timeSlot = restaurantTimeSlotRepository
@@ -124,12 +139,6 @@ public class RestaurantServiceImpl implements RestaurantService {
         .restaurantUuid(command.restaurantUuid())
         .name(command.name())
         .build();
-  }
-
-  @Override
-  public GetRestaurantSimpleInfo getRestaurantByStaffId(Long staffId) {
-    Restaurant restaurant = getRestaurantByStaffOrOwnerId(staffId);
-    return GetRestaurantSimpleInfo.from(restaurant);
   }
 
   private Restaurant getRestaurantByStaffOrOwnerId(Long staffId) {

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantServiceImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/RestaurantServiceImpl.java
@@ -89,6 +89,7 @@ public class RestaurantServiceImpl implements RestaurantService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public PaginatedInfo<SearchRestaurantsInfo> searchRestaurants(GetRestaurantsCriteria criteria) {
     return PaginatedInfo.from(restaurantRepository.searchRestaurants(criteria))
         .mapWithIndex((restaurant, idx) -> SearchRestaurantsInfo.from(restaurant, idx));

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/request/GetRestaurantsCriteria.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/request/GetRestaurantsCriteria.java
@@ -1,0 +1,45 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 15.
+ */
+package table.eat.now.restaurant.restaurant.application.service.dto.request;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import table.eat.now.common.resolver.dto.UserRole;
+
+@Builder
+public record GetRestaurantsCriteria(
+    UserRole role,
+    Long userId,
+    String searchText,
+    Long ownerId,
+    Long staffId,
+    RestaurantStatus restaurantStatus,
+    WaitingStatus waitingStatus,
+    int pageNumber,
+    int pageSize,
+    boolean isAsc,
+    String sortBy,
+    boolean includeDeleted
+){
+
+  @RequiredArgsConstructor
+  public enum RestaurantStatus {
+    OPENED("운영중"),
+    CLOSED("마감된"),
+    BREAK("브레이크 타임"),
+    HOLIDAY("휴일"),
+    INACTIVE("비활성화"),
+    ;
+    private final String name;
+  }
+
+  @RequiredArgsConstructor
+  public enum WaitingStatus {
+    ACTIVE("활성화"),
+    INACTIVE("비활성화"),
+    ;
+    private final String name;
+  }
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/request/GetRestaurantsCriteria.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/request/GetRestaurantsCriteria.java
@@ -1,6 +1,6 @@
 /**
  * @author : jieun(je-pa)
- * @Date : 2025. 04. 15.
+ * @Date : 2025. 04. 26.
  */
 package table.eat.now.restaurant.restaurant.application.service.dto.request;
 

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/PaginatedInfo.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/PaginatedInfo.java
@@ -71,12 +71,6 @@ public record PaginatedInfo<T>(
   }
 
   private <R> List<R> getListWithIndex(BiFunction<T, Long, R> mapper) {
-    //  이렇게도 되는데 뭐가 더 좋을까?
-//      long[] idx = { offset() };
-//
-//        return this.contents.stream()
-//            .map(t -> mapper.apply(t, idx[0]++))
-//          .toList();
     return IntStream.range(0, contents.size())
         .mapToObj(i -> mapper.apply(contents.get(i), i + this.offset()))
         .toList();

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/PaginatedInfo.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/PaginatedInfo.java
@@ -1,0 +1,80 @@
+package table.eat.now.restaurant.restaurant.application.service.dto.response;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.IntStream;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import table.eat.now.restaurant.restaurant.domain.dto.response.Paginated;
+
+@Builder
+public record PaginatedInfo<T>(
+    List<T> contents,
+    long totalElements,
+    int totalPages,
+    int pageNumber,
+    int pageSize
+) {
+
+  public static <T> PaginatedInfo<T> from(Page<T> page) {
+    Pageable pageable = page.getPageable();
+
+    return PaginatedInfo.<T>builder()
+        .contents(page.getContent())
+        .totalElements(page.getTotalElements())
+        .totalPages(page.getTotalPages())
+        .pageNumber(pageable.getPageNumber() + 1)
+        .pageSize(pageable.getPageSize())
+        .build();
+  }
+
+  public static <T> PaginatedInfo<T> of(
+      List<T> contents, long totalElements, int totalPages, int pageNumber, int pageSize) {
+
+    return PaginatedInfo.<T>builder()
+        .contents(contents)
+        .totalElements(totalElements)
+        .totalPages(totalPages)
+        .pageNumber(pageNumber)
+        .pageSize(pageSize)
+        .build();
+  }
+
+  public static <T> PaginatedInfo<T> from(Paginated<T> page) {
+
+    return PaginatedInfo.<T>builder()
+        .contents(page.contents())
+        .totalElements(page.totalElements())
+        .totalPages(page.totalPages())
+        .pageNumber(page.pageNumber())
+        .pageSize(page.pageSize())
+        .build();
+  }
+
+  public <R> PaginatedInfo<R> mapWithIndex(BiFunction<T, Long, R> mapper) {
+    return PaginatedInfo.<R>builder()
+        .contents(getListWithIndex(mapper))
+        .totalElements(this.totalElements)
+        .totalPages(this.totalPages)
+        .pageNumber(this.pageNumber)
+        .pageSize(this.pageSize)
+        .build();
+  }
+
+  public long offset() {
+    return (long) (this.pageNumber - 1) * this.pageSize + 1;
+  }
+
+  private <R> List<R> getListWithIndex(BiFunction<T, Long, R> mapper) {
+    //  이렇게도 되는데 뭐가 더 좋을까?
+//      long[] idx = { offset() };
+//
+//        return this.contents.stream()
+//            .map(t -> mapper.apply(t, idx[0]++))
+//          .toList();
+    return IntStream.range(0, contents.size())
+        .mapToObj(i -> mapper.apply(contents.get(i), i + this.offset()))
+        .toList();
+  }
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/PaginatedInfo.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/PaginatedInfo.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 26.
+ */
 package table.eat.now.restaurant.restaurant.application.service.dto.response;
 
 import java.util.List;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/SearchRestaurantsInfo.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/SearchRestaurantsInfo.java
@@ -1,0 +1,44 @@
+package table.eat.now.restaurant.restaurant.application.service.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import lombok.Builder;
+import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
+
+@Builder
+public record SearchRestaurantsInfo(
+    Long index,
+    String restaurantUuid,
+    Long ownerId,
+    Long staffId,
+    String name,
+    BigDecimal reviewRatingAvg,
+    String info,
+    Integer maxReservationGuestCountPerTeamOnline,
+    String waitingStatus,
+    String status,
+    String contactNumber,
+    String address,
+    LocalTime openingAt,
+    LocalTime closingAt
+) {
+
+  public static SearchRestaurantsInfo from(Restaurant restaurant, Long index) {
+    return SearchRestaurantsInfo.builder()
+        .index(index)
+        .restaurantUuid(restaurant.getRestaurantUuid())
+        .ownerId(restaurant.getOwnerId())
+        .staffId(restaurant.getStaffId())
+        .name(restaurant.getName())
+        .reviewRatingAvg(restaurant.getReviewRatingAvg())
+        .info(restaurant.getInfo())
+        .maxReservationGuestCountPerTeamOnline(
+            restaurant.getMaxReservationGuestCountPerTeamOnline())
+        .waitingStatus(restaurant.getWaitingStatus().name())
+        .status(restaurant.getStatus().name())
+        .address(restaurant.getContactInfo().getAddress())
+        .openingAt(restaurant.getOperatingTime().getOpeningAt())
+        .closingAt(restaurant.getOperatingTime().getClosingAt())
+        .build();
+  }
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/SearchRestaurantsInfo.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/SearchRestaurantsInfo.java
@@ -36,6 +36,7 @@ public record SearchRestaurantsInfo(
             restaurant.getMaxReservationGuestCountPerTeamOnline())
         .waitingStatus(restaurant.getWaitingStatus().name())
         .status(restaurant.getStatus().name())
+        .contactNumber(restaurant.getContactInfo().getAddress())
         .address(restaurant.getContactInfo().getAddress())
         .openingAt(restaurant.getOperatingTime().getOpeningAt())
         .closingAt(restaurant.getOperatingTime().getClosingAt())

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/SearchRestaurantsInfo.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/application/service/dto/response/SearchRestaurantsInfo.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 26.
+ */
 package table.eat.now.restaurant.restaurant.application.service.dto.response;
 
 import java.math.BigDecimal;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/dto/response/Paginated.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/dto/response/Paginated.java
@@ -1,0 +1,25 @@
+package table.eat.now.restaurant.restaurant.domain.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record Paginated<T>(
+    List<T> contents,
+    long totalElements,
+    int totalPages,
+    int pageNumber,
+    int pageSize
+) {
+
+  public static <T> Paginated<T> of(
+      List<T> contents, long totalElements, int totalPages, int pageNumber, int pageSize) {
+    return Paginated.<T>builder()
+        .contents(contents)
+        .totalElements(totalElements)
+        .totalPages(totalPages)
+        .pageNumber(pageNumber)
+        .pageSize(pageSize)
+        .build();
+  }
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/dto/response/Paginated.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/dto/response/Paginated.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 26.
+ */
 package table.eat.now.restaurant.restaurant.domain.dto.response;
 
 import java.util.List;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/entity/Restaurant.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/entity/Restaurant.java
@@ -189,8 +189,7 @@ public class Restaurant extends BaseEntity {
   @Getter
   @RequiredArgsConstructor
   public enum WaitingStatus {
-    OPENED("운영중"),
-    LIMITED("제한된"),
+    ACTIVE("활성화"),
     INACTIVE("비활성화"),
     ;
     private final String name;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/repository/RestaurantRepository.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/domain/repository/RestaurantRepository.java
@@ -6,6 +6,8 @@ package table.eat.now.restaurant.restaurant.domain.repository;
 
 import java.util.List;
 import java.util.Optional;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
+import table.eat.now.restaurant.restaurant.domain.dto.response.Paginated;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
 
 public interface RestaurantRepository {
@@ -17,6 +19,10 @@ public interface RestaurantRepository {
   Optional<Restaurant> findByDynamicCondition(String restaurantUuid, boolean includeDeleted,
       boolean includeInactive);
 
+  Optional<Restaurant> findByStaffIdOrOwnerId(Long id);
+
+  Paginated<Restaurant> searchRestaurants(GetRestaurantsCriteria criteria);
+
   boolean isOwner(Long userId, String restaurantUuid);
 
   boolean isStaff(Long userId, String restaurantUuid);
@@ -26,5 +32,4 @@ public interface RestaurantRepository {
 
   <S extends Restaurant> List<S> saveAll(Iterable<S> restaurants);
 
-  Optional<Restaurant> findByStaffIdOrOwnerId(Long id);
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustom.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustom.java
@@ -5,10 +5,18 @@
 package table.eat.now.restaurant.restaurant.infrastructure.persistence;
 
 import java.util.Optional;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
+import table.eat.now.restaurant.restaurant.domain.dto.response.Paginated;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
 
 public interface RestaurantRepositoryCustom {
-  Optional<Restaurant> findByDynamicCondition(String restaurantUuid, boolean includeDeleted, boolean includeInactive);
+
+  Optional<Restaurant> findByDynamicCondition(String restaurantUuid, boolean includeDeleted,
+      boolean includeInactive);
+
+  Paginated<Restaurant> searchRestaurants(GetRestaurantsCriteria criteria);
+
   boolean isOwnerByUserIdAndRestaurantUuid(Long userId, String restaurantUuid);
+
   boolean isStaffByUserIdAndRestaurantUuid(Long userId, String restaurantUuid);
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
@@ -63,7 +63,7 @@ public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCusto
 
   @Override
   public Paginated<Restaurant> searchRestaurants(GetRestaurantsCriteria criteria) {
-    QRestaurant qRestaurant = QRestaurant.restaurant;
+    QRestaurant qRestaurant = restaurant;
 
     // 조건 빌더 클래스를 사용하여 동적 조건 추가
     RestaurantSearchCondition searchCondition = new RestaurantSearchCondition(qRestaurant, criteria);

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
 import table.eat.now.restaurant.restaurant.domain.dto.response.Paginated;
-import table.eat.now.restaurant.restaurant.domain.entity.QRestaurant;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant.RestaurantStatus;
 import table.eat.now.restaurant.restaurant.domain.entity.RestaurantMenu.MenuStatus;
@@ -63,14 +62,12 @@ public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCusto
 
   @Override
   public Paginated<Restaurant> searchRestaurants(GetRestaurantsCriteria criteria) {
-    QRestaurant qRestaurant = restaurant;
-
     // 조건 빌더 클래스를 사용하여 동적 조건 추가
-    RestaurantSearchCondition searchCondition = new RestaurantSearchCondition(qRestaurant, criteria);
+    RestaurantSearchCondition searchCondition = new RestaurantSearchCondition(restaurant, criteria);
     BooleanBuilder builder = searchCondition.build();
 
     // 쿼리 실행
-    List<Restaurant> result = queryFactory.selectFrom(qRestaurant)
+    List<Restaurant> result = queryFactory.selectFrom(restaurant)
         .where(builder)
         .orderBy(getOrderSpecifier(criteria.sortBy(), criteria.isAsc()))
         .offset(criteria.pageNumber() * criteria.pageSize())
@@ -81,7 +78,7 @@ public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCusto
     if (result.isEmpty() || result.size() >= criteria.pageSize()) {
       total = Optional.ofNullable(
           queryFactory.select(Wildcard.count)
-              .from(qRestaurant)
+              .from(restaurant)
               .where(builder)
               .fetchOne()
       ).orElse(0L);

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
@@ -78,16 +78,16 @@ public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCusto
         .fetch();
 
     long total;
-    if (result.size() < criteria.pageSize()) {
-      int start =  criteria.pageNumber() * criteria.pageSize();
-      total = start + result.size();
-    } else {
+    if (result.isEmpty() || result.size() >= criteria.pageSize()) {
       total = Optional.ofNullable(
           queryFactory.select(Wildcard.count)
               .from(qRestaurant)
               .where(builder)
               .fetchOne()
       ).orElse(0L);
+    } else {
+      int start =  criteria.pageNumber() * criteria.pageSize();
+      total = start + result.size();
     }
 
     int totalPages = (int) ((total + criteria.pageSize() - 1) / criteria.pageSize());

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
@@ -12,6 +12,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -81,9 +82,12 @@ public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCusto
       int start =  criteria.pageNumber() * criteria.pageSize();
       total = start + result.size();
     } else {
-      total =queryFactory.selectFrom(qRestaurant)
-          .where(builder)
-          .fetchCount();
+      total = Optional.ofNullable(
+          queryFactory.select(Wildcard.count)
+              .from(qRestaurant)
+              .where(builder)
+              .fetchOne()
+      ).orElse(0L);
     }
 
     int totalPages = (int) ((total + criteria.pageSize() - 1) / criteria.pageSize());

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryCustomImpl.java
@@ -9,12 +9,20 @@ import static table.eat.now.restaurant.restaurant.domain.entity.QRestaurantMenu.
 import static table.eat.now.restaurant.restaurant.domain.entity.QRestaurantTimeSlot.restaurantTimeSlot;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
+import table.eat.now.restaurant.restaurant.domain.dto.response.Paginated;
+import table.eat.now.restaurant.restaurant.domain.entity.QRestaurant;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant.RestaurantStatus;
 import table.eat.now.restaurant.restaurant.domain.entity.RestaurantMenu.MenuStatus;
+import table.eat.now.restaurant.restaurant.infrastructure.persistence.condition.RestaurantSearchCondition;
 
 @RequiredArgsConstructor
 public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCustom {
@@ -48,18 +56,75 @@ public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCusto
     if (!includeInactive) {
       builder.and(restaurant.status.ne(RestaurantStatus.INACTIVE))
           .and(restaurantMenu.status.ne(MenuStatus.INACTIVE));
-//      builder.and(
-//          JPAExpressions
-//              .selectOne()
-//              .from(restaurantMenu)
-//              .where(
-//                  restaurantMenu.restaurant.eq(restaurant),
-//                  restaurantMenu.status.eq(RestaurantMenu.MenuStatus.INACTIVE)
-//              )
-//              .notExists()
-//      );
     }
     return builder;
+  }
+
+  @Override
+  public Paginated<Restaurant> searchRestaurants(GetRestaurantsCriteria criteria) {
+    QRestaurant qRestaurant = QRestaurant.restaurant;
+
+    // 조건 빌더 클래스를 사용하여 동적 조건 추가
+    RestaurantSearchCondition searchCondition = new RestaurantSearchCondition(qRestaurant, criteria);
+    BooleanBuilder builder = searchCondition.build();
+
+    // 쿼리 실행
+    List<Restaurant> result = queryFactory.selectFrom(qRestaurant)
+        .where(builder)
+        .orderBy(getOrderSpecifier(criteria.sortBy(), criteria.isAsc()))
+        .offset(criteria.pageNumber() * criteria.pageSize())
+        .limit(criteria.pageSize())
+        .fetch();
+
+    long total;
+    if (result.size() < criteria.pageSize()) {
+      int start =  criteria.pageNumber() * criteria.pageSize();
+      total = start + result.size();
+    } else {
+      total =queryFactory.selectFrom(qRestaurant)
+          .where(builder)
+          .fetchCount();
+    }
+
+    int totalPages = (int) ((total + criteria.pageSize() - 1) / criteria.pageSize());
+
+    return Paginated.of(result, total, totalPages, criteria.pageNumber(), criteria.pageSize());
+  }
+
+  public static OrderSpecifier<?> getOrderSpecifier(String sortBy, boolean isAsc) {
+    if(sortBy == null) sortBy = "id";
+
+    Order order = isAsc ? Order.ASC : Order.DESC;
+    PathBuilder<?> entityPath = new PathBuilder<>(Restaurant.class, "restaurant");
+
+    RestaurantSortField sortField = RestaurantSortField.from(sortBy);
+
+    switch (sortField) {
+      case ID -> {
+        return new OrderSpecifier<>(order, entityPath.getNumber("id", Long.class));
+      }
+      case NAME -> {
+        return new OrderSpecifier<>(order, entityPath.getString("name"));
+      }
+      default -> throw new IllegalArgumentException("Unsupported sort field: " + sortField);
+    }
+  }
+
+  @RequiredArgsConstructor
+  public enum RestaurantSortField {
+    ID("id"),
+    NAME("name");
+
+    private final String field;
+
+    public static RestaurantSortField from(String sortBy) {
+      for (RestaurantSortField value : values()) {
+        if (value.field.equals(sortBy)) {
+          return value;
+        }
+      }
+      throw new IllegalArgumentException("Unsupported sortBy: " + sortBy);
+    }
   }
 
   @Override

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryImpl.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/RestaurantRepositoryImpl.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
+import table.eat.now.restaurant.restaurant.domain.dto.response.Paginated;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
 import table.eat.now.restaurant.restaurant.domain.repository.RestaurantRepository;
 
@@ -45,6 +47,16 @@ public class RestaurantRepositoryImpl implements RestaurantRepository {
   }
 
   @Override
+  public Optional<Restaurant> findByStaffIdOrOwnerId(Long id) {
+    return jpaRestaurantRepository.findByStaffIdOrOwnerIdWithSingleParam(id);
+  }
+
+  @Override
+  public Paginated<Restaurant> searchRestaurants(GetRestaurantsCriteria criteria) {
+    return jpaRestaurantRepository.searchRestaurants(criteria);
+  }
+
+  @Override
   public boolean isOwner(Long userId, String restaurantUuid) {
     return jpaRestaurantRepository.isOwnerByUserIdAndRestaurantUuid(userId, restaurantUuid);
   }
@@ -54,8 +66,4 @@ public class RestaurantRepositoryImpl implements RestaurantRepository {
     return jpaRestaurantRepository.isStaffByUserIdAndRestaurantUuid(userId, restaurantUuid);
   }
 
-  @Override
-  public Optional<Restaurant> findByStaffIdOrOwnerId(Long id) {
-    return jpaRestaurantRepository.findByStaffIdOrOwnerIdWithSingleParam(id);
-  }
 }

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/condition/RestaurantSearchCondition.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/condition/RestaurantSearchCondition.java
@@ -1,0 +1,81 @@
+package table.eat.now.restaurant.restaurant.infrastructure.persistence.condition;
+
+import com.querydsl.core.BooleanBuilder;
+import table.eat.now.common.resolver.dto.UserRole;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
+import table.eat.now.restaurant.restaurant.domain.entity.QRestaurant;
+import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
+
+public class RestaurantSearchCondition {
+
+  private final QRestaurant qRestaurant;
+  private final GetRestaurantsCriteria criteria;
+  private final BooleanBuilder builder;
+
+  public RestaurantSearchCondition(QRestaurant qRestaurant, GetRestaurantsCriteria criteria) {
+    this.qRestaurant = qRestaurant;
+    this.criteria = criteria;
+    this.builder = new BooleanBuilder();
+  }
+
+  public BooleanBuilder build() {
+    addSearchTextCondition();
+    addOwnerIdCondition();
+    addStaffIdCondition();
+    addRestaurantStatusCondition();
+    addWaitingStatusCondition();
+    addDeletedCondition();
+    return builder;
+  }
+
+  // (비즈니스 로직이 여기 들어간 것 같아서 맘에 안드는데 이정도는 괜찮을지..)
+  private void addDeletedCondition() {
+    if(criteria.role() == UserRole.MASTER){
+      if(!criteria.includeDeleted()) builder.and(qRestaurant.deletedAt.isNull());
+      return;
+    }
+
+    if(criteria.role() == UserRole.OWNER && criteria.includeDeleted()){
+      builder.and(
+          qRestaurant.deletedAt.isNull()
+              .or(
+                  qRestaurant.deletedAt.isNotNull().and(qRestaurant.ownerId.eq(criteria.userId()))
+              )
+      );
+      return;
+    }
+
+    builder.and(qRestaurant.deletedAt.isNull());
+  }
+
+  private void addSearchTextCondition() {
+    if (criteria.searchText() != null && !criteria.searchText().isEmpty()) {
+      builder.and(qRestaurant.name.contains(criteria.searchText())
+          .or(qRestaurant.info.contains(criteria.searchText())));
+    }
+  }
+
+  private void addOwnerIdCondition() {
+    if (criteria.ownerId() != null) {
+      builder.and(qRestaurant.ownerId.eq(criteria.ownerId()));
+    }
+  }
+
+  private void addStaffIdCondition() {
+    if (criteria.staffId() != null) {
+      builder.and(qRestaurant.staffId.eq(criteria.staffId()));
+    }
+  }
+
+  private void addRestaurantStatusCondition() {
+    if (criteria.restaurantStatus() != null) {
+      builder.and(qRestaurant.status.eq(Restaurant.RestaurantStatus.valueOf(criteria.restaurantStatus().name())));
+    }
+  }
+
+  private void addWaitingStatusCondition() {
+    if (criteria.waitingStatus() != null) {
+      builder.and(qRestaurant.waitingStatus.eq(Restaurant.WaitingStatus.valueOf(criteria.waitingStatus().name())));
+    }
+  }
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/condition/RestaurantSearchCondition.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/condition/RestaurantSearchCondition.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 26.
+ */
 package table.eat.now.restaurant.restaurant.infrastructure.persistence.condition;
 
 import com.querydsl.core.BooleanBuilder;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/condition/RestaurantSearchCondition.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/infrastructure/persistence/condition/RestaurantSearchCondition.java
@@ -32,7 +32,6 @@ public class RestaurantSearchCondition {
     return builder;
   }
 
-  // (비즈니스 로직이 여기 들어간 것 같아서 맘에 안드는데 이정도는 괜찮을지..)
   private void addDeletedCondition() {
     if(criteria.role() == UserRole.MASTER){
       if(!criteria.includeDeleted()) builder.and(qRestaurant.deletedAt.isNull());

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/request/SearchRestaurantsRequest.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/request/SearchRestaurantsRequest.java
@@ -1,0 +1,59 @@
+package table.eat.now.restaurant.restaurant.presentation.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria.RestaurantStatus;
+import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantsCriteria.WaitingStatus;
+
+public record SearchRestaurantsRequest(
+    String searchText,
+    Long ownerId,
+    Long staffId,
+    @Pattern(
+        regexp = "^(OPENED|CLOSED|BREAK|HOLIDAY|INACTIVE)$",
+        message = "식당 상태는 OPENED, CLOSED, BREAK, HOLIDAY, INACTIVE 중 하나여야 합니다."
+    )
+    String restaurantStatus,
+    @Pattern(
+        regexp = "^(ACTIVE|INACTIVE)$",
+        message = "웨이팅 상태는 ACTIVE 또는 INACTIVE 이어야 합니다."
+    )
+    String waitingStatus,
+    Integer pageNumber,
+    Integer pageSize,
+    Boolean isAsc,
+    @Pattern(
+        regexp = "^(id|name)$",
+        message = "정렬 기준은 id 또는 name만 가능합니다."
+    )
+    String sortBy,
+
+    Boolean includeDeleted
+) {
+  public SearchRestaurantsRequest {
+    if (sortBy == null) sortBy = "id";
+    if (pageSize == null || pageSize <= 0) pageSize = 10;
+    if (pageNumber == null || pageNumber < 0) pageNumber = 0;
+    if (includeDeleted == null) includeDeleted = false;
+    if (isAsc == null) isAsc = false;
+  }
+
+  public GetRestaurantsCriteria toCriteria(CurrentUserInfoDto userInfo) {
+    return GetRestaurantsCriteria.builder()
+        .role(userInfo.role())
+        .userId(userInfo.userId())
+        .searchText(searchText)
+        .ownerId(ownerId)
+        .staffId(staffId)
+        .restaurantStatus(restaurantStatus != null ? RestaurantStatus.valueOf(restaurantStatus) : null)
+        .waitingStatus(waitingStatus != null ? WaitingStatus.valueOf(waitingStatus) : null)
+        .pageNumber(pageNumber)
+        .pageSize(pageSize)
+        .isAsc(isAsc)
+        .sortBy(sortBy)
+        .includeDeleted(includeDeleted)
+        .build();
+  }
+
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/request/SearchRestaurantsRequest.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/request/SearchRestaurantsRequest.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 26.
+ */
 package table.eat.now.restaurant.restaurant.presentation.dto.request;
 
 import jakarta.validation.constraints.Pattern;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/response/PaginatedResponse.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/response/PaginatedResponse.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 26.
+ */
 package table.eat.now.restaurant.restaurant.presentation.dto.response;
 
 import java.util.List;

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/response/PaginatedResponse.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/response/PaginatedResponse.java
@@ -1,0 +1,46 @@
+package table.eat.now.restaurant.restaurant.presentation.dto.response;
+
+import java.util.List;
+import java.util.function.Function;
+import table.eat.now.restaurant.restaurant.application.service.dto.response.PaginatedInfo;
+
+public record PaginatedResponse<T>(
+    List<T> contents,
+    int pageNumber,
+    int pageSize,
+    Long totalElements,
+    int totalPages) {
+
+  public static <T>PaginatedResponse<T> from(PaginatedInfo<T> info) {
+
+    return new PaginatedResponse<T>(
+        info.contents(),
+        info.pageNumber(),
+        info.pageSize(),
+        info.totalElements(),
+        info.totalPages()
+    );
+  }
+
+  public <U> PaginatedResponse<U> map(Function<T, U> mapper) {
+
+    return PaginatedResponse
+        .from(this, this.contents.stream()
+            .map(mapper)
+            .toList());
+  }
+
+  private static <T, U> PaginatedResponse<U> from(
+      PaginatedResponse<T> response,
+      List<U> content) {
+
+    return new PaginatedResponse<>(
+        content,
+        response.pageNumber(),
+        response.pageSize(),
+        response.totalElements(),
+        response.totalPages()
+    );
+  }
+
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/response/SearchRestaurantsResponse.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/response/SearchRestaurantsResponse.java
@@ -1,0 +1,41 @@
+package table.eat.now.restaurant.restaurant.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import lombok.Builder;
+import table.eat.now.restaurant.restaurant.application.service.dto.response.SearchRestaurantsInfo;
+
+@Builder
+public record SearchRestaurantsResponse(
+    String restaurantUuid,
+    Long ownerId,
+    Long staffId,
+    String name,
+    BigDecimal reviewRatingAvg,
+    String info,
+    Integer maxReservationGuestCountPerTeamOnline,
+    String waitingStatus,
+    String status,
+    String contactNumber,
+    String address,
+    LocalTime openingAt,
+    LocalTime closingAt
+) {
+  public static SearchRestaurantsResponse from(SearchRestaurantsInfo info){
+    return SearchRestaurantsResponse.builder()
+        .restaurantUuid(info.restaurantUuid())
+        .ownerId(info.ownerId())
+        .staffId(info.staffId())
+        .name(info.name())
+        .reviewRatingAvg(info.reviewRatingAvg())
+        .info(info.info())
+        .maxReservationGuestCountPerTeamOnline(info.maxReservationGuestCountPerTeamOnline())
+        .waitingStatus(info.waitingStatus())
+        .status(info.status())
+        .contactNumber(info.contactNumber())
+        .address(info.address())
+        .openingAt(info.openingAt())
+        .closingAt(info.closingAt())
+        .build();
+  }
+}

--- a/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/response/SearchRestaurantsResponse.java
+++ b/restaurant/src/main/java/table/eat/now/restaurant/restaurant/presentation/dto/response/SearchRestaurantsResponse.java
@@ -1,3 +1,7 @@
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2025. 04. 26.
+ */
 package table.eat.now.restaurant.restaurant.presentation.dto.response;
 
 import java.math.BigDecimal;

--- a/restaurant/src/test/http/restaurant.http
+++ b/restaurant/src/test/http/restaurant.http
@@ -5,7 +5,7 @@ X-User-Id: 1
 X-User-Role: MASTER
 
 {
-  "ownerId": 101,
+  "ownerId": 102,
   "name": "청춘고기",
   "address": "서울특별시 강남구 테헤란로 123",
   "contactNumber": "02-1234-5678",
@@ -31,7 +31,7 @@ X-User-Id: 1
 X-User-Role: MASTER
 
 {
-  "name": "내가 차린 식당",
+  "name": "내일 먹을 막창 식당",
   "address": "서울특별시 강남구 테헤란로 123",
   "contactNumber": "010-1234-5678",
   "openingAt": "2025-04-17T10:00:00",
@@ -63,13 +63,13 @@ X-User-Role: MASTER
   "timeslots": [
     {
       "restaurantTimeslotUuid": "e61aeb98-b434-447d-8928-b44cf741ca34",
-      "availableStartDate": "2025-04-18",
+      "availableDate": "2025-04-18",
       "maxCapacity": 10,
       "timeslot": "12:00"
     },
     {
       "restaurantTimeslotUuid": null,
-      "availableStartDate": "2025-04-18",
+      "availableDate": "2025-04-18",
       "maxCapacity": 15,
       "timeslot": "18:00"
     }
@@ -84,5 +84,21 @@ X-User-Role: STAFF
 ### 식당 조회
 GET http://localhost:8082/admin/v1/restaurants/38125e11-904b-450e-89ae-3a8145e8cd56
 Content-Type: application/json
+X-User-Id: 1
+X-User-Role: MASTER
+
+### 식당 검색 목록 조회(내부)
+GET http://localhost:8082/internal/v1/restaurants
+    ?
+    searchText=막창
+    &restaurantStatus=INACTIVE
+    &waitingStatus=INACTIVE
+    &pageNumber=0
+    &pageSize=10
+    &isAsc=false
+    &sortBy=id
+    &includeDeleted=true
+#    &ownerId=10
+#    &staffId=1
 X-User-Id: 1
 X-User-Role: MASTER

--- a/restaurant/src/test/java/table/eat/now/restaurant/global/fixture/RestaurantFixture.java
+++ b/restaurant/src/test/java/table/eat/now/restaurant/global/fixture/RestaurantFixture.java
@@ -10,6 +10,7 @@ import java.time.LocalTime;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
 import table.eat.now.restaurant.global.util.LongIdGenerator;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant;
 import table.eat.now.restaurant.restaurant.domain.entity.Restaurant.RestaurantStatus;
@@ -34,7 +35,7 @@ public class RestaurantFixture {
         "address",
         LocalTime.of(9, 0),
         LocalTime.of(17, 0),
-        WaitingStatus.OPENED,
+        WaitingStatus.ACTIVE,
         status,
         menus,
         timeSlots
@@ -77,6 +78,24 @@ public class RestaurantFixture {
 
     restaurant.addMenus(menus);
     restaurant.addTimeSlots(timeSlots);
+    return restaurant;
+  }
+
+  public static Restaurant createRandomByStatusAndWaitingStatusOwnerId(RestaurantStatus restaurantStatus, WaitingStatus waitingStatus, long ownerId) {
+    Restaurant restaurant = createRandomByStatusAndMenusAndTimeSlots(
+        restaurantStatus, Set.of(RestaurantMenuFixture.createRandom()),
+        Set.of(RestaurantTimeSlotFixture.createRandom()));
+    ReflectionTestUtils.setField(restaurant, "waitingStatus", waitingStatus);
+    ReflectionTestUtils.setField(restaurant, "ownerId", ownerId);
+    return restaurant;
+  }
+
+  public static Restaurant createRandomByStatusAndStaffId(RestaurantStatus restaurantStatus, WaitingStatus waitingStatus, long staffId) {
+    Restaurant restaurant = createRandomByStatusAndMenusAndTimeSlots(
+        restaurantStatus, Set.of(RestaurantMenuFixture.createRandom()),
+        Set.of(RestaurantTimeSlotFixture.createRandom()));
+    ReflectionTestUtils.setField(restaurant, "waitingStatus", waitingStatus);
+    ReflectionTestUtils.setField(restaurant, "staffId", staffId);
     return restaurant;
   }
 }

--- a/restaurant/src/test/java/table/eat/now/restaurant/restaurant/presentation/RestaurantInternalControllerTest.java
+++ b/restaurant/src/test/java/table/eat/now/restaurant/restaurant/presentation/RestaurantInternalControllerTest.java
@@ -39,6 +39,8 @@ import table.eat.now.restaurant.restaurant.application.exception.RestaurantTimeS
 import table.eat.now.restaurant.restaurant.application.service.dto.request.GetRestaurantCriteria;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.GetRestaurantInfo;
 import table.eat.now.restaurant.restaurant.application.service.dto.response.GetRestaurantSimpleInfo;
+import table.eat.now.restaurant.restaurant.application.service.dto.response.PaginatedInfo;
+import table.eat.now.restaurant.restaurant.application.service.dto.response.SearchRestaurantsInfo;
 
 class RestaurantInternalControllerTest extends ControllerTestSupport {
 
@@ -126,6 +128,71 @@ class RestaurantInternalControllerTest extends ControllerTestSupport {
     }
   }
 
+  @DisplayName("식당 목록 조회 컨트롤러")
+  @Nested
+  class SearchRestaurants {
+
+    public static Stream<Arguments> provideUserRoleForSearchingRestaurants() {
+      return Stream.of(
+          Arguments.of(UserRole.MASTER),
+          Arguments.of(UserRole.OWNER),
+          Arguments.of(UserRole.STAFF),
+          Arguments.of(UserRole.CUSTOMER)
+      );
+    }
+
+    @DisplayName("식당 목록을 조회할 수 있다.")
+    @MethodSource("provideUserRoleForSearchingRestaurants")
+    @ParameterizedTest(name = "{index}: ''{0}'' 는 식당 목록을 조회할 수 있다.")
+    void success(UserRole role) throws Exception {
+      // given
+      Long userId = 1L;
+
+      SearchRestaurantsInfo info = SearchRestaurantsInfo.builder()
+          .restaurantUuid(UUID.randomUUID().toString())
+          .ownerId(1L)
+          .staffId(2L)
+          .name("맛있는 식당")
+          .reviewRatingAvg(BigDecimal.valueOf(4.5))
+          .info("깔끔한 분위기의 한식당")
+          .maxReservationGuestCountPerTeamOnline(4)
+          .waitingStatus("ACTIVE")
+          .status("OPENED")
+          .contactNumber("010-1234-5678")
+          .address("서울시 강남구")
+          .openingAt(LocalTime.of(9, 0))
+          .closingAt(LocalTime.of(21, 0))
+          .build();
+
+      PaginatedInfo<SearchRestaurantsInfo> paginatedInfo = new PaginatedInfo<>(
+          List.of(info),
+          10,
+          10,
+          1,
+          10
+      );
+
+      given(restaurantService.searchRestaurants(any()))
+          .willReturn(paginatedInfo);
+
+      // when & then
+      mockMvc.perform(get(baseUrl)
+              .header(USER_ID_HEADER, userId)
+              .header(USER_ROLE_HEADER, role)
+              .contentType(MediaType.APPLICATION_JSON)
+              .queryParam("pageNumber", "0")
+              .queryParam("sortBy", "id")
+          )
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.contents[0].name").value("맛있는 식당"))
+          .andExpect(jsonPath("$.pageNumber").value(paginatedInfo.pageNumber()))
+          .andExpect(jsonPath("$.pageSize").value(paginatedInfo.pageSize()))
+          .andExpect(jsonPath("$.totalElements").value(paginatedInfo.totalElements()))
+          .andExpect(jsonPath("$.totalPages").value(paginatedInfo.totalPages()));
+    }
+  }
+
+
   @DisplayName("식당 타임슬롯 현재 인원 수 수정 컨트롤러")
   @Nested
   class modifyGuestCount{
@@ -170,6 +237,7 @@ class RestaurantInternalControllerTest extends ControllerTestSupport {
           .andExpect(status().isBadRequest());
     }
   }
+
   @DisplayName("직원 ID로 식당 조회 internal 컨트롤러")
   @Nested
   class getRestaurantByStaffId {


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #124

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용
- **to-be**
  - [x] 식당 내부 목록 조회

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [x] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- 내부 검색 조회입니다. 수정필요하면 말해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 레스토랑 검색 및 페이징 기능이 내부 API에 추가되었습니다. 다양한 조건(이름, 상태, 소유자/직원 ID 등)으로 레스토랑을 검색할 수 있습니다.
    - 검색 결과는 페이지 단위로 제공되며, 각 레스토랑의 상세 정보와 함께 반환됩니다.

- **버그 수정**
    - 레스토랑 대기 상태 관련 일부 값이 변경되어 더 명확하게 표시됩니다.

- **테스트**
    - 레스토랑 검색 기능에 대한 다양한 역할 및 상태별 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->