### PR TITLE
[common] 테스트 서버 기동 최소화

### DIFF
--- a/coupon/src/test/java/table/eat/now/coupon/coupon/application/service/CouponServiceImplTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/application/service/CouponServiceImplTest.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -48,7 +47,6 @@ import table.eat.now.coupon.coupon.domain.store.CouponStore;
 import table.eat.now.coupon.coupon.fixture.CouponFixture;
 import table.eat.now.coupon.coupon.infrastructure.persistence.redis.RedisCouponCacheManager;
 import table.eat.now.coupon.helper.IntegrationTestSupport;
-import table.eat.now.coupon.user_coupon.infrastructure.messaging.spring.UserCouponSpringEventListener;
 
 @RecordApplicationEvents
 class CouponServiceImplTest extends IntegrationTestSupport {
@@ -67,9 +65,6 @@ class CouponServiceImplTest extends IntegrationTestSupport {
 
   @Resource
   ApplicationEvents applicationEvents;
-
-  @MockitoBean
-  UserCouponSpringEventListener userCouponSpringEventListener;
 
   private List<Coupon> coupons;
 

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/application/usecase/IssuePromotionCouponUsecaseTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/application/usecase/IssuePromotionCouponUsecaseTest.java
@@ -18,10 +18,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import table.eat.now.common.exception.CustomException;
-import table.eat.now.coupon.coupon.application.messaging.EventPublisher;
 import table.eat.now.coupon.coupon.application.messaging.event.CouponRequestedIssueEvent;
 import table.eat.now.coupon.coupon.application.usecase.dto.request.IssuePromotionCouponCommand;
 import table.eat.now.coupon.coupon.application.utils.TimeProvider;
@@ -44,9 +42,6 @@ class IssuePromotionCouponUsecaseTest extends IntegrationTestSupport {
   private CouponStore couponStore;
   @Autowired
   private RedisCouponCacheManager redisCouponCacheManager;
-
-  @MockitoBean
-  private EventPublisher<CouponRequestedIssueEvent> eventPublisher;
 
   private Coupon coupon;
 

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/presentation/CouponAdminControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/presentation/CouponAdminControllerTest.java
@@ -23,9 +23,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -34,18 +32,12 @@ import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.coupon.coupon.application.service.dto.response.GetCouponInfo;
 import table.eat.now.coupon.coupon.application.service.dto.response.PageResponse;
 import table.eat.now.coupon.coupon.application.service.dto.response.SearchCouponInfo;
-import table.eat.now.coupon.coupon.application.service.CouponService;
 import table.eat.now.coupon.coupon.fixture.CouponFixture;
 import table.eat.now.coupon.coupon.presentation.dto.request.CreateCouponRequest;
 import table.eat.now.coupon.coupon.presentation.dto.request.UpdateCouponRequest;
 import table.eat.now.coupon.helper.ControllerTestSupport;
 
-
-@WebMvcTest(CouponAdminController.class)
 class CouponAdminControllerTest extends ControllerTestSupport {
-
-  @MockitoBean
-  private CouponService couponService;
 
   @BeforeEach
   void setUp() {

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/presentation/CouponApiControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/presentation/CouponApiControllerTest.java
@@ -22,15 +22,12 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
-import table.eat.now.coupon.coupon.application.service.CouponService;
 import table.eat.now.coupon.coupon.application.service.dto.response.GetCouponsInfo;
 import table.eat.now.coupon.coupon.application.service.dto.response.GetCouponsInfo.GetCouponInfo;
 import table.eat.now.coupon.coupon.application.service.dto.response.IssuableCouponInfo;
@@ -38,11 +35,7 @@ import table.eat.now.coupon.coupon.application.service.dto.response.PageResponse
 import table.eat.now.coupon.coupon.fixture.CouponFixture;
 import table.eat.now.coupon.helper.ControllerTestSupport;
 
-@WebMvcTest(CouponApiController.class)
 class CouponApiControllerTest extends ControllerTestSupport {
-
-  @MockitoBean
-  private CouponService couponService;
 
   @BeforeEach
   void setUp() {

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/presentation/CouponInternalControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/presentation/CouponInternalControllerTest.java
@@ -18,22 +18,15 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.coupon.coupon.application.service.dto.response.GetCouponInfo;
 import table.eat.now.coupon.coupon.application.service.dto.response.GetCouponsInfoI;
-import table.eat.now.coupon.coupon.application.service.CouponService;
 import table.eat.now.coupon.coupon.domain.entity.Coupon;
 import table.eat.now.coupon.coupon.fixture.CouponFixture;
 import table.eat.now.coupon.helper.ControllerTestSupport;
 
-@WebMvcTest(CouponInternalController.class)
 class CouponInternalControllerTest extends ControllerTestSupport {
-
-  @MockitoBean
-  private CouponService couponService;
 
   @BeforeEach
   void setUp() {

--- a/coupon/src/test/java/table/eat/now/coupon/helper/ControllerTestSupport.java
+++ b/coupon/src/test/java/table/eat/now/coupon/helper/ControllerTestSupport.java
@@ -3,9 +3,25 @@ package table.eat.now.coupon.helper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import table.eat.now.coupon.coupon.application.service.CouponService;
+import table.eat.now.coupon.coupon.presentation.CouponAdminController;
+import table.eat.now.coupon.coupon.presentation.CouponApiController;
+import table.eat.now.coupon.coupon.presentation.CouponInternalController;
+import table.eat.now.coupon.user_coupon.application.service.UserCouponService;
+import table.eat.now.coupon.user_coupon.presentation.UserCouponApiController;
+import table.eat.now.coupon.user_coupon.presentation.UserCouponInternalController;
 
+@WebMvcTest({
+    CouponAdminController.class,
+    CouponApiController.class,
+    CouponInternalController.class,
+    UserCouponApiController.class,
+    UserCouponInternalController.class
+})
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 public abstract class ControllerTestSupport {
@@ -15,4 +31,10 @@ public abstract class ControllerTestSupport {
 
   @Autowired
   protected ObjectMapper objectMapper;
+
+  @MockitoBean
+  protected CouponService couponService;
+
+  @MockitoBean
+  protected UserCouponService userCouponService;
 }

--- a/coupon/src/test/java/table/eat/now/coupon/helper/IntegrationTestSupport.java
+++ b/coupon/src/test/java/table/eat/now/coupon/helper/IntegrationTestSupport.java
@@ -10,8 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import table.eat.now.coupon.coupon.application.messaging.EventPublisher;
+import table.eat.now.coupon.coupon.application.messaging.event.CouponRequestedIssueEvent;
+import table.eat.now.coupon.user_coupon.application.client.CouponClient;
+import table.eat.now.coupon.user_coupon.infrastructure.messaging.spring.UserCouponSpringEventListener;
 
 @Sql(executionPhase = ExecutionPhase.BEFORE_TEST_CLASS,
     statements = "ALTER TABLE p_user_coupon ALTER COLUMN id SET DEFAULT NEXT VALUE FOR p_user_coupon_seq")
@@ -26,6 +31,15 @@ public abstract class IntegrationTestSupport {
 
   @Autowired
   protected RedisTemplate<String, Object> redisTemplate;
+
+  @MockitoBean
+  protected UserCouponSpringEventListener userCouponSpringEventListener;
+
+  @MockitoBean
+  protected EventPublisher<CouponRequestedIssueEvent> eventPublisher;
+
+  @MockitoBean
+  protected CouponClient couponClient;
 
   @AfterEach
   void tearDown() {

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/scheduler/UserCouponSchedulerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/scheduler/UserCouponSchedulerTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import table.eat.now.coupon.coupon.application.usecase.PrepareDailyCouponCacheUsecase;
 import table.eat.now.coupon.user_coupon.application.usecase.ReleaseUserCouponUsecase;
 
 @ExtendWith(SpringExtension.class)
@@ -23,6 +24,8 @@ class UserCouponSchedulerTest {
   @MockitoBean
   private ReleaseUserCouponUsecase releaseUserCouponUsecase;
 
+  @MockitoBean
+  protected PrepareDailyCouponCacheUsecase prepareDailyCouponCacheUsecase;
 
   @DisplayName("스케쥴러 호출시 usecase가 잘 동작하는지 확인")
   @Test

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImplTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/application/service/UserCouponServiceImplTest.java
@@ -24,12 +24,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.coupon.helper.IntegrationTestSupport;
-import table.eat.now.coupon.user_coupon.application.client.CouponClient;
 import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
 import table.eat.now.coupon.user_coupon.application.dto.request.IssueUserCouponCommand;
 import table.eat.now.coupon.user_coupon.application.dto.request.PreemptUserCouponCommand;
@@ -50,9 +48,6 @@ class UserCouponServiceImplTest extends IntegrationTestSupport {
 
   @Autowired
   private UserCouponRepository userCouponRepository;
-
-  @MockitoBean
-  private CouponClient couponClient;
 
   private List<UserCoupon> userCoupons;
 

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponApiControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponApiControllerTest.java
@@ -12,24 +12,19 @@ import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.coupon.helper.ControllerTestSupport;
 import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfo;
 import table.eat.now.coupon.user_coupon.application.dto.response.PageResponse;
-import table.eat.now.coupon.user_coupon.application.service.UserCouponService;
 import table.eat.now.coupon.user_coupon.fixture.UserCouponFixture;
 
-@WebMvcTest(UserCouponApiController.class)
 class UserCouponApiControllerTest extends ControllerTestSupport {
-  @MockitoBean
-  private UserCouponService userCouponService;
+
 
   @DisplayName("사용자별 쿠폰 조회 성공 - 200 응답")
   @Test

--- a/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalControllerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/user_coupon/presentation/UserCouponInternalControllerTest.java
@@ -19,23 +19,16 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.coupon.helper.ControllerTestSupport;
 import table.eat.now.coupon.user_coupon.application.client.dto.response.GetCouponInfoI;
 import table.eat.now.coupon.user_coupon.application.dto.response.GetUserCouponInfoI;
-import table.eat.now.coupon.user_coupon.application.service.UserCouponService;
 import table.eat.now.coupon.user_coupon.presentation.dto.request.PreemptUserCouponRequest;
 
-@WebMvcTest(UserCouponInternalController.class)
 class UserCouponInternalControllerTest extends ControllerTestSupport {
-
-  @MockitoBean
-  private UserCouponService userCouponService;
 
   @BeforeEach
   void setUp() {

--- a/payment/src/test/java/table/eat/now/payment/payment/global/support/ControllerTestSupport.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/global/support/ControllerTestSupport.java
@@ -1,0 +1,45 @@
+package table.eat.now.payment.payment.global.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import table.eat.now.common.aop.AuthCheckAspect;
+import table.eat.now.common.config.WebConfig;
+import table.eat.now.common.exception.GlobalErrorHandler;
+import table.eat.now.common.resolver.CurrentUserInfoResolver;
+import table.eat.now.common.resolver.CustomPageableArgumentResolver;
+import table.eat.now.payment.payment.application.PaymentService;
+import table.eat.now.payment.payment.presentation.PaymentAdminController;
+import table.eat.now.payment.payment.presentation.PaymentApiController;
+import table.eat.now.payment.payment.presentation.PaymentInternalController;
+import table.eat.now.payment.payment.presentation.PaymentViewController;
+
+@WebMvcTest(controllers = {
+    PaymentAdminController.class,
+    PaymentApiController.class,
+    PaymentInternalController.class,
+    PaymentViewController.class
+})
+@Import({
+    WebConfig.class,
+    CustomPageableArgumentResolver.class,
+    CurrentUserInfoResolver.class,
+    GlobalErrorHandler.class,
+    AuthCheckAspect.class
+})
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+public abstract class ControllerTestSupport {
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @MockitoBean
+  protected PaymentService paymentService;
+
+}

--- a/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentAdminControllerTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentAdminControllerTest.java
@@ -10,7 +10,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,48 +19,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import table.eat.now.common.aop.AuthCheckAspect;
-import table.eat.now.common.config.WebConfig;
-import table.eat.now.common.exception.GlobalErrorHandler;
 import table.eat.now.common.exception.type.ApiErrorCode;
-import table.eat.now.common.resolver.CurrentUserInfoResolver;
-import table.eat.now.common.resolver.CustomPageableArgumentResolver;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
-import table.eat.now.payment.payment.application.PaymentService;
 import table.eat.now.payment.payment.application.dto.request.SearchMasterPaymentsQuery;
 import table.eat.now.payment.payment.application.dto.response.PaginatedInfo;
 import table.eat.now.payment.payment.application.dto.response.SearchPaymentsInfo;
+import table.eat.now.payment.payment.global.support.ControllerTestSupport;
 
-@ActiveProfiles("test")
-@Import({
-    WebConfig.class,
-    CustomPageableArgumentResolver.class,
-    CurrentUserInfoResolver.class,
-    GlobalErrorHandler.class,
-    AuthCheckAspect.class
-})
-@EnableAspectJAutoProxy(proxyTargetClass = true)
-@WebMvcTest(PaymentAdminController.class)
-class PaymentAdminControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PaymentService paymentService;
+class PaymentAdminControllerTest extends ControllerTestSupport {
 
   @Nested
   class 관리자_결제_목록_조회_시 {

--- a/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentApiControllerTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentApiControllerTest.java
@@ -11,7 +11,6 @@ import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.PAYMENT_ACCESS_DENIED;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,52 +19,21 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import table.eat.now.common.aop.AuthCheckAspect;
-import table.eat.now.common.config.WebConfig;
 import table.eat.now.common.exception.CustomException;
-import table.eat.now.common.exception.GlobalErrorHandler;
 import table.eat.now.common.exception.type.ApiErrorCode;
-import table.eat.now.common.resolver.CurrentUserInfoResolver;
-import table.eat.now.common.resolver.CustomPageableArgumentResolver;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
-import table.eat.now.payment.payment.application.PaymentService;
 import table.eat.now.payment.payment.application.dto.response.ConfirmPaymentInfo;
 import table.eat.now.payment.payment.application.dto.response.GetCheckoutDetailInfo;
 import table.eat.now.payment.payment.application.dto.response.GetPaymentInfo;
 import table.eat.now.payment.payment.application.dto.response.PaginatedInfo;
 import table.eat.now.payment.payment.application.dto.response.SearchPaymentsInfo;
+import table.eat.now.payment.payment.global.support.ControllerTestSupport;
 import table.eat.now.payment.payment.presentation.dto.request.ConfirmPaymentRequest;
 
-@ActiveProfiles("test")
-@Import({
-    WebConfig.class,
-    CustomPageableArgumentResolver.class,
-    CurrentUserInfoResolver.class,
-    GlobalErrorHandler.class,
-    AuthCheckAspect.class
-})
-@EnableAspectJAutoProxy(proxyTargetClass = true)
-@WebMvcTest(PaymentApiController.class)
-class PaymentApiControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PaymentService paymentService;
+class PaymentApiControllerTest extends ControllerTestSupport {
 
   @Nested
   class 체크아웃_정보_조회_시 {

--- a/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentInternalControllerTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentInternalControllerTest.java
@@ -9,53 +9,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH;
 import static table.eat.now.payment.payment.application.exception.PaymentErrorCode.RESERVATION_NOT_PENDING;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import table.eat.now.common.aop.AuthCheckAspect;
-import table.eat.now.common.config.WebConfig;
 import table.eat.now.common.exception.CustomException;
-import table.eat.now.common.exception.GlobalErrorHandler;
-import table.eat.now.common.resolver.CurrentUserInfoResolver;
-import table.eat.now.common.resolver.CustomPageableArgumentResolver;
-import table.eat.now.payment.payment.application.PaymentService;
 import table.eat.now.payment.payment.application.dto.request.CreatePaymentCommand;
 import table.eat.now.payment.payment.application.dto.response.CreatePaymentInfo;
+import table.eat.now.payment.payment.global.support.ControllerTestSupport;
 import table.eat.now.payment.payment.presentation.dto.request.CreatePaymentRequest;
 
-@ActiveProfiles("test")
-@Import({
-    WebConfig.class,
-    CustomPageableArgumentResolver.class,
-    CurrentUserInfoResolver.class,
-    GlobalErrorHandler.class,
-    AuthCheckAspect.class
-})
-@EnableAspectJAutoProxy(proxyTargetClass = true)
-@WebMvcTest(PaymentInternalController.class)
-class PaymentInternalControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PaymentService paymentService;
+class PaymentInternalControllerTest extends ControllerTestSupport {
 
   @Nested
   class 결제_생성_요청시 {

--- a/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentViewControllerTest.java
+++ b/payment/src/test/java/table/eat/now/payment/payment/presentation/PaymentViewControllerTest.java
@@ -1,39 +1,14 @@
 package table.eat.now.payment.payment.presentation;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.UUID;
-import table.eat.now.common.aop.AuthCheckAspect;
-import table.eat.now.common.config.WebConfig;
-import table.eat.now.common.exception.GlobalErrorHandler;
-import table.eat.now.common.resolver.CurrentUserInfoResolver;
-import table.eat.now.common.resolver.CustomPageableArgumentResolver;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-@ActiveProfiles("test")
-@Import({
-    WebConfig.class,
-    CustomPageableArgumentResolver.class,
-    CurrentUserInfoResolver.class,
-    GlobalErrorHandler.class,
-    AuthCheckAspect.class
-})
-@EnableAspectJAutoProxy(proxyTargetClass = true)
-@WebMvcTest(PaymentViewController.class)
-class PaymentViewControllerTest {
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import table.eat.now.payment.payment.global.support.ControllerTestSupport;
 
-  @Autowired
-  private MockMvc mockMvc;
+class PaymentViewControllerTest extends ControllerTestSupport {
 
   @Test
   void 체크아웃_페이지_요청_시_checkout_뷰를_반환한다() throws Exception {

--- a/promotion/src/test/java/table/eat/now/promotion/global/support/ControllerTestSupport.java
+++ b/promotion/src/test/java/table/eat/now/promotion/global/support/ControllerTestSupport.java
@@ -1,0 +1,42 @@
+package table.eat.now.promotion.global.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import table.eat.now.promotion.promotion.application.service.PromotionService;
+import table.eat.now.promotion.promotion.presentation.PromotionAdminController;
+import table.eat.now.promotion.promotion.presentation.PromotionController;
+import table.eat.now.promotion.promotion.presentation.PromotionInternalController;
+import table.eat.now.promotion.promotionrestaurant.application.service.PromotionRestaurantService;
+import table.eat.now.promotion.promotionrestaurant.presentation.PromotionRestaurantInternalController;
+import table.eat.now.promotion.promotionuser.application.service.PromotionUserService;
+import table.eat.now.promotion.promotionuser.presentation.PromotionUserAdminController;
+import table.eat.now.promotion.promotionuser.presentation.PromotionUserController;
+
+@WebMvcTest(controllers = {
+    PromotionAdminController.class,
+    PromotionController.class,
+    PromotionInternalController.class,
+    PromotionRestaurantInternalController.class,
+    PromotionUserAdminController.class,
+    PromotionUserController.class
+})
+public abstract class ControllerTestSupport {
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @MockitoBean
+  protected PromotionService promotionService;
+
+  @MockitoBean
+  protected PromotionRestaurantService promotionRestaurantService;
+
+  @MockitoBean
+  protected PromotionUserService promotionUserService;
+
+}

--- a/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionAdminControllerTest.java
+++ b/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionAdminControllerTest.java
@@ -15,25 +15,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MediaType;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.promotion.global.support.ControllerTestSupport;
 import table.eat.now.promotion.promotion.application.dto.request.UpdatePromotionCommand;
 import table.eat.now.promotion.promotion.application.dto.response.CreatePromotionInfo;
 import table.eat.now.promotion.promotion.application.dto.response.UpdatePromotionInfo;
-import table.eat.now.promotion.promotion.application.service.PromotionService;
 import table.eat.now.promotion.promotion.domain.entity.Promotion;
 import table.eat.now.promotion.promotion.domain.entity.PromotionStatus;
 import table.eat.now.promotion.promotion.domain.entity.PromotionType;
@@ -44,20 +37,7 @@ import table.eat.now.promotion.promotion.presentation.dto.request.UpdatePromotio
  * @author : hanjihoon
  * @Date : 2025. 04. 08.
  */
-@AutoConfigureMockMvc
-@WebMvcTest(PromotionAdminController.class)
-@ActiveProfiles("test")
-class PromotionAdminControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PromotionService promotionService;
-
+class PromotionAdminControllerTest extends ControllerTestSupport {
 
   @DisplayName("프로모션 생성 테스트")
   @Test

--- a/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionControllerTest.java
+++ b/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionControllerTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MediaType;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -20,19 +19,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.promotion.global.support.ControllerTestSupport;
 import table.eat.now.promotion.promotion.application.dto.PaginatedResultCommand;
 import table.eat.now.promotion.promotion.application.dto.request.ParticipatePromotionUserInfo;
 import table.eat.now.promotion.promotion.application.dto.request.SearchPromotionCommand;
 import table.eat.now.promotion.promotion.application.dto.response.GetPromotionInfo;
 import table.eat.now.promotion.promotion.application.dto.response.SearchPromotionInfo;
-import table.eat.now.promotion.promotion.application.service.PromotionService;
 import table.eat.now.promotion.promotion.presentation.dto.request.ParticipatePromotionUserRequest;
 import table.eat.now.promotion.promotion.presentation.dto.request.SearchPromotionRequest;
 
@@ -40,20 +33,7 @@ import table.eat.now.promotion.promotion.presentation.dto.request.SearchPromotio
  * @author : hanjihoon
  * @Date : 2025. 04. 10.
  */
-@AutoConfigureMockMvc
-@WebMvcTest(PromotionController.class)
-@ActiveProfiles("test")
-class PromotionControllerTest {
-
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PromotionService promotionService;
+class PromotionControllerTest extends ControllerTestSupport {
 
   @DisplayName("promotionUuid로 프로모션을 단 건 조회한다.")
   @Test

--- a/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionInternalControllerTest.java
+++ b/promotion/src/test/java/table/eat/now/promotion/promotion/presentation/PromotionInternalControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MediaType;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -14,35 +13,16 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.promotion.global.support.ControllerTestSupport;
 import table.eat.now.promotion.promotion.application.dto.response.GetPromotionsClientInfo;
-import table.eat.now.promotion.promotion.application.service.PromotionService;
 import table.eat.now.promotion.promotion.presentation.dto.request.GetPromotionsFeignRequest;
 
 /**
  * @author : hanjihoon
  * @Date : 2025. 04. 13.
  */
-@AutoConfigureMockMvc
-@WebMvcTest(PromotionInternalController.class)
-@ActiveProfiles("test")
-class PromotionInternalControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PromotionService promotionService;
-
+class PromotionInternalControllerTest extends ControllerTestSupport {
 
   @DisplayName("레스토랑 아이디로 프로모션에 참여중인 식당과 내용을 조회해 반환한다.")
   @Test

--- a/promotion/src/test/java/table/eat/now/promotion/promotionrestaurant/presentation/PromotionRestaurantInternalControllerTest.java
+++ b/promotion/src/test/java/table/eat/now/promotion/promotionrestaurant/presentation/PromotionRestaurantInternalControllerTest.java
@@ -8,38 +8,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MediaType;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.promotion.global.support.ControllerTestSupport;
 import table.eat.now.promotion.promotionrestaurant.application.dto.response.GetPromotionRestaurantInfo;
-import table.eat.now.promotion.promotionrestaurant.application.service.PromotionRestaurantService;
 
 /**
  * @author : hanjihoon
  * @Date : 2025. 04. 13.
  */
-@AutoConfigureMockMvc
-@WebMvcTest(PromotionRestaurantInternalController.class)
-@ActiveProfiles("test")
-class PromotionRestaurantInternalControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PromotionRestaurantService promotionRestaurantService;
+class PromotionRestaurantInternalControllerTest extends ControllerTestSupport {
 
   @DisplayName("레스토랑 UUID로 프로모션-레스토랑 정보 조회 테스트")
   @Test

--- a/promotion/src/test/java/table/eat/now/promotion/promotionuser/presentation/PromotionUserAdminControllerTest.java
+++ b/promotion/src/test/java/table/eat/now/promotion/promotionuser/presentation/PromotionUserAdminControllerTest.java
@@ -14,24 +14,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
+import table.eat.now.promotion.global.support.ControllerTestSupport;
 import table.eat.now.promotion.promotionuser.application.dto.PaginatedResultCommand;
 import table.eat.now.promotion.promotionuser.application.dto.response.SearchPromotionUserInfo;
 import table.eat.now.promotion.promotionuser.application.dto.response.UpdatePromotionUserInfo;
-import table.eat.now.promotion.promotionuser.application.service.PromotionUserService;
 import table.eat.now.promotion.promotionuser.presentation.dto.request.SearchPromotionUserRequest;
 import table.eat.now.promotion.promotionuser.presentation.dto.request.UpdatePromotionUserRequest;
 
@@ -39,19 +32,7 @@ import table.eat.now.promotion.promotionuser.presentation.dto.request.UpdateProm
  * @Date : 2025. 04. 10.
  * @author : hanjihoon
  */
-@AutoConfigureMockMvc
-@WebMvcTest(PromotionUserAdminController.class)
-@ActiveProfiles("test")
-class PromotionUserAdminControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PromotionUserService promotionUserService;
+class PromotionUserAdminControllerTest extends ControllerTestSupport {
 
   @DisplayName("promotionUserUuid로 프로모션 유저 정보를 수정한다.")
   @Test

--- a/promotion/src/test/java/table/eat/now/promotion/promotionuser/presentation/PromotionUserControllerTest.java
+++ b/promotion/src/test/java/table/eat/now/promotion/promotionuser/presentation/PromotionUserControllerTest.java
@@ -8,20 +8,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static table.eat.now.common.constant.UserInfoConstant.USER_ID_HEADER;
 import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MediaType;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import table.eat.now.promotion.global.support.ControllerTestSupport;
 import table.eat.now.promotion.promotionuser.application.dto.response.CreatePromotionUserInfo;
-import table.eat.now.promotion.promotionuser.application.service.PromotionUserService;
 import table.eat.now.promotion.promotionuser.domain.entity.PromotionUser;
 import table.eat.now.promotion.promotionuser.presentation.dto.request.CreatePromotionUserRequest;
 
@@ -29,19 +22,7 @@ import table.eat.now.promotion.promotionuser.presentation.dto.request.CreateProm
  * @author : hanjihoon
  * @Date : 2025. 04. 08.
  */
-@AutoConfigureMockMvc
-@WebMvcTest(PromotionUserController.class)
-@ActiveProfiles("test")
-class PromotionUserControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private PromotionUserService promotionUserService;
+class PromotionUserControllerTest extends ControllerTestSupport {
 
   @DisplayName("프로모션 유저 생성 테스트")
   @Test

--- a/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
+++ b/review/src/test/java/table/eat/now/review/application/service/ReviewServiceImplTest.java
@@ -17,12 +17,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
-import table.eat.now.review.application.client.ReservationClient;
-import table.eat.now.review.application.client.RestaurantClient;
-import table.eat.now.review.application.client.WaitingClient;
 import table.eat.now.review.application.client.dto.GetRestaurantInfo;
 import table.eat.now.review.application.client.dto.GetRestaurantStaffInfo;
 import table.eat.now.review.application.client.dto.GetServiceInfo;
@@ -46,15 +42,6 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
 
   @Autowired
   private ReviewRepository reviewRepository;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private ReservationClient reservationClient;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
 
   @Nested
   class createReview_는 {

--- a/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
+++ b/review/src/test/java/table/eat/now/review/application/usecase/UpdateRestaurantRatingUseCaseTest.java
@@ -14,13 +14,10 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import table.eat.now.review.application.batch.Cursor;
 import table.eat.now.review.application.batch.CursorKey;
 import table.eat.now.review.application.batch.CursorStore;
-import table.eat.now.review.application.event.ReviewEventPublisher;
 import table.eat.now.review.domain.entity.Review;
 import table.eat.now.review.domain.entity.ReviewContent;
 import table.eat.now.review.domain.entity.ReviewReference;
@@ -29,9 +26,6 @@ import table.eat.now.review.domain.entity.ServiceType;
 import table.eat.now.review.domain.repository.ReviewRepository;
 import table.eat.now.review.helper.IntegrationTestSupport;
 
-@TestPropertySource(properties = {
-    "review.rating.update.batch-size=3"
-})
 class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
 
   @Autowired
@@ -42,9 +36,6 @@ class UpdateRestaurantRatingUseCaseTest extends IntegrationTestSupport {
 
   @Autowired
   private CursorStore cursorStore;
-
-  @MockitoBean
-  private ReviewEventPublisher reviewEventPublisher;
 
   private final CursorKey cursorKey = CursorKey.RATING_UPDATE_RECENT_CURSOR;
   private final Duration interval = Duration.ofMinutes(5L);

--- a/review/src/test/java/table/eat/now/review/global/support/ControllerTestSupport.java
+++ b/review/src/test/java/table/eat/now/review/global/support/ControllerTestSupport.java
@@ -1,0 +1,41 @@
+package table.eat.now.review.global.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import table.eat.now.common.aop.AuthCheckAspect;
+import table.eat.now.common.config.WebConfig;
+import table.eat.now.common.exception.GlobalErrorHandler;
+import table.eat.now.common.resolver.CurrentUserInfoResolver;
+import table.eat.now.common.resolver.CustomPageableArgumentResolver;
+import table.eat.now.review.application.service.ReviewService;
+import table.eat.now.review.presentation.ReviewAdminController;
+import table.eat.now.review.presentation.ReviewApiController;
+
+@WebMvcTest(controllers = {
+    ReviewAdminController.class,
+    ReviewApiController.class
+})
+@Import({
+    WebConfig.class,
+    CustomPageableArgumentResolver.class,
+    CurrentUserInfoResolver.class,
+    GlobalErrorHandler.class,
+    AuthCheckAspect.class
+})
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+public abstract class ControllerTestSupport {
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @MockitoBean
+  protected ReviewService reviewService;
+
+}

--- a/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
+++ b/review/src/test/java/table/eat/now/review/helper/IntegrationTestSupport.java
@@ -7,7 +7,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import table.eat.now.review.application.client.ReservationClient;
+import table.eat.now.review.application.client.RestaurantClient;
+import table.eat.now.review.application.client.WaitingClient;
+import table.eat.now.review.application.event.ReviewEventPublisher;
 
+@TestPropertySource(properties = {
+    "review.rating.update.batch-size=3"
+})
 @ExtendWith(RedisTestContainerExtension.class)
 @Import(DatabaseCleanUp.class)
 @ActiveProfiles("test")
@@ -19,6 +28,18 @@ public abstract class IntegrationTestSupport {
 
   @Autowired
   private DatabaseCleanUp databaseCleanUp;
+
+  @MockitoBean
+  protected ReviewEventPublisher reviewEventPublisher;
+
+  @MockitoBean
+  protected WaitingClient waitingClient;
+
+  @MockitoBean
+  protected ReservationClient reservationClient;
+
+  @MockitoBean
+  protected RestaurantClient restaurantClient;
 
   @AfterEach
   void tearDown() {

--- a/review/src/test/java/table/eat/now/review/presentation/ReviewAdminControllerTest.java
+++ b/review/src/test/java/table/eat/now/review/presentation/ReviewAdminControllerTest.java
@@ -18,44 +18,16 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import table.eat.now.common.aop.AuthCheckAspect;
-import table.eat.now.common.config.WebConfig;
 import table.eat.now.common.exception.CustomException;
-import table.eat.now.common.exception.GlobalErrorHandler;
 import table.eat.now.common.exception.type.ApiErrorCode;
-import table.eat.now.common.resolver.CurrentUserInfoResolver;
-import table.eat.now.common.resolver.CustomPageableArgumentResolver;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
-import table.eat.now.review.application.service.ReviewService;
 import table.eat.now.review.application.service.dto.request.SearchAdminReviewQuery;
 import table.eat.now.review.application.service.dto.response.PaginatedInfo;
 import table.eat.now.review.application.service.dto.response.SearchAdminReviewInfo;
+import table.eat.now.review.global.support.ControllerTestSupport;
 
-@ActiveProfiles("test")
-@Import({
-    WebConfig.class,
-    CustomPageableArgumentResolver.class,
-    CurrentUserInfoResolver.class,
-    GlobalErrorHandler.class,
-    AuthCheckAspect.class
-})
-@EnableAspectJAutoProxy(proxyTargetClass = true)
-@WebMvcTest(ReviewAdminController.class)
-class ReviewAdminControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @MockitoBean
-  private ReviewService reviewService;
+class ReviewAdminControllerTest extends ControllerTestSupport {
 
   @Nested
   class 관리자_리뷰_검색_요청시 {

--- a/review/src/test/java/table/eat/now/review/presentation/ReviewApiControllerTest.java
+++ b/review/src/test/java/table/eat/now/review/presentation/ReviewApiControllerTest.java
@@ -20,30 +20,16 @@ import static table.eat.now.review.application.exception.ReviewErrorCode.MODIFY_
 import static table.eat.now.review.application.exception.ReviewErrorCode.REVIEW_IS_INVISIBLE;
 import static table.eat.now.review.application.exception.ReviewErrorCode.REVIEW_NOT_FOUND;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import table.eat.now.common.aop.AuthCheckAspect;
-import table.eat.now.common.config.WebConfig;
 import table.eat.now.common.exception.CustomException;
-import table.eat.now.common.exception.GlobalErrorHandler;
-import table.eat.now.common.resolver.CurrentUserInfoResolver;
-import table.eat.now.common.resolver.CustomPageableArgumentResolver;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
-import table.eat.now.review.application.service.ReviewService;
 import table.eat.now.review.application.service.dto.request.CreateReviewCommand;
 import table.eat.now.review.application.service.dto.request.SearchReviewQuery;
 import table.eat.now.review.application.service.dto.request.UpdateReviewCommand;
@@ -51,29 +37,11 @@ import table.eat.now.review.application.service.dto.response.CreateReviewInfo;
 import table.eat.now.review.application.service.dto.response.GetReviewInfo;
 import table.eat.now.review.application.service.dto.response.PaginatedInfo;
 import table.eat.now.review.application.service.dto.response.SearchReviewInfo;
+import table.eat.now.review.global.support.ControllerTestSupport;
 import table.eat.now.review.presentation.dto.request.CreateReviewRequest;
 import table.eat.now.review.presentation.dto.request.UpdateReviewRequest;
 
-@ActiveProfiles("test")
-@Import({
-    WebConfig.class,
-    CustomPageableArgumentResolver.class,
-    CurrentUserInfoResolver.class,
-    GlobalErrorHandler.class,
-    AuthCheckAspect.class
-})
-@EnableAspectJAutoProxy(proxyTargetClass = true)
-@WebMvcTest(ReviewApiController.class)
-class ReviewApiControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockitoBean
-  private ReviewService reviewService;
+class ReviewApiControllerTest extends ControllerTestSupport {
 
   @Nested
   class 리뷰_생성_요청시 {

--- a/waiting/src/test/java/table/eat/now/waiting/helper/ControllerTestSupport.java
+++ b/waiting/src/test/java/table/eat/now/waiting/helper/ControllerTestSupport.java
@@ -3,16 +3,30 @@ package table.eat.now.waiting.helper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import table.eat.now.common.aop.AuthCheckAspect;
 import table.eat.now.common.config.WebConfig;
 import table.eat.now.common.exception.GlobalErrorHandler;
 import table.eat.now.common.resolver.CurrentUserInfoResolver;
 import table.eat.now.common.resolver.CustomPageableArgumentResolver;
+import table.eat.now.waiting.waiting.application.service.WaitingService;
+import table.eat.now.waiting.waiting.presentation.WaitingInternalController;
+import table.eat.now.waiting.waiting_request.application.router.UsecaseRouter;
+import table.eat.now.waiting.waiting_request.presentation.WaitingRequestAdminController;
+import table.eat.now.waiting.waiting_request.presentation.WaitingRequestApiController;
+import table.eat.now.waiting.waiting_request.presentation.WaitingRequestInternalController;
 
+@WebMvcTest({
+    WaitingInternalController.class,
+    WaitingRequestAdminController.class,
+    WaitingRequestApiController.class,
+    WaitingRequestInternalController.class
+})
 @Import({
     WebConfig.class,
     CustomPageableArgumentResolver.class,
@@ -30,4 +44,10 @@ public abstract class ControllerTestSupport {
 
   @Autowired
   protected ObjectMapper objectMapper;
+
+  @MockitoBean
+  protected WaitingService waitingService;
+
+  @MockitoBean
+  protected UsecaseRouter router;
 }

--- a/waiting/src/test/java/table/eat/now/waiting/helper/IntegrationTestSupport.java
+++ b/waiting/src/test/java/table/eat/now/waiting/helper/IntegrationTestSupport.java
@@ -7,6 +7,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
+import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
+import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
+import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 
 @ExtendWith(RedisTestContainerExtension.class)
 @Import(DatabaseCleanUp.class)
@@ -19,6 +24,15 @@ public abstract class IntegrationTestSupport {
 
   @Autowired
   private DatabaseCleanUp databaseCleanUp;
+
+  @MockitoBean
+  protected RestaurantClient restaurantClient;
+
+  @MockitoBean
+  protected WaitingClient waitingClient;
+
+  @MockitoBean
+  protected EventPublisher<WaitingRequestEvent> eventPublisher;
 
   @AfterEach
   void tearDown() {

--- a/waiting/src/test/java/table/eat/now/waiting/waiting/presentation/WaitingInternalControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting/presentation/WaitingInternalControllerTest.java
@@ -11,18 +11,11 @@ import java.time.LocalDate;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.waiting.helper.ControllerTestSupport;
-import table.eat.now.waiting.waiting.application.service.WaitingService;
 import table.eat.now.waiting.waiting.application.service.dto.response.GetDailyWaitingInfo;
 
-@WebMvcTest(WaitingInternalController.class)
 class WaitingInternalControllerTest extends ControllerTestSupport {
-
-  @MockitoBean
-  private WaitingService waitingService;
 
   @DisplayName("일간 대기 정보 내부 조회 검증 - 200 성공")
   @Test

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/CancelWaitingRequestUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/CancelWaitingRequestUsecaseTest.java
@@ -8,13 +8,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.CancelWaitingRequestCommand;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingStatus;
@@ -32,15 +27,6 @@ class CancelWaitingRequestUsecaseTest extends IntegrationTestSupport {
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
 

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/CreateWaitingRequestUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/CreateWaitingRequestUsecaseTest.java
@@ -13,18 +13,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetDailyWaitingInfo;
 import table.eat.now.waiting.waiting_request.application.exception.WaitingRequestErrorCode;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
 import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestCreatedEvent;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.CreateWaitingRequestCommand;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
 import table.eat.now.waiting.waiting_request.domain.reader.WaitingRequestReader;
@@ -41,15 +36,6 @@ class CreateWaitingRequestUsecaseTest extends IntegrationTestSupport {
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
 

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/GetCurrentWaitingRequestsAdminUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/GetCurrentWaitingRequestsAdminUsecaseTest.java
@@ -13,16 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetDailyWaitingInfo;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetRestaurantInfo;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.query.GetCurrentWaitingRequestsAdminQuery;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.response.GetWaitingRequestInfo;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.response.PageResult;
@@ -42,15 +37,6 @@ class GetCurrentWaitingRequestsAdminUsecaseTest  extends IntegrationTestSupport 
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
   private List<WaitingRequest> waitingRequests;

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/GetWaitingRequestAdminUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/GetWaitingRequestAdminUsecaseTest.java
@@ -10,16 +10,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetDailyWaitingInfo;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetRestaurantInfo;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.query.GetWaitingRequestAdminQuery;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.response.GetWaitingRequestInfo;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
@@ -38,15 +33,6 @@ class GetWaitingRequestAdminUsecaseTest extends IntegrationTestSupport {
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
 

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/GetWaitingRequestInternalUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/GetWaitingRequestInternalUsecaseTest.java
@@ -11,18 +11,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetDailyWaitingInfo;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetRestaurantInfo;
 import table.eat.now.waiting.waiting_request.application.exception.WaitingRequestErrorCode;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.query.GetWaitingRequestInternalQuery;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.response.GetWaitingRequestInfo;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
@@ -41,15 +36,6 @@ class GetWaitingRequestInternalUsecaseTest extends IntegrationTestSupport {
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
 

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/GetWaitingRequestUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/GetWaitingRequestUsecaseTest.java
@@ -10,14 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetDailyWaitingInfo;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetRestaurantInfo;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.query.GetWaitingRequestQuery;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.response.GetWaitingRequestInfo;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
@@ -36,15 +31,6 @@ class GetWaitingRequestUsecaseTest extends IntegrationTestSupport {
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
 

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/PostponeWaitingRequestUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/PostponeWaitingRequestUsecaseTest.java
@@ -14,16 +14,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetDailyWaitingInfo;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetRestaurantInfo;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
 import table.eat.now.waiting.waiting_request.application.messaging.dto.EventType;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestPostponedEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.PostponeWaitingRequestCommand;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
@@ -43,15 +38,6 @@ class PostponeWaitingRequestUsecaseTest extends IntegrationTestSupport {
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
 

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/UpdateWaitingRequestStatusAdminUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/UpdateWaitingRequestStatusAdminUsecaseTest.java
@@ -10,16 +10,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetRestaurantInfo;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.UpdateWaitingRequestStatusAdminCommand;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingStatus;
@@ -38,15 +33,6 @@ class UpdateWaitingRequestStatusAdminUsecaseTest  extends IntegrationTestSupport
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
 

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/WaitingRequestEntranceAdminUsecaseTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/application/usecase/WaitingRequestEntranceAdminUsecaseTest.java
@@ -12,18 +12,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import table.eat.now.common.exception.CustomException;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.IntegrationTestSupport;
-import table.eat.now.waiting.waiting_request.application.client.RestaurantClient;
-import table.eat.now.waiting.waiting_request.application.client.WaitingClient;
 import table.eat.now.waiting.waiting_request.application.client.dto.response.GetRestaurantInfo;
 import table.eat.now.waiting.waiting_request.application.exception.WaitingRequestErrorCode;
-import table.eat.now.waiting.waiting_request.application.messaging.EventPublisher;
 import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEntranceEvent;
-import table.eat.now.waiting.waiting_request.application.messaging.dto.WaitingRequestEvent;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.WaitingRequestEntranceAdminCommand;
 import table.eat.now.waiting.waiting_request.domain.entity.WaitingRequest;
 import table.eat.now.waiting.waiting_request.domain.reader.WaitingRequestReader;
@@ -41,15 +36,6 @@ class WaitingRequestEntranceAdminUsecaseTest extends IntegrationTestSupport {
 
   @Autowired
   private WaitingRequestStore store;
-
-  @MockitoBean
-  private RestaurantClient restaurantClient;
-
-  @MockitoBean
-  private WaitingClient waitingClient;
-
-  @MockitoBean
-  private EventPublisher<WaitingRequestEvent> eventPublisher;
 
   private WaitingRequest waitingRequest;
 

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestAdminControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestAdminControllerTest.java
@@ -14,15 +14,12 @@ import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.ControllerTestSupport;
-import table.eat.now.waiting.waiting_request.application.router.UsecaseRouter;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.UpdateWaitingRequestStatusAdminCommand;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.WaitingRequestEntranceAdminCommand;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.query.GetCurrentWaitingRequestsAdminQuery;
@@ -30,11 +27,7 @@ import table.eat.now.waiting.waiting_request.application.usecase.dto.query.GetWa
 import table.eat.now.waiting.waiting_request.application.usecase.dto.response.PageResult;
 import table.eat.now.waiting.waiting_request.fixture.GetWaitingRequestInfoFixture;
 
-@WebMvcTest(WaitingRequestAdminController.class)
 class WaitingRequestAdminControllerTest extends ControllerTestSupport {
-
-  @MockitoBean
-  private UsecaseRouter router;
 
   @DisplayName("대기 요청 입장 처리 요청 - 200 성공 응답")
   @Test

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestApiControllerTest.java
@@ -16,25 +16,18 @@ import java.util.UUID;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.ControllerTestSupport;
-import table.eat.now.waiting.waiting_request.application.router.UsecaseRouter;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.CancelWaitingRequestCommand;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.command.PostponeWaitingRequestCommand;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.query.GetWaitingRequestQuery;
 import table.eat.now.waiting.waiting_request.fixture.GetWaitingRequestInfoFixture;
 import table.eat.now.waiting.waiting_request.presentation.dto.request.CreateWaitingRequestRequest;
 
-@WebMvcTest(WaitingRequestApiController.class)
 class WaitingRequestApiControllerTest extends ControllerTestSupport {
-
-  @MockitoBean
-  private UsecaseRouter router;
 
   @DisplayName("대기 요청 생성 검증 - 201 응답")
   @Test

--- a/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestInternalControllerTest.java
+++ b/waiting/src/test/java/table/eat/now/waiting/waiting_request/presentation/WaitingRequestInternalControllerTest.java
@@ -12,21 +12,14 @@ import static table.eat.now.common.constant.UserInfoConstant.USER_ROLE_HEADER;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import table.eat.now.common.resolver.dto.CurrentUserInfoDto;
 import table.eat.now.common.resolver.dto.UserRole;
 import table.eat.now.waiting.helper.ControllerTestSupport;
-import table.eat.now.waiting.waiting_request.application.router.UsecaseRouter;
 import table.eat.now.waiting.waiting_request.application.usecase.dto.query.GetWaitingRequestInternalQuery;
 import table.eat.now.waiting.waiting_request.fixture.GetWaitingRequestInfoFixture;
 
-@WebMvcTest(WaitingRequestInternalController.class)
 class WaitingRequestInternalControllerTest extends ControllerTestSupport {
-
-  @MockitoBean
-  private UsecaseRouter router;
 
   @DisplayName("대기 요청 내부 조회 - 200 성공")
   @Test


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #224

## 변경 타입
- [x] 리팩토링

## 변경 내용
- **as-is**
  - 변경 전 테스트 가동 횟수
    - coupon: 7
    - notification: 1
    - payment: 5
    - promotion: 7
    - reservation: 2
    - restaurant: 2
    - review: 4
    - user: 1
    - waiting: 6

- **to-be**
  - [x] 테스트 서버 기동 최소화
    - coupon: 7 -> 3
    - notification: 1
    - payment: 5 -> 2
    - promotion: 7 -> 2
    - reservation: 2
    - restaurant: 2
    - review: 4 -> 2
    - user: 1
    - waiting: 6 -> 2
## 코멘트
- 하온님의 스케줄러 테스트가 service를 mock으로 사용하고 계셔서 3번 띄우게 되었습니다!

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [x] 문서(코드, 주석, README 등)를 업데이트했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
    - 공통 컨트롤러 테스트 지원 클래스(ControllerTestSupport)를 각 모듈에 도입하여 테스트 설정 및 의존성 주입을 일원화했습니다.
    - 여러 컨트롤러 테스트 클래스가 공통 지원 클래스를 상속하도록 리팩터링되어 중복된 설정 및 필드 선언이 제거되었습니다.
    - 통합 테스트 지원 클래스에 MockBean 의존성을 추가하거나, 일부 테스트에서 MockBean 및 관련 필드를 제거하여 테스트 구조가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->