### PR TITLE
[review] 오프셋기반페이징 -> 커서기반페이징 수정

### DIFF
--- a/review/build.gradle
+++ b/review/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	//DB, JPA
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/review/build.gradle
+++ b/review/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 	//DB, JPA
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//
+	//CLIENT
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	//COMMON
@@ -63,8 +63,9 @@ dependencies {
 	//KAFKA
 	implementation 'org.springframework.kafka:spring-kafka'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
-	//REDISSON
+	//REDIS
 	implementation 'org.redisson:redisson:3.45.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	//METRICS
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/review/src/main/java/table/eat/now/review/application/batch/Cursor.java
+++ b/review/src/main/java/table/eat/now/review/application/batch/Cursor.java
@@ -1,6 +1,7 @@
 package table.eat.now.review.application.batch;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import table.eat.now.review.domain.repository.search.CursorResult;
 
 public record Cursor(
@@ -22,25 +23,16 @@ public record Cursor(
 
   @Override
   public int compareTo(Cursor other) {
-    int timeCompare = compareNullable(this.lastProcessedUpdatedAt, other.lastProcessedUpdatedAt);
+    int timeCompare = Comparator
+        .<LocalDateTime>nullsFirst(Comparator.naturalOrder())
+        .compare(this.lastProcessedUpdatedAt, other.lastProcessedUpdatedAt);
+
     if (timeCompare != 0) {
       return timeCompare;
     }
-
-    return compareNullable(this.lastProcessedRestaurantId, other.lastProcessedRestaurantId);
-  }
-
-  private static <T extends Comparable<T>> int compareNullable(T a, T b) {
-    if (a == null && b == null) {
-      return 0;
-    }
-    if (a == null) {
-      return -1;
-    }
-    if (b == null) {
-      return 1;
-    }
-    return a.compareTo(b);
+    return Comparator
+        .<String>nullsFirst(Comparator.naturalOrder())
+        .compare(this.lastProcessedRestaurantId, other.lastProcessedRestaurantId);
   }
 
 }

--- a/review/src/main/java/table/eat/now/review/application/batch/Cursor.java
+++ b/review/src/main/java/table/eat/now/review/application/batch/Cursor.java
@@ -1,0 +1,46 @@
+package table.eat.now.review.application.batch;
+
+import java.time.LocalDateTime;
+import table.eat.now.review.domain.repository.search.CursorResult;
+
+public record Cursor(
+    LocalDateTime lastProcessedUpdatedAt,
+    String lastProcessedRestaurantId
+) implements Comparable<Cursor> {
+
+  public static Cursor empty() {
+    return new Cursor(null, null);
+  }
+
+  public static Cursor of(LocalDateTime lastProcessedUpdatedAt, String lastProcessedRestaurantId) {
+    return new Cursor(lastProcessedUpdatedAt, lastProcessedRestaurantId);
+  }
+
+  public static Cursor from(CursorResult endCursorResult) {
+    return new Cursor(endCursorResult.updatedAt(), endCursorResult.restaurantId());
+  }
+
+  @Override
+  public int compareTo(Cursor other) {
+    int timeCompare = compareNullable(this.lastProcessedUpdatedAt, other.lastProcessedUpdatedAt);
+    if (timeCompare != 0) {
+      return timeCompare;
+    }
+
+    return compareNullable(this.lastProcessedRestaurantId, other.lastProcessedRestaurantId);
+  }
+
+  private static <T extends Comparable<T>> int compareNullable(T a, T b) {
+    if (a == null && b == null) {
+      return 0;
+    }
+    if (a == null) {
+      return -1;
+    }
+    if (b == null) {
+      return 1;
+    }
+    return a.compareTo(b);
+  }
+
+}

--- a/review/src/main/java/table/eat/now/review/application/batch/CursorKey.java
+++ b/review/src/main/java/table/eat/now/review/application/batch/CursorKey.java
@@ -1,0 +1,18 @@
+package table.eat.now.review.application.batch;
+
+public enum CursorKey {
+
+  RATING_UPDATE_RECENT_CURSOR("review:rating:batch:recent:cursor"),
+  RATING_UPDATE_DAILY_CURSOR("review:rating:batch:daily:cursor"),
+  ;
+
+  private final String value;
+
+  CursorKey(String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return value;
+  }
+}

--- a/review/src/main/java/table/eat/now/review/application/batch/CursorStore.java
+++ b/review/src/main/java/table/eat/now/review/application/batch/CursorStore.java
@@ -1,0 +1,8 @@
+package table.eat.now.review.application.batch;
+
+public interface CursorStore {
+
+  void saveCursor(String key, Cursor context);
+
+  Cursor getCursor(String key);
+}

--- a/review/src/main/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCase.java
+++ b/review/src/main/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCase.java
@@ -63,7 +63,7 @@ public class UpdateRestaurantRatingUseCase {
         .reviewEventPublisher(reviewEventPublisher)
         .cursorStore(cursorStore)
         .cursorKey(cursorKey.value())
-        .initialCursor(Cursor.of(startTime, lastRestaurantId))
+        .initialCursor(startCursor)
         .endCursor(endCursor)
         .batchSize(batchSize)
         .startTime(startTime)

--- a/review/src/main/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCase.java
+++ b/review/src/main/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCase.java
@@ -1,19 +1,22 @@
 package table.eat.now.review.application.usecase;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import table.eat.now.review.application.batch.Cursor;
+import table.eat.now.review.application.batch.CursorKey;
+import table.eat.now.review.application.batch.CursorStore;
 import table.eat.now.review.application.event.RestaurantRatingUpdateEvent;
 import table.eat.now.review.application.event.RestaurantRatingUpdatePayload;
 import table.eat.now.review.application.event.ReviewEventPublisher;
 import table.eat.now.review.domain.repository.ReviewRepository;
+import table.eat.now.review.domain.repository.search.CursorResult;
 import table.eat.now.review.domain.repository.search.RestaurantRatingResult;
 
 @Slf4j
@@ -21,123 +24,112 @@ import table.eat.now.review.domain.repository.search.RestaurantRatingResult;
 @RequiredArgsConstructor
 public class UpdateRestaurantRatingUseCase {
 
-  @Value("${review.rating.update.batch-size:100}")
-  private int batchSize;
-
+  private final CursorStore cursorStore;
   private final ReviewRepository reviewRepository;
   private final ReviewEventPublisher reviewEventPublisher;
 
-  @Transactional(readOnly = true)
-  public void execute(LocalDateTime startTime, LocalDateTime endTime) {
-    long totalCount = reviewRepository.countRecentlyUpdatedRestaurants(startTime, endTime);
+  @Value("${review.rating.update.batch-size:100}")
+  private int batchSize;
 
-    if (totalCount == 0) {
-      logNoRestaurantsToUpdate();
+  @Transactional(readOnly = true)
+  public void execute(CursorKey cursorKey, Duration interval) {
+
+    LocalDateTime endTime = LocalDateTime.now();
+    Cursor cursor = cursorStore.getCursor(cursorKey.value());
+    LocalDateTime startTime = cursor.lastProcessedUpdatedAt() != null
+        ? cursor.lastProcessedUpdatedAt()
+        : endTime.minus(interval);
+
+    String lastRestaurantId = cursor.lastProcessedRestaurantId();
+
+    Cursor startCursor = Cursor.of(startTime, lastRestaurantId);
+
+    CursorResult endCursorResult = reviewRepository.findEndCursorResult(endTime);
+    if (endCursorResult == null) {
+      log.info("[{}] 업데이트할 레스토랑 평점이 없습니다.", cursorKey.name());
       return;
     }
 
-    logStartBatchUpdate(totalCount);
+    Cursor endCursor = Cursor.from(endCursorResult);
+
+    if (startCursor.compareTo(endCursor) >= 0) {
+      log.info("[{}] 처리할 범위가 없습니다. startCursor={}, endCursor={}",
+          cursorKey.name(), startCursor, endCursor);
+      return;
+    }
 
     BatchProcessor.builder()
         .reviewRepository(reviewRepository)
         .reviewEventPublisher(reviewEventPublisher)
-        .totalCount(totalCount)
+        .cursorStore(cursorStore)
+        .cursorKey(cursorKey.value())
+        .initialCursor(Cursor.of(startTime, lastRestaurantId))
+        .endCursor(endCursor)
         .batchSize(batchSize)
         .startTime(startTime)
         .endTime(endTime)
         .build().process();
   }
 
-  private void logNoRestaurantsToUpdate() {
-    log.info("업데이트할 레스토랑 평점이 없습니다.");
-  }
-
-  private void logStartBatchUpdate(long totalCount) {
-    log.info("총 {}개 레스토랑의 평점을 배치 단위로 업데이트합니다.", totalCount);
-  }
-
+  @Builder
   private static class BatchProcessor {
 
-    private final long totalCount;
-    private final int batchSize;
-    private final LocalDateTime startTime;
-    private final LocalDateTime endTime;
-    private final Set<String> processedIds;
-    private long processedCount;
     private final ReviewRepository reviewRepository;
     private final ReviewEventPublisher reviewEventPublisher;
+    private final CursorStore cursorStore;
+    private final String cursorKey;
+    private final Cursor initialCursor;
+    private final Cursor endCursor;
+    private final LocalDateTime startTime;
+    private final LocalDateTime endTime;
+    private final int batchSize;
 
-    @Builder
-    BatchProcessor(
-        ReviewRepository reviewRepository,
-        ReviewEventPublisher reviewEventPublisher,
-        long totalCount,
-        int batchSize,
-        LocalDateTime startTime,
-        LocalDateTime endTime
-    ) {
-      this.reviewRepository = reviewRepository;
-      this.reviewEventPublisher = reviewEventPublisher;
-      this.totalCount = totalCount;
-      this.batchSize = batchSize;
-      this.startTime = startTime;
-      this.endTime = endTime;
-      this.processedIds = new HashSet<>();
-      this.processedCount = 0;
-    }
+    private Cursor currentCursor;
 
     void process() {
-      while (processedCount < totalCount) {
-        List<String> batch = reviewRepository
-            .findRecentlyUpdatedRestaurantIds(
-                startTime, endTime, processedCount, batchSize);
+      this.currentCursor = this.initialCursor;
+
+      while (currentCursor.compareTo(endCursor) < 0) {
+        List<CursorResult> batch = reviewRepository.findRecentlyUpdatedRestaurantIds(
+            startTime, endTime,
+            currentCursor.lastProcessedUpdatedAt(),
+            currentCursor.lastProcessedRestaurantId(),
+            batchSize
+        );
 
         if (batch.isEmpty()) {
           break;
         }
 
-        List<String> uniqueIds = batch.stream()
-            .filter(id -> !processedIds.contains(id))
-            .peek(processedIds::add)
-            .toList();
-
-        List<RestaurantRatingResult> results =
-            reviewRepository.calculateRestaurantRatings(uniqueIds);
+        List<RestaurantRatingResult> results = reviewRepository
+            .calculateRestaurantRatings(
+                batch.stream()
+                    .map(CursorResult::restaurantId)
+                    .toList()
+            );
 
         results.forEach(result -> {
-              try {
-                reviewEventPublisher.publish(
-                    RestaurantRatingUpdateEvent.of(
-                        RestaurantRatingUpdatePayload.from(result)));
-              } catch (Exception e) {
-                logPublishError(e);
-              }
-            }
-        );
+          try {
+            reviewEventPublisher.publish(
+                RestaurantRatingUpdateEvent.of(
+                    RestaurantRatingUpdatePayload.from(result)));
+          } catch (Exception e) {
+            log.error("레스토랑 평점 업데이트 이벤트 발행 실패", e);
+          }
+        });
 
-        logPublish(results);
-        processedCount += uniqueIds.size();
-        logProgress();
+        moveCursor(batch);
+
+        log.info("레스토랑 평점 업데이트: {}개 처리 완료 (currentCursor: {})", batch.size(), currentCursor);
       }
-      logCompletion();
+
+      log.info("레스토랑 평점 업데이트 작업 완료");
     }
 
-    private void logPublishError(Exception e) {
-      log.error("레스토랑 평점 업데이트 중 오류 발생: {}", e.getMessage(), e);
-    }
-
-    private void logPublish(List<RestaurantRatingResult> results) {
-      log.info("레스토랑 평점 일괄 업데이트 이벤트 발행: {}개", results.size());
-    }
-
-    private void logProgress() {
-      log.info("레스토랑 평점 업데이트 진행률: {}/{} (중복 제외 실제 처리: {}개)",
-          processedCount, totalCount, processedIds.size());
-    }
-
-    private void logCompletion() {
-      log.info("레스토랑 평점 업데이트 작업 완료: 총 {}개 조회됨, 중복 제외 {}개 처리됨",
-          processedCount, processedIds.size());
+    private void moveCursor(List<CursorResult> batch) {
+      CursorResult result = batch.get(batch.size() - 1);
+      this.currentCursor = Cursor.from(result);
+      cursorStore.saveCursor(cursorKey, currentCursor);
     }
   }
 }

--- a/review/src/main/java/table/eat/now/review/domain/repository/ReviewRepository.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/ReviewRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import table.eat.now.review.domain.entity.Review;
 import table.eat.now.review.domain.entity.ReviewReference;
+import table.eat.now.review.domain.repository.search.CursorResult;
 import table.eat.now.review.domain.repository.search.PaginatedResult;
 import table.eat.now.review.domain.repository.search.RestaurantRatingResult;
 import table.eat.now.review.domain.repository.search.SearchAdminReviewCriteria;
@@ -26,10 +27,15 @@ public interface ReviewRepository {
 
   List<RestaurantRatingResult> calculateRestaurantRatings(List<String> restaurantIds);
 
-  List<String> findRecentlyUpdatedRestaurantIds(
-      LocalDateTime startTime, LocalDateTime endTime, long offset, int limit);
-
-  long countRecentlyUpdatedRestaurants(LocalDateTime startTime, LocalDateTime endTime);
-
   <S extends Review> List<S> saveAllAndFlush(Iterable<S> entities);
+
+  List<CursorResult> findRecentlyUpdatedRestaurantIds(
+      LocalDateTime startTime,
+      LocalDateTime endTime,
+      LocalDateTime lastUpdatedAt,
+      String lastRestaurantId,
+      int limit
+  );
+
+  CursorResult findEndCursorResult(LocalDateTime endTime);
 }

--- a/review/src/main/java/table/eat/now/review/domain/repository/search/CursorResult.java
+++ b/review/src/main/java/table/eat/now/review/domain/repository/search/CursorResult.java
@@ -1,0 +1,10 @@
+package table.eat.now.review.domain.repository.search;
+
+import java.time.LocalDateTime;
+
+public record CursorResult(
+    LocalDateTime updatedAt,
+    String restaurantId
+) {
+
+}

--- a/review/src/main/java/table/eat/now/review/infrastructure/kafka/config/ReviewKafkaProducerConfig.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/kafka/config/ReviewKafkaProducerConfig.java
@@ -46,14 +46,15 @@ public class ReviewKafkaProducerConfig {
   public ProducerFactory<String, ReviewEvent> batchProducerFactory() {
     Map<String, Object> props = getCommonProducerProps();
 
-    props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384 * 4);
-    props.put(ProducerConfig.LINGER_MS_CONFIG, 100);
-    props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
+    props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384 * 4); // 64KB
+    props.put(ProducerConfig.LINGER_MS_CONFIG, 100); // 100ms
+    props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432); // 32MB
     props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-    props.put(ProducerConfig.RETRIES_CONFIG, 1); //리트라이 횟수 : 1회
-    props.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 500); // 리트라이 간격 : 0.5초
-    props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000); // 1초로 설정
-    props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 1500); // 최대 리트라이까지의 대기시간 : 1.5초
+    props.put(ProducerConfig.RETRIES_CONFIG, 3); // 재시도 3회
+    props.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 1000); // 재시도 간격 1초
+    props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000); // 요청 타임아웃 30초
+    props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 180000); // 전체 타임아웃 3분
+
     return new DefaultKafkaProducerFactory<>(props);
   }
 

--- a/review/src/main/java/table/eat/now/review/infrastructure/persistence/ReviewRepositoryImpl.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/persistence/ReviewRepositoryImpl.java
@@ -1,0 +1,73 @@
+package table.eat.now.review.infrastructure.persistence;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import table.eat.now.review.domain.entity.Review;
+import table.eat.now.review.domain.entity.ReviewReference;
+import table.eat.now.review.domain.repository.ReviewRepository;
+import table.eat.now.review.domain.repository.search.CursorResult;
+import table.eat.now.review.domain.repository.search.PaginatedResult;
+import table.eat.now.review.domain.repository.search.RestaurantRatingResult;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewCriteria;
+import table.eat.now.review.domain.repository.search.SearchAdminReviewResult;
+import table.eat.now.review.domain.repository.search.SearchReviewCriteria;
+import table.eat.now.review.domain.repository.search.SearchReviewResult;
+import table.eat.now.review.infrastructure.persistence.jpa.JpaReviewRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepository {
+
+  private final JpaReviewRepository jpaRepository;
+
+  @Override
+  public Review save(Review review) {
+    return jpaRepository.save(review);
+  }
+
+  @Override
+  public Optional<Review> findByReviewIdAndDeletedAtIsNull(String reviewId) {
+    return jpaRepository.findByReviewIdAndDeletedAtIsNull(reviewId);
+  }
+
+  @Override
+  public PaginatedResult<SearchReviewResult> searchReviews(SearchReviewCriteria criteria) {
+    return jpaRepository.searchReviews(criteria);
+  }
+
+  @Override
+  public PaginatedResult<SearchAdminReviewResult> searchAdminReviews(
+      SearchAdminReviewCriteria criteria) {
+    return jpaRepository.searchAdminReviews(criteria);
+  }
+
+  @Override
+  public boolean existsByReferenceAndDeletedAtIsNull(ReviewReference reference) {
+    return jpaRepository.existsByReferenceAndDeletedAtIsNull(reference);
+  }
+
+  @Override
+  public List<RestaurantRatingResult> calculateRestaurantRatings(List<String> restaurantIds) {
+    return jpaRepository.calculateRestaurantRatings(restaurantIds);
+  }
+
+  @Override
+  public <S extends Review> List<S> saveAllAndFlush(Iterable<S> entities) {
+    return jpaRepository.saveAllAndFlush(entities);
+  }
+
+  @Override
+  public List<CursorResult> findRecentlyUpdatedRestaurantIds(LocalDateTime startTime,
+      LocalDateTime endTime, LocalDateTime lastUpdatedAt, String lastRestaurantId, int limit) {
+    return jpaRepository.findRecentlyUpdatedRestaurantIds(
+        startTime, endTime, lastUpdatedAt, lastRestaurantId, limit);
+  }
+
+  @Override
+  public CursorResult findEndCursorResult(LocalDateTime endTime) {
+    return jpaRepository.findEndCursorResult(endTime);
+  }
+}

--- a/review/src/main/java/table/eat/now/review/infrastructure/persistence/jpa/JpaReviewRepository.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/persistence/jpa/JpaReviewRepository.java
@@ -1,30 +1,14 @@
 package table.eat.now.review.infrastructure.persistence.jpa;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import table.eat.now.review.domain.entity.Review;
 import table.eat.now.review.domain.entity.ReviewReference;
-import table.eat.now.review.domain.repository.ReviewRepository;
 
 public interface JpaReviewRepository extends
-    JpaRepository<Review, Long>, ReviewRepository, JpaReviewRepositoryCustom {
+    JpaRepository<Review, Long>, JpaReviewRepositoryCustom {
 
   Optional<Review> findByReviewIdAndDeletedAtIsNull(String reviewId);
 
   boolean existsByReferenceAndDeletedAtIsNull(ReviewReference reference);
-
-  @Query(value = """
-        SELECT COUNT(*)
-        FROM (
-            SELECT r.restaurant_uuid
-            FROM p_review r
-            WHERE r.updated_at BETWEEN :startTime AND :endTime
-            GROUP BY r.restaurant_uuid
-        ) AS grouped
-      """, nativeQuery = true)
-  long countRecentlyUpdatedRestaurants(@Param("startTime") LocalDateTime startTime,
-      @Param("endTime") LocalDateTime endTime);
 }

--- a/review/src/main/java/table/eat/now/review/infrastructure/persistence/jpa/JpaReviewRepositoryCustom.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/persistence/jpa/JpaReviewRepositoryCustom.java
@@ -2,6 +2,7 @@ package table.eat.now.review.infrastructure.persistence.jpa;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import table.eat.now.review.domain.repository.search.CursorResult;
 import table.eat.now.review.domain.repository.search.PaginatedResult;
 import table.eat.now.review.domain.repository.search.RestaurantRatingResult;
 import table.eat.now.review.domain.repository.search.SearchAdminReviewCriteria;
@@ -17,6 +18,14 @@ public interface JpaReviewRepositoryCustom {
 
   List<RestaurantRatingResult> calculateRestaurantRatings(List<String> restaurantIds);
 
-  List<String> findRecentlyUpdatedRestaurantIds(
-      LocalDateTime startTime, LocalDateTime endTime, long offset, int limit);
+  List<CursorResult> findRecentlyUpdatedRestaurantIds(
+      LocalDateTime startTime,
+      LocalDateTime endTime,
+      LocalDateTime lastUpdatedAt,
+      String lastRestaurantId,
+      int limit
+  );
+
+  CursorResult findEndCursorResult(LocalDateTime endTime);
 }
+

--- a/review/src/main/java/table/eat/now/review/infrastructure/persistence/jpa/JpaReviewRepositoryCustomImpl.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/persistence/jpa/JpaReviewRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package table.eat.now.review.infrastructure.persistence.jpa;
 
 import static table.eat.now.review.domain.entity.QReview.review;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -42,7 +43,8 @@ public class JpaReviewRepositoryCustomImpl implements JpaReviewRepositoryCustom 
         ))
         .from(review)
         .where(
-            updatedAtBetween(startTime,endTime)
+            new BooleanBuilder()
+                .and(updatedAtBetween(startTime,endTime))
                 .and(afterCursor(lastUpdatedAt, lastRestaurantId))
         )
         .groupBy(review.reference.restaurantId)

--- a/review/src/main/java/table/eat/now/review/infrastructure/redis/RedisCursorStoreImpl.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/redis/RedisCursorStoreImpl.java
@@ -1,0 +1,44 @@
+package table.eat.now.review.infrastructure.redis;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import table.eat.now.review.application.batch.Cursor;
+import table.eat.now.review.application.batch.CursorStore;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisCursorStoreImpl implements CursorStore {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  private static final String FIELD_UPDATED_AT = "lastProcessedUpdatedAt";
+  private static final String FIELD_RESTAURANT_ID = "lastProcessedRestaurantId";
+
+  @Override
+  public void saveCursor(String key, Cursor cursor) {
+    Map<String, String> cursorMap = new HashMap<>();
+    cursorMap.put(FIELD_UPDATED_AT, cursor.lastProcessedUpdatedAt().toString());
+    cursorMap.put(FIELD_RESTAURANT_ID, cursor.lastProcessedRestaurantId());
+
+    redisTemplate.opsForHash().putAll(key, cursorMap);
+  }
+
+  @Override
+  public Cursor getCursor(String key) {
+    Object updatedAtValue = redisTemplate.opsForHash().get(key, FIELD_UPDATED_AT);
+    Object restaurantIdValue = redisTemplate.opsForHash().get(key, FIELD_RESTAURANT_ID);
+
+    if (updatedAtValue == null || restaurantIdValue == null) {
+      return Cursor.empty();
+    }
+
+    return Cursor.of(
+        LocalDateTime.parse(updatedAtValue.toString()),
+        restaurantIdValue.toString()
+    );
+  }
+}

--- a/review/src/main/java/table/eat/now/review/infrastructure/redis/RedisCursorStoreImpl.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/redis/RedisCursorStoreImpl.java
@@ -4,11 +4,13 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 import table.eat.now.review.application.batch.Cursor;
 import table.eat.now.review.application.batch.CursorStore;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class RedisCursorStoreImpl implements CursorStore {
@@ -21,16 +23,28 @@ public class RedisCursorStoreImpl implements CursorStore {
   @Override
   public void saveCursor(String key, Cursor cursor) {
     Map<String, String> cursorMap = new HashMap<>();
-    cursorMap.put(FIELD_UPDATED_AT, cursor.lastProcessedUpdatedAt().toString());
-    cursorMap.put(FIELD_RESTAURANT_ID, cursor.lastProcessedRestaurantId());
+
+    if (cursor.lastProcessedUpdatedAt() != null) {
+      cursorMap.put(FIELD_UPDATED_AT, cursor.lastProcessedUpdatedAt().toString());
+    }
+
+    if (cursor.lastProcessedRestaurantId() != null) {
+      cursorMap.put(FIELD_RESTAURANT_ID, cursor.lastProcessedRestaurantId());
+    }
 
     redisTemplate.opsForHash().putAll(key, cursorMap);
   }
 
   @Override
   public Cursor getCursor(String key) {
-    Object updatedAtValue = redisTemplate.opsForHash().get(key, FIELD_UPDATED_AT);
-    Object restaurantIdValue = redisTemplate.opsForHash().get(key, FIELD_RESTAURANT_ID);
+    Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+
+    if (entries.isEmpty()) {
+      return Cursor.empty();
+    }
+
+    Object updatedAtValue = entries.get(FIELD_UPDATED_AT);
+    Object restaurantIdValue = entries.get(FIELD_RESTAURANT_ID);
 
     if (updatedAtValue == null || restaurantIdValue == null) {
       return Cursor.empty();

--- a/review/src/main/java/table/eat/now/review/infrastructure/redis/config/RedisTemplateConfig.java
+++ b/review/src/main/java/table/eat/now/review/infrastructure/redis/config/RedisTemplateConfig.java
@@ -1,0 +1,22 @@
+package table.eat.now.review.infrastructure.redis.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisTemplateConfig {
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<String, Object> template = new RedisTemplate<>();
+    template.setConnectionFactory(redisConnectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    template.setHashKeySerializer(new StringRedisSerializer());
+    template.setHashValueSerializer(new StringRedisSerializer());
+    return template;
+  }
+}

--- a/review/src/main/resources/application.yml
+++ b/review/src/main/resources/application.yml
@@ -62,8 +62,7 @@ review:
   rating:
     update:
       recent:
-        cron: 0 */5 * * * *
-        interval: 5
+        delay-ms: 300000
       daily:
         cron: 0 0 4 * * *
       batch-size: 100

--- a/review/src/test/java/table/eat/now/review/application/batch/CursorTest.java
+++ b/review/src/test/java/table/eat/now/review/application/batch/CursorTest.java
@@ -1,0 +1,129 @@
+package table.eat.now.review.application.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import table.eat.now.review.domain.repository.search.CursorResult;
+
+class CursorTest {
+
+  @Test
+  void empty_메서드는_null_값을_가진_커서를_반환할_수_있다() {
+    // when
+    Cursor emptyCursor = Cursor.empty();
+
+    // then
+    assertThat(emptyCursor.lastProcessedUpdatedAt()).isNull();
+    assertThat(emptyCursor.lastProcessedRestaurantId()).isNull();
+  }
+
+  @Test
+  void of_메서드는_지정된_값으로_커서를_생성할_수_있다() {
+    // given
+    LocalDateTime time = LocalDateTime.of(2025, 4, 27, 12, 0);
+    String restaurantId = "restaurant-1";
+
+    // when
+    Cursor cursor = Cursor.of(time, restaurantId);
+
+    // then
+    assertThat(cursor.lastProcessedUpdatedAt()).isEqualTo(time);
+    assertThat(cursor.lastProcessedRestaurantId()).isEqualTo(restaurantId);
+  }
+
+  @Test
+  void from_메서드는_CursorResult로부터_커서를_생성할_수_있다() {
+    // given
+    LocalDateTime time = LocalDateTime.of(2025, 4, 27, 12, 0);
+    String restaurantId = "restaurant-1";
+    CursorResult cursorResult = new CursorResult(time, restaurantId);
+
+    // when
+    Cursor cursor = Cursor.from(cursorResult);
+
+    // then
+    assertThat(cursor.lastProcessedUpdatedAt()).isEqualTo(time);
+    assertThat(cursor.lastProcessedRestaurantId()).isEqualTo(restaurantId);
+  }
+
+  @Nested
+  class compareTo_메서드는 {
+
+    @Test
+    void 시간이_다르면_시간_기준으로_비교한다() {
+      // given
+      LocalDateTime earlier = LocalDateTime.of(2025, 4, 27, 10, 0);
+      LocalDateTime later = LocalDateTime.of(2025, 4, 27, 12, 0);
+
+      Cursor earlierCursor = Cursor.of(earlier, "restaurant-1");
+      Cursor laterCursor = Cursor.of(later, "restaurant-1");
+
+      // then
+      assertThat(earlierCursor.compareTo(laterCursor)).isNegative();
+      assertThat(laterCursor.compareTo(earlierCursor)).isPositive();
+    }
+
+    @Test
+    void 시간이_같으면_레스토랑_ID로_비교한다() {
+      // given
+      LocalDateTime sameTime = LocalDateTime.of(2025, 4, 27, 12, 0);
+
+      Cursor cursor1 = Cursor.of(sameTime, "restaurant-1");
+      Cursor cursor2 = Cursor.of(sameTime, "restaurant-2");
+
+      // then
+      assertThat(cursor1.compareTo(cursor2)).isNegative();
+      assertThat(cursor2.compareTo(cursor1)).isPositive();
+    }
+
+    @Test
+    void 시간과_ID가_모두_같으면_0을_반환한다() {
+      // given
+      LocalDateTime sameTime = LocalDateTime.of(2025, 4, 27, 12, 0);
+      String sameId = "restaurant-1";
+
+      Cursor cursor1 = Cursor.of(sameTime, sameId);
+      Cursor cursor2 = Cursor.of(sameTime, sameId);
+
+      // then
+      assertThat(cursor1.compareTo(cursor2)).isZero();
+    }
+
+    @Test
+    void 시간_null은_non_null보다_작다고_간주한다() {
+      // given
+      Cursor nullTimeCursor = Cursor.of(null, "restaurant-1");
+      Cursor nonNullTimeCursor = Cursor.of(LocalDateTime.now(), "restaurant-1");
+
+      // then
+      assertThat(nullTimeCursor.compareTo(nonNullTimeCursor)).isNegative();
+      assertThat(nonNullTimeCursor.compareTo(nullTimeCursor)).isPositive();
+    }
+
+    @Test
+    void 레스토랑_ID_null은_non_null보다_작다고_간주한다() {
+      // given
+      LocalDateTime sameTime = LocalDateTime.of(2025, 4, 27, 12, 0);
+
+      Cursor nullIdCursor = Cursor.of(sameTime, null);
+      Cursor nonNullIdCursor = Cursor.of(sameTime, "restaurant-1");
+
+      // then
+      assertThat(nullIdCursor.compareTo(nonNullIdCursor)).isNegative();
+      assertThat(nonNullIdCursor.compareTo(nullIdCursor)).isPositive();
+    }
+
+    @Test
+    void empty_커서는_다른_커서보다_작다고_간주한다() {
+      // given
+      Cursor emptyCursor = Cursor.empty();
+      Cursor nonEmptyCursor = Cursor.of(LocalDateTime.now(), "restaurant-1");
+
+      // then
+      assertThat(emptyCursor.compareTo(nonEmptyCursor)).isNegative();
+      assertThat(nonEmptyCursor.compareTo(emptyCursor)).isPositive();
+    }
+  }
+}

--- a/review/src/test/java/table/eat/now/review/application/batch/CursorTest.java
+++ b/review/src/test/java/table/eat/now/review/application/batch/CursorTest.java
@@ -61,8 +61,8 @@ class CursorTest {
       Cursor laterCursor = Cursor.of(later, "restaurant-1");
 
       // then
-      assertThat(earlierCursor.compareTo(laterCursor)).isNegative();
-      assertThat(laterCursor.compareTo(earlierCursor)).isPositive();
+      assertThat(earlierCursor).isLessThan(laterCursor);
+      assertThat(laterCursor).isGreaterThan(earlierCursor);
     }
 
     @Test
@@ -74,8 +74,8 @@ class CursorTest {
       Cursor cursor2 = Cursor.of(sameTime, "restaurant-2");
 
       // then
-      assertThat(cursor1.compareTo(cursor2)).isNegative();
-      assertThat(cursor2.compareTo(cursor1)).isPositive();
+      assertThat(cursor1).isLessThan(cursor2);
+      assertThat(cursor2).isGreaterThan(cursor1);
     }
 
     @Test
@@ -88,7 +88,7 @@ class CursorTest {
       Cursor cursor2 = Cursor.of(sameTime, sameId);
 
       // then
-      assertThat(cursor1.compareTo(cursor2)).isZero();
+      assertThat(cursor1).isEqualByComparingTo(cursor2);
     }
 
     @Test
@@ -98,8 +98,8 @@ class CursorTest {
       Cursor nonNullTimeCursor = Cursor.of(LocalDateTime.now(), "restaurant-1");
 
       // then
-      assertThat(nullTimeCursor.compareTo(nonNullTimeCursor)).isNegative();
-      assertThat(nonNullTimeCursor.compareTo(nullTimeCursor)).isPositive();
+      assertThat(nullTimeCursor).isLessThan(nonNullTimeCursor);
+      assertThat(nonNullTimeCursor).isGreaterThan(nullTimeCursor);
     }
 
     @Test
@@ -111,8 +111,8 @@ class CursorTest {
       Cursor nonNullIdCursor = Cursor.of(sameTime, "restaurant-1");
 
       // then
-      assertThat(nullIdCursor.compareTo(nonNullIdCursor)).isNegative();
-      assertThat(nonNullIdCursor.compareTo(nullIdCursor)).isPositive();
+      assertThat(nullIdCursor).isLessThan(nonNullIdCursor);
+      assertThat(nonNullIdCursor).isGreaterThan(nullIdCursor);
     }
 
     @Test
@@ -122,8 +122,8 @@ class CursorTest {
       Cursor nonEmptyCursor = Cursor.of(LocalDateTime.now(), "restaurant-1");
 
       // then
-      assertThat(emptyCursor.compareTo(nonEmptyCursor)).isNegative();
-      assertThat(nonEmptyCursor.compareTo(emptyCursor)).isPositive();
+      assertThat(emptyCursor).isLessThan(nonEmptyCursor);
+      assertThat(nonEmptyCursor).isGreaterThan(emptyCursor);
     }
   }
 }

--- a/review/src/test/java/table/eat/now/review/application/batch/CursorTest.java
+++ b/review/src/test/java/table/eat/now/review/application/batch/CursorTest.java
@@ -95,7 +95,8 @@ class CursorTest {
     void 시간_null은_non_null보다_작다고_간주한다() {
       // given
       Cursor nullTimeCursor = Cursor.of(null, "restaurant-1");
-      Cursor nonNullTimeCursor = Cursor.of(LocalDateTime.now(), "restaurant-1");
+      LocalDateTime fixed = LocalDateTime.of(2025, 4, 27, 12, 1);
+      Cursor nonNullTimeCursor = Cursor.of(fixed, "restaurant-1");
 
       // then
       assertThat(nullTimeCursor).isLessThan(nonNullTimeCursor);
@@ -119,7 +120,9 @@ class CursorTest {
     void empty_커서는_다른_커서보다_작다고_간주한다() {
       // given
       Cursor emptyCursor = Cursor.empty();
-      Cursor nonEmptyCursor = Cursor.of(LocalDateTime.now(), "restaurant-1");
+
+      LocalDateTime fixed = LocalDateTime.of(2025, 4, 27, 12, 1);
+      Cursor nonEmptyCursor = Cursor.of(fixed, "restaurant-1");
 
       // then
       assertThat(emptyCursor).isLessThan(nonEmptyCursor);

--- a/review/src/test/java/table/eat/now/review/application/scheduler/ReviewSchedulerTest.java
+++ b/review/src/test/java/table/eat/now/review/application/scheduler/ReviewSchedulerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import table.eat.now.review.application.batch.CursorKey;
 import table.eat.now.review.application.executor.TaskExecutorFactory;
 import table.eat.now.review.application.executor.task.TaskExecutor;
 import table.eat.now.review.application.usecase.UpdateRestaurantRatingUseCase;
@@ -74,8 +75,8 @@ class ReviewSchedulerTest {
       reviewScheduler.updateRestaurantRecentRatings();
 
       // then
-      verify(updateRestaurantRatingUseCase, times(1)).execute(any(LocalDateTime.class),
-          any(LocalDateTime.class));
+      verify(updateRestaurantRatingUseCase, times(1))
+          .execute(any(CursorKey.class), any(Duration.class));
       assert executed.get();
     }
 
@@ -89,7 +90,7 @@ class ReviewSchedulerTest {
       }).when(taskExecutor).execute(any());
 
       doThrow(new RuntimeException("에러")).when(updateRestaurantRatingUseCase)
-          .execute(any(LocalDateTime.class), any(LocalDateTime.class));
+          .execute(any(CursorKey.class), any(Duration.class));
 
       // when & then
       assertDoesNotThrow(() -> reviewScheduler.updateRestaurantRecentRatings());
@@ -125,7 +126,8 @@ class ReviewSchedulerTest {
       reviewScheduler.updateRestaurantDailyRatings();
 
       // then
-      verify(updateRestaurantRatingUseCase, times(1)).execute(any(LocalDateTime.class), any(LocalDateTime.class));
+      verify(updateRestaurantRatingUseCase, times(1))
+          .execute(any(CursorKey.class), any(Duration.class));
       assert executed.get();
     }
 
@@ -138,7 +140,7 @@ class ReviewSchedulerTest {
       }).when(taskExecutor).execute(any());
 
       doThrow(new RuntimeException("에러")).when(updateRestaurantRatingUseCase)
-          .execute(any(LocalDateTime.class), any(LocalDateTime.class));
+          .execute(any(CursorKey.class), any(Duration.class));
 
       // when & then
       assertDoesNotThrow(() -> reviewScheduler.updateRestaurantDailyRatings());

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -1,30 +1,33 @@
 package table.eat.now.review.application.usecase;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.math.BigDecimal;
+import java.lang.reflect.Constructor;
+import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.Nested;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import table.eat.now.review.application.event.RestaurantRatingUpdateEvent;
+import org.springframework.test.util.ReflectionTestUtils;
+import table.eat.now.review.application.batch.Cursor;
+import table.eat.now.review.application.batch.CursorKey;
+import table.eat.now.review.application.batch.CursorStore;
 import table.eat.now.review.application.event.ReviewEventPublisher;
+import table.eat.now.review.domain.entity.Review;
+import table.eat.now.review.domain.entity.ReviewContent;
+import table.eat.now.review.domain.entity.ReviewReference;
+import table.eat.now.review.domain.entity.ReviewVisibility;
+import table.eat.now.review.domain.entity.ServiceType;
 import table.eat.now.review.domain.repository.ReviewRepository;
-import table.eat.now.review.domain.repository.search.RestaurantRatingResult;
 import table.eat.now.review.helper.IntegrationTestSupport;
 
 @TestPropertySource(properties = {
@@ -32,300 +35,154 @@ import table.eat.now.review.helper.IntegrationTestSupport;
 })
 class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
 
-  @MockitoBean
+  @Autowired
+  private UpdateRestaurantRatingUseCase updateRestaurantRatingUseCase;
+
+  @Autowired
   private ReviewRepository reviewRepository;
+
+  @Autowired
+  private CursorStore cursorStore;
 
   @MockitoBean
   private ReviewEventPublisher reviewEventPublisher;
 
-  @Autowired
-  private UpdateRestaurantRatingUseCase updateRestaurantRatingUseCase;
+  private final CursorKey cursorKey = CursorKey.RATING_UPDATE_RECENT_CURSOR;
+  private final Duration interval = Duration.ofMinutes(5L);
 
-  @Nested
-  class execute_메서드는 {
-    
-    LocalDateTime endTime = LocalDateTime.now();
-    LocalDateTime startTime = endTime.minusMinutes(5L);
+  private LocalDateTime baseTime;
 
-    @Test
-    void 업데이트할_식당이_없으면_아무_처리도_하지_않는다() {
-      // given
-      when(reviewRepository.countRecentlyUpdatedRestaurants(
-          any(LocalDateTime.class),any(LocalDateTime.class)))
-          .thenReturn(0L);
+  @BeforeEach
+  void setUp() {
+    baseTime = LocalDateTime.now().minusMinutes(5);
+  }
 
-      // when
-      updateRestaurantRatingUseCase.execute(startTime, endTime);
+  @Test
+  void 업데이트할_식당이_없으면_아무것도_처리하지_않는다() {
+    // when
+    updateRestaurantRatingUseCase.execute(cursorKey, interval);
 
-      // then
-      verify(reviewRepository, times(1))
-          .countRecentlyUpdatedRestaurants(
-              any(LocalDateTime.class),any(LocalDateTime.class));
+    // then
+    Cursor cursor = cursorStore.getCursor(cursorKey.value());
+    assertThat(cursor.lastProcessedUpdatedAt()).isNull();
+    assertThat(cursor.lastProcessedRestaurantId()).isNull();
+  }
 
-      verify(reviewRepository, never())
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class),any(LocalDateTime.class), anyLong(), anyInt());
+  @Test
+  void 업데이트할_식당이_있으면_커서가_이동한다() {
+    // given
+    Review review1 = createReview("restaurant-1", baseTime.plusMinutes(1), 5);
+    Review review2 = createReview("restaurant-2", baseTime.plusMinutes(2), 4);
+    Review review3 = createReview("restaurant-3", baseTime.plusMinutes(3), 3);
+    Review review4 = createReview("restaurant-4", baseTime.plusMinutes(4), 2);
 
-      verify(reviewRepository, never())
-          .calculateRestaurantRatings(anyList());
+    reviewRepository.saveAllAndFlush(List.of(review1, review2, review3, review4));
+    // when
+    updateRestaurantRatingUseCase.execute(cursorKey, interval);
 
-      verify(reviewEventPublisher, never())
-          .publish(any());
-    }
+    // then
+    Cursor updatedCursor = cursorStore.getCursor(cursorKey.value());
+    assertThat(updatedCursor.lastProcessedUpdatedAt()).isNotNull();
+    assertThat(updatedCursor.lastProcessedRestaurantId()).isNotNull();
 
-    @Test
-    void 업데이트할_식당이_있으면_모든_배치를_처리한다() {
-      // given
-      int batchSize = 3;
+    assertThat(updatedCursor.lastProcessedRestaurantId()).isEqualTo("restaurant-4");
+    verify(reviewEventPublisher, times(4)).publish(any());
+  }
 
-      List<String> batch1 = Arrays.asList("1", "2", "3");
-      List<String> batch2 = Arrays.asList("4", "5", "6");
-      List<String> batch3 = Collections.singletonList("7");
+  @Test
+  void 이벤트_발행_중_에러가_발생해도_나머지_식당은_계속_처리한다() {
+    // given
+    Review review1 = createReview("restaurant-1", baseTime.plusMinutes(1), 5);
+    Review review2 = createReview("restaurant-2", baseTime.plusMinutes(2), 4);
 
-      List<RestaurantRatingResult> result1 = List.of(
-          new RestaurantRatingResult("1", new BigDecimal("4.5")),
-          new RestaurantRatingResult("2", new BigDecimal("3.2")),
-          new RestaurantRatingResult("3", new BigDecimal("4.0"))
-      );
+    reviewRepository.saveAllAndFlush(List.of(review1, review2));
+    // when
+    updateRestaurantRatingUseCase.execute(cursorKey, interval);
+    doThrow(new RuntimeException("테스트용 예외"))
+        .when(reviewEventPublisher).publish(any());
 
-      List<RestaurantRatingResult> result2 = List.of(
-          new RestaurantRatingResult("4", new BigDecimal("3.5")),
-          new RestaurantRatingResult("5", new BigDecimal("2.8")),
-          new RestaurantRatingResult("6", new BigDecimal("4.2"))
-      );
+    // then
+    Cursor updatedCursor = cursorStore.getCursor(cursorKey.value());
 
-      List<RestaurantRatingResult> result3 = List.of(
-          new RestaurantRatingResult("7", new BigDecimal("5.0"))
-      );
+    assertThat(updatedCursor.lastProcessedRestaurantId()).isEqualTo("restaurant-2");
+  }
 
-      // 스텁 설정
-      when(reviewRepository.countRecentlyUpdatedRestaurants(
-          any(LocalDateTime.class),any(LocalDateTime.class)))
-          .thenReturn(7L);
+  @Test
+  void 배치_조회_결과가_없으면_즉시_종료한다() {
+    // given
+    Review review = createReview("restaurant-1", baseTime.plusMinutes(1), 5);
+    reviewRepository.save(review);
 
-      when(reviewRepository
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class),any(LocalDateTime.class), eq(0L), eq(batchSize)))
-          .thenReturn(batch1);
-      when(reviewRepository
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class),any(LocalDateTime.class), eq(3L), eq(batchSize)))
-          .thenReturn(batch2);
-      when(reviewRepository
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class),any(LocalDateTime.class), eq(6L), eq(batchSize)))
-          .thenReturn(batch3);
-      when(reviewRepository
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class),any(LocalDateTime.class), eq(7L), eq(batchSize)))
-          .thenReturn(Collections.emptyList());
+    updateRestaurantRatingUseCase.execute(cursorKey, interval);
 
-      when(reviewRepository.calculateRestaurantRatings(batch1)).thenReturn(result1);
-      when(reviewRepository.calculateRestaurantRatings(batch2)).thenReturn(result2);
-      when(reviewRepository.calculateRestaurantRatings(batch3)).thenReturn(result3);
+    // 두 번째 실행 - 이미 처리된 이후라서 조회 결과 없음
+    updateRestaurantRatingUseCase.execute(cursorKey, interval);
 
-      // when
-      updateRestaurantRatingUseCase.execute(startTime, endTime);
+    // then
+    Cursor updatedCursor = cursorStore.getCursor(cursorKey.value());
+    assertThat(updatedCursor.lastProcessedRestaurantId()).isEqualTo("restaurant-1");
+  }
 
-      // then
-      verify(reviewRepository)
-          .countRecentlyUpdatedRestaurants(any(LocalDateTime.class),any(LocalDateTime.class));
+  @Test
+  void 같은_레스토랑ID가_여러번_나와도_마지막만_기준으로_커서가_이동한다() {
+    // given
+    Review review1 = createReview("restaurant-1", baseTime.plusMinutes(1), 5);
+    Review review2 = createReview("restaurant-1", baseTime.plusMinutes(2), 4);
 
-      verify(reviewRepository, times(3))
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class),any(LocalDateTime.class), anyLong(), eq(batchSize));
+    reviewRepository.saveAllAndFlush(List.of(review1, review2));
 
-      verify(reviewRepository, times(3))
-          .calculateRestaurantRatings(anyList());
+    // when
+    updateRestaurantRatingUseCase.execute(cursorKey, interval);
 
-      verify(reviewEventPublisher, times(7))
-          .publish(any(RestaurantRatingUpdateEvent.class));
-    }
+    // then
+    Cursor updatedCursor = cursorStore.getCursor(cursorKey.value());
+    assertThat(updatedCursor.lastProcessedUpdatedAt()).isEqualTo(review2.getUpdatedAt());
+    assertThat(updatedCursor.lastProcessedRestaurantId()).isEqualTo("restaurant-1");
+  }
 
-    @Test
-    void 이벤트_발행_중_에러가_발생해도_나머지_식당은_계속_처리한다() {
-      // given
-      int batchSize = 3;
-      List<String> batch1 = Collections.singletonList("1");
-      List<String> batch2 = Collections.singletonList("2");
+  private Review createReview(String restaurantId, LocalDateTime updatedAt, int rating) {
+    try {
+      // Review 생성자 호출
+      Constructor<Review> reviewConstructor = Review.class.getDeclaredConstructor();
+      reviewConstructor.setAccessible(true);
+      Review review = reviewConstructor.newInstance();
 
-      List<RestaurantRatingResult> result2 = Collections.singletonList(
-          new RestaurantRatingResult("2", new BigDecimal("4.0"))
-      );
+      // ReviewReference 생성자 호출
+      Constructor<ReviewReference> referenceConstructor =
+          ReviewReference.class.getDeclaredConstructor();
+      referenceConstructor.setAccessible(true);
+      ReviewReference reference = referenceConstructor.newInstance();
 
-      when(reviewRepository.countRecentlyUpdatedRestaurants(
-          any(LocalDateTime.class),any(LocalDateTime.class)))
-          .thenReturn(2L);
+      // ReviewContent 생성자 호출
+      Constructor<ReviewContent> contentConstructor = ReviewContent.class.getDeclaredConstructor();
+      contentConstructor.setAccessible(true);
+      ReviewContent content = contentConstructor.newInstance();
 
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class),any(LocalDateTime.class), eq(0L),
-          eq(batchSize))).thenReturn(batch1);
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class),any(LocalDateTime.class), eq(1L),
-          eq(batchSize))).thenReturn(batch2);
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(any(
-          LocalDateTime.class),any(LocalDateTime.class), eq(2L),
-          eq(batchSize))).thenReturn(Collections.emptyList());
+      // ReviewVisibility 생성자 호출
+      Constructor<ReviewVisibility> visibilityConstructor =
+          ReviewVisibility.class.getDeclaredConstructor();
+      visibilityConstructor.setAccessible(true);
+      ReviewVisibility visibility = visibilityConstructor.newInstance();
 
+      // 필드 세팅 (ReflectionTestUtils 활용)
+      ReflectionTestUtils.setField(reference, "restaurantId", restaurantId);
+      ReflectionTestUtils.setField(reference, "serviceId", "test-service-id");
+      ReflectionTestUtils.setField(reference, "customerId", 1L);
+      ReflectionTestUtils.setField(reference, "serviceType", ServiceType.WAITING);
 
-      doThrow(new RuntimeException("테스트 예외"))
-          .when(reviewEventPublisher).publish(any(RestaurantRatingUpdateEvent.class));
-      when(reviewRepository.calculateRestaurantRatings(batch2))
-          .thenReturn(result2);
+      ReflectionTestUtils.setField(content, "content", "리뷰 내용");
+      ReflectionTestUtils.setField(content, "rating", rating);
 
-      // when
-      updateRestaurantRatingUseCase.execute(startTime, endTime);
+      ReflectionTestUtils.setField(visibility, "isVisible", true);
+      ReflectionTestUtils.setField(review, "reviewId", UUID.randomUUID().toString());
+      ReflectionTestUtils.setField(review, "reference", reference);
+      ReflectionTestUtils.setField(review, "content", content);
+      ReflectionTestUtils.setField(review, "visibility", visibility);
+      ReflectionTestUtils.setField(review, "updatedAt", updatedAt);
 
-      // then
-      verify(reviewRepository, times(1))
-          .countRecentlyUpdatedRestaurants(any(LocalDateTime.class),any(LocalDateTime.class));
-
-      verify(reviewRepository, times(2))
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class),any(LocalDateTime.class), anyLong(), eq(batchSize));
-
-      verify(reviewRepository, times(2))
-          .calculateRestaurantRatings(anyList());
-
-      verify(reviewEventPublisher, times(1))
-          .publish(any(RestaurantRatingUpdateEvent.class));
-    }
-    @Test
-    void 중복된_레스토랑_ID는_한번만_처리한다() {
-      // given
-      int batchSize = 3;
-
-      List<String> batch1 = Arrays.asList("1", "2", "3");
-      List<String> batch2 = Arrays.asList("2", "3", "4");
-
-      List<RestaurantRatingResult> result1 = List.of(
-          new RestaurantRatingResult("1", new BigDecimal("4.5")),
-          new RestaurantRatingResult("2", new BigDecimal("3.2")),
-          new RestaurantRatingResult("3", new BigDecimal("4.0"))
-      );
-
-      List<RestaurantRatingResult> result2 = List.of(
-          new RestaurantRatingResult("4", new BigDecimal("3.8"))
-      );
-
-      when(reviewRepository.countRecentlyUpdatedRestaurants(
-          any(LocalDateTime.class), any(LocalDateTime.class)))
-          .thenReturn(5L);
-
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class), any(LocalDateTime.class), eq(0L), eq(batchSize)))
-          .thenReturn(batch1);
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class), any(LocalDateTime.class), eq(3L), eq(batchSize)))
-          .thenReturn(batch2);
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class), any(LocalDateTime.class), eq(5L), eq(batchSize)))
-          .thenReturn(Collections.emptyList());
-
-      when(reviewRepository.calculateRestaurantRatings(Arrays.asList("1", "2", "3")))
-          .thenReturn(result1);
-      when(reviewRepository.calculateRestaurantRatings(Collections.singletonList("4")))
-          .thenReturn(result2);
-
-      // when
-      updateRestaurantRatingUseCase.execute(startTime, endTime);
-
-      // then
-      verify(reviewRepository, times(1))
-          .countRecentlyUpdatedRestaurants(any(LocalDateTime.class), any(LocalDateTime.class));
-
-      verify(reviewRepository, times(3))
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class), any(LocalDateTime.class), anyLong(), eq(batchSize));
-
-      verify(reviewRepository).calculateRestaurantRatings(Arrays.asList("1", "2", "3"));
-      verify(reviewRepository).calculateRestaurantRatings(Collections.singletonList("4"));
-      verify(reviewRepository, times(2)).calculateRestaurantRatings(anyList());
-
-      verify(reviewEventPublisher, times(4))
-          .publish(any(RestaurantRatingUpdateEvent.class));
-    }
-
-    @Test
-    void 빈_결과가_반환되면_이벤트를_발행하지_않는다() {
-      // given
-      int batchSize = 3;
-      List<String> batch1 = Arrays.asList("1", "2", "3");
-
-      when(reviewRepository.countRecentlyUpdatedRestaurants(
-          any(LocalDateTime.class), any(LocalDateTime.class)))
-          .thenReturn(3L);
-
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class), any(LocalDateTime.class), eq(0L), eq(batchSize)))
-          .thenReturn(batch1);
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class), any(LocalDateTime.class), eq(3L), eq(batchSize)))
-          .thenReturn(Collections.emptyList());
-
-      when(reviewRepository.calculateRestaurantRatings(batch1))
-          .thenReturn(Collections.emptyList());
-
-      // when
-      updateRestaurantRatingUseCase.execute(startTime, endTime);
-
-      // then
-      verify(reviewRepository, times(1))
-          .countRecentlyUpdatedRestaurants(any(LocalDateTime.class), any(LocalDateTime.class));
-
-      verify(reviewRepository, times(1))
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class), any(LocalDateTime.class), anyLong(), eq(batchSize));
-
-      verify(reviewRepository, times(1))
-          .calculateRestaurantRatings(anyList());
-
-      verify(reviewEventPublisher, never())
-          .publish(any(RestaurantRatingUpdateEvent.class));
-    }
-
-    @Test
-    void 배치_처리_중_빈_배치가_반환되면_즉시_종료한다() {
-      // given
-      int batchSize = 3;
-      List<String> batch1 = Arrays.asList("1", "2", "3");
-
-      List<RestaurantRatingResult> result1 = List.of(
-          new RestaurantRatingResult("1", new BigDecimal("4.5")),
-          new RestaurantRatingResult("2", new BigDecimal("3.2")),
-          new RestaurantRatingResult("3", new BigDecimal("4.0"))
-      );
-
-      when(reviewRepository.countRecentlyUpdatedRestaurants(
-          any(LocalDateTime.class), any(LocalDateTime.class)))
-          .thenReturn(5L);
-
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class), any(LocalDateTime.class), eq(0L), eq(batchSize)))
-          .thenReturn(batch1);
-      when(reviewRepository.findRecentlyUpdatedRestaurantIds(
-          any(LocalDateTime.class), any(LocalDateTime.class), eq(3L), eq(batchSize)))
-          .thenReturn(Collections.emptyList());
-
-      when(reviewRepository.calculateRestaurantRatings(batch1))
-          .thenReturn(result1);
-
-      // when
-      updateRestaurantRatingUseCase.execute(startTime, endTime);
-
-      // then
-      verify(reviewRepository, times(1))
-          .countRecentlyUpdatedRestaurants(any(LocalDateTime.class), any(LocalDateTime.class));
-
-      verify(reviewRepository, times(2))
-          .findRecentlyUpdatedRestaurantIds(
-              any(LocalDateTime.class), any(LocalDateTime.class), anyLong(), eq(batchSize));
-
-      verify(reviewRepository, times(1))
-          .calculateRestaurantRatings(anyList());
-
-      verify(reviewEventPublisher, times(3))
-          .publish(any(RestaurantRatingUpdateEvent.class));
+      return review;
+    } catch (Exception e) {
+      throw new RuntimeException("리뷰 생성 실패", e);
     }
   }
 }

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -2,7 +2,6 @@ package table.eat.now.review.application.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -96,10 +95,10 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
     Review review2 = createReview("restaurant-2", baseTime.plusMinutes(2), 4);
 
     reviewRepository.saveAllAndFlush(List.of(review1, review2));
-    // when
-    updateRestaurantRatingUseCase.execute(cursorKey, interval);
     doThrow(new RuntimeException("테스트용 예외"))
         .when(reviewEventPublisher).publish(any());
+    // when
+    updateRestaurantRatingUseCase.execute(cursorKey, interval);
 
     // then
     Cursor updatedCursor = cursorStore.getCursor(cursorKey.value());

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -75,7 +75,8 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
     Review review3 = createReview("restaurant-3", baseTime.plusMinutes(3), 3);
     Review review4 = createReview("restaurant-4", baseTime.plusMinutes(4), 2);
 
-    reviewRepository.saveAllAndFlush(List.of(review1, review2, review3, review4));
+    List<Review> reviews = List.of(review1, review2, review3);
+    reviewRepository.saveAllAndFlush(reviews);
     // when
     updateRestaurantRatingUseCase.execute(cursorKey, interval);
 
@@ -85,7 +86,8 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
     assertThat(updatedCursor.lastProcessedRestaurantId()).isNotNull();
 
     assertThat(updatedCursor.lastProcessedRestaurantId()).isEqualTo("restaurant-4");
-    verify(reviewEventPublisher, times(4)).publish(any());
+    int expectedCallCount = reviews.size();
+    verify(reviewEventPublisher, times(expectedCallCount)).publish(any());
   }
 
   @Test
@@ -104,6 +106,7 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
     Cursor updatedCursor = cursorStore.getCursor(cursorKey.value());
 
     assertThat(updatedCursor.lastProcessedRestaurantId()).isEqualTo("restaurant-2");
+    verify(reviewEventPublisher, times(2)).publish(any());
   }
 
   @Test

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -123,23 +123,6 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
     assertThat(updatedCursor.lastProcessedRestaurantId()).isEqualTo("restaurant-1");
   }
 
-  @Test
-  void 같은_레스토랑ID가_여러번_나와도_마지막만_기준으로_커서가_이동한다() {
-    // given
-    Review review1 = createReview("restaurant-1", baseTime.plusMinutes(1), 5);
-    Review review2 = createReview("restaurant-1", baseTime.plusMinutes(2), 4);
-
-    reviewRepository.saveAllAndFlush(List.of(review1, review2));
-
-    // when
-    updateRestaurantRatingUseCase.execute(cursorKey, interval);
-
-    // then
-    Cursor updatedCursor = cursorStore.getCursor(cursorKey.value());
-    assertThat(updatedCursor.lastProcessedUpdatedAt()).isEqualTo(review2.getUpdatedAt());
-    assertThat(updatedCursor.lastProcessedRestaurantId()).isEqualTo("restaurant-1");
-  }
-
   private Review createReview(String restaurantId, LocalDateTime updatedAt, int rating) {
     try {
       // Review 생성자 호출

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -75,7 +75,7 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
     Review review3 = createReview("restaurant-3", baseTime.plusMinutes(3), 3);
     Review review4 = createReview("restaurant-4", baseTime.plusMinutes(4), 2);
 
-    List<Review> reviews = List.of(review1, review2, review3);
+    List<Review> reviews = List.of(review1, review2, review3, review4);
     reviewRepository.saveAllAndFlush(reviews);
     // when
     updateRestaurantRatingUseCase.execute(cursorKey, interval);

--- a/review/src/test/java/table/eat/now/review/helper/DatabaseCleanUp.java
+++ b/review/src/test/java/table/eat/now/review/helper/DatabaseCleanUp.java
@@ -1,0 +1,60 @@
+package table.eat.now.review.helper;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestComponent
+@RequiredArgsConstructor
+public class DatabaseCleanUp {
+
+  @PersistenceContext
+  private final EntityManager entityManager;
+  private List<String> tableNames;
+
+  @PostConstruct
+  public void afterPropertiesSet() {
+    tableNames = entityManager.getMetamodel()
+        .getEntities()
+        .stream()
+        .filter(entityType -> entityType
+            .getJavaType()
+            .getAnnotation(Entity.class) != null)
+        .map(entityType -> {
+          Table table = entityType
+              .getJavaType()
+              .getAnnotation(Table.class);
+
+          return Objects.nonNull(table) && Objects.nonNull(table.name()) ?
+              table.name() :
+              convertToLowerUnderscore(entityType.getName());
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public void execute() {
+    // 쓰기 지연 저장소에 남은 SQL을 마저 수행
+    entityManager.flush();
+    // 연관 관계 매핑된 테이블이 있는 경우 참조 무결성을 해제해주고, TRUNCATE 수행
+    entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+    for (String tableName : tableNames) {
+      // 테이블 이름을 순회하면서, TRUNCATE 수행
+      entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+    }
+    entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+  }
+
+  private String convertToLowerUnderscore(String camelCase) {
+    return camelCase.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
+  }
+}

--- a/review/src/test/java/table/eat/now/review/helper/DatabaseCleanUp.java
+++ b/review/src/test/java/table/eat/now/review/helper/DatabaseCleanUp.java
@@ -3,11 +3,9 @@ package table.eat.now.review.helper;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Table;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DatabaseCleanUp {
 
-  @PersistenceContext
   private final EntityManager entityManager;
   private List<String> tableNames;
 
@@ -37,7 +34,7 @@ public class DatabaseCleanUp {
               table.name() :
               convertToLowerUnderscore(entityType.getName());
         })
-        .collect(Collectors.toList());
+        .toList();
   }
 
   @Transactional

--- a/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
+++ b/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
@@ -1,6 +1,5 @@
 package table.eat.now.review.helper;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
+++ b/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
@@ -1,14 +1,34 @@
 package table.eat.now.review.helper;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(RedisTestContainerExtension.class)
+@Import(DatabaseCleanUp.class)
 @ActiveProfiles("test")
-@Transactional
 @SpringBootTest
 public abstract class IntegrationTestSupport {
 
+  @Autowired
+  protected RedisTemplate<String, Object> redisTemplate;
+
+  @Autowired
+  private DatabaseCleanUp databaseCleanUp;
+
+  @AfterEach
+  void tearDown() {
+    databaseCleanUp.afterPropertiesSet();
+    databaseCleanUp.execute();
+    clearRedis();
+  }
+
+  void clearRedis() {
+    redisTemplate.delete(redisTemplate.keys("*"));
+  }
 }

--- a/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
+++ b/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
@@ -22,7 +22,6 @@ public abstract class IntegrationTestSupport {
 
   @AfterEach
   void tearDown() {
-    databaseCleanUp.afterPropertiesSet();
     databaseCleanUp.execute();
     clearRedis();
   }

--- a/review/src/test/java/table/eat/now/review/helper/RedisTestContainerExtension.java
+++ b/review/src/test/java/table/eat/now/review/helper/RedisTestContainerExtension.java
@@ -9,12 +9,13 @@ public class RedisTestContainerExtension implements BeforeAllCallback {
 
   private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
   private static final int REDIS_PORT = 6379;
+  private static final GenericContainer<?> redisContainer = new GenericContainer<>(
+      DockerImageName.parse(REDIS_IMAGE))
+      .withExposedPorts(REDIS_PORT);
+
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    GenericContainer<?> redisContainer =
-        new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE)).withExposedPorts(REDIS_PORT);
-
     redisContainer.start();
 
     System.setProperty("spring.data.redis.host", redisContainer.getHost());


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #209 

## 변경 타입
- [x] 신규 기능 추가/수정

- **to-be**
  - [x] 오프셋기반 페이징을 커서기반 페이징으로 수정했습니다

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.

## 코멘트
- 테스트 코드를 수정하는데..ㅠㅠ redis쪽 모킹을 했는데도 계속 이상하게 동작해서,. 통합테스트로 구성했습니다.. 
- 커서 <- 가 사실상 도메인은 아닌 것 같아서, 어플리케이션 레이어에 넣어뒀습니다. 패키지 구조가 너무 고민이됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 레스토랑 평점 배치 처리에 커서 기반 방식 도입 및 커서 상태를 Redis에 저장하는 기능 추가
    - Spring Data Redis 및 관련 설정 추가
    - 레스토랑 평점 업데이트 스케줄러가 커서 및 기간 기반으로 동작하도록 개선
    - 커서 관련 도메인, 저장소, 키 관리 기능 추가
    - 배치 처리 진행 상태를 추적하는 Redis 커서 저장소 구현
    - RedisTemplate 설정 및 의존성 추가

- **버그 수정**
    - Kafka 프로듀서의 재시도 및 타임아웃 설정 강화로 신뢰성 개선

- **리팩터링**
    - 오프셋 기반 배치 처리에서 커서 기반 배치 처리로 전환
    - 저장소, 배치, 스케줄러 등 주요 로직의 구조 개선 및 간소화
    - 기존 날짜 시간 기반 파라미터를 커서 키와 기간 기반 파라미터로 변경

- **테스트**
    - 커서 및 배치 처리 로직에 대한 단위/통합 테스트 추가 및 보강
    - 실제 엔티티를 활용한 통합 테스트로 전환
    - 테스트 데이터베이스 및 Redis 초기화 자동화 도입
    - 테스트용 데이터베이스 클린업 및 Redis 클리어 기능 추가

- **환경설정**
    - 평점 업데이트 주기 설정을 cron에서 delay(ms) 방식으로 변경
    - Redis 및 관련 의존성 추가 및 주석 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->