### PR TITLE
[common] 설정 파일 수정 -> 빌드 트리거

### DIFF
--- a/config/src/main/resources/application-prod.yml
+++ b/config/src/main/resources/application-prod.yml
@@ -1,0 +1,26 @@
+spring:
+  application:
+    name: config
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://github.com/HI-dle/ten-private
+          username: ${GITHUB_USERNAME}
+          password: ${GITHUB_PASSWORD}
+          default-label: main
+          search-paths: dev, prod
+          basedir: config
+server:
+  port: 8888
+
+eureka:
+  client:
+    register-with-eureka: true  # Eureka Server에 등록
+    fetch-registry: true  # Eureka Server에서 서비스 목록 가져오기
+    service-url:
+      defaultZone: ${PROD_EUREKA_SERVICE_URL}
+  instance:
+    hostname: ${EUREKA_INSTANCE_HOSTNAME}
+    prefer-ip-address: false
+    non-secure-port: 80

--- a/config/src/main/resources/application.yml
+++ b/config/src/main/resources/application.yml
@@ -11,8 +11,8 @@ spring:
           default-label: main
           search-paths: dev, prod
           basedir: config
-#server:
-#  port: 8888
+server:
+  port: 8888
 
 eureka:
   client:

--- a/coupon/src/main/resources/properties/jpa.yml
+++ b/coupon/src/main/resources/properties/jpa.yml
@@ -12,7 +12,7 @@ spring:
         order_inserts: true
         order_updates: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     defer-datasource-initialization: true # hibernate가 초기화되기 전 data.sql 실행하는 것을 방지
     open-in-view: false
 
@@ -22,10 +22,9 @@ spring:
   config.activate.on-profile: test
   jpa:
     generate-ddl: true
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        format_sql: true
         jdbc:
           batch_size: 1000
         order_inserts: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,14 @@ services:
     ports:
       - "6380:6379"  # 레디스 기본 포트
 
+  redis-insight:
+    container_name: ten-redis-insight
+    image: redis/redisinsight
+    ports:
+      - 5540:5540
+    networks:
+      - app_network
+
   prometheus:
     container_name: ten-prometheus
     image: prom/prometheus:latest
@@ -82,3 +90,7 @@ services:
 
 volumes:
   grafana-storage:
+
+networks:
+  app_network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,14 +25,6 @@ services:
     ports:
       - "6380:6379"  # 레디스 기본 포트
 
-  redis-insight:
-    container_name: ten-redis-insight
-    image: redis/redisinsight
-    ports:
-      - 5540:5540
-    networks:
-      - app_network
-
   prometheus:
     container_name: ten-prometheus
     image: prom/prometheus:latest

--- a/gateway/src/main/resources/application-prod.yml
+++ b/gateway/src/main/resources/application-prod.yml
@@ -63,3 +63,7 @@ eureka:
   client:
     service-url:
       defaultZone: ${PROD_EUREKA_SERVICE_URL}
+  instance:
+    hostname: ${EUREKA_INSTANCE_HOSTNAME}
+    prefer-ip-address: false
+    non-secure-port: 80

--- a/notification/docker-compose.yml
+++ b/notification/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: hidle-notification
     image: 390403891668.dkr.ecr.ap-northeast-2.amazonaws.com/hidle-ecr:notification
     ports:
-      - "8089:8089"
+      - "80:8089"
     volumes:
       - ./logs:/logs
       - ./.env.notification:/app/.env.notification

--- a/notification/src/main/resources/application-prod.yml
+++ b/notification/src/main/resources/application-prod.yml
@@ -64,9 +64,9 @@ eureka:
     service-url:
       defaultZone: ${PROD_EUREKA_SERVICE_URL}
   instance:
-    ip-address: ${PROD_EC2_ADDRESS}
-    prefer-ip-address: true  # 서비스 등록 시 IP 주소 사용
-
+    hostname: ${EUREKA_INSTANCE_HOSTNAME}
+    prefer-ip-address: false
+    non-secure-port: 80
 
 management:
   endpoints:

--- a/promotion/docker-compose.yml
+++ b/promotion/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: hidle-promotion
     image: 390403891668.dkr.ecr.ap-northeast-2.amazonaws.com/hidle-ecr:promotion
     ports:
-      - "8084:8084"
+      - "80:8084"
     volumes:
       - ./logs:/logs
       - ./.env.promotion:/app/.env.promotion

--- a/promotion/src/main/resources/application-prod.yml
+++ b/promotion/src/main/resources/application-prod.yml
@@ -54,9 +54,9 @@ eureka:
     service-url:
       defaultZone: ${PROD_EUREKA_SERVICE_URL}
   instance:
-    ip-address: ${PROD_EC2_ADDRESS}
-    prefer-ip-address: true  # 서비스 등록 시 IP 주소 사용
-
+    hostname: ${EUREKA_INSTANCE_HOSTNAME}
+    prefer-ip-address: false
+    non-secure-port: 80
 
 management:
   endpoints:

--- a/user/docker-compose.yml
+++ b/user/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: hidle-user
     image: 390403891668.dkr.ecr.ap-northeast-2.amazonaws.com/hidle-ecr:user
     ports:
-      - "8081:8081"
+      - "80:8081"
     volumes:
       - ./logs:/logs
       - ./.env.user:/app/.env.user

--- a/user/src/main/resources/application-prod.yml
+++ b/user/src/main/resources/application-prod.yml
@@ -26,8 +26,9 @@ eureka:
     service-url:
       defaultZone: ${PROD_EUREKA_SERVICE_URL}
   instance:
-    prefer-ip-address: true
-    ip-address: ${PROD_EC2_ADDRESS}
+    hostname: ${EUREKA_INSTANCE_HOSTNAME}
+    prefer-ip-address: false
+    non-secure-port: 80
 
 jwt:
   secret: ${JWT_SECRET}

--- a/waiting/src/main/resources/properties/cloud.yml
+++ b/waiting/src/main/resources/properties/cloud.yml
@@ -52,3 +52,7 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: ${PROD_EUREKA_SERVER}
+  instance:
+    hostname: ${EUREKA_INSTANCE_HOSTNAME}
+    prefer-ip-address: false
+    non-secure-port: 80

--- a/waiting/src/main/resources/properties/monitoring.yml
+++ b/waiting/src/main/resources/properties/monitoring.yml
@@ -46,8 +46,8 @@ spring:
   config.activate.on-profile: prod
 management:
   server:
-    port: 19043
-    address: 172.31.38.190
+#    port: 19043
+#    address: 172.31.38.190
   endpoints:
     health:
       show-details: always


### PR DESCRIPTION
- 도메인으로 통신하도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - Redis Insight 서비스가 Docker Compose에 추가되어 Redis 관리 UI를 제공합니다.
    - Spring Cloud Config Server의 프로덕션 환경 설정 파일이 추가되었습니다.

- **버그 수정**
    - 여러 서비스의 Eureka 클라이언트 등록 방식이 IP 기반에서 호스트네임 기반으로 변경되어 네트워크 식별 방식이 개선되었습니다.

- **환경설정**
    - 여러 서비스(Docker Compose 및 YAML)에서 외부 접근 포트가 808x에서 80으로 변경되어 표준 HTTP 포트로 통합되었습니다.
    - JPA 설정에서 로컬 환경의 스키마 자동 생성 방식이 update로 변경되고, 테스트 환경에서 SQL 로그 및 포맷팅이 비활성화되었습니다.
    - 프로덕션 환경의 관리 서버 포트 및 주소 설정이 비활성화되었습니다.

- **기타**
    - 서브프로젝트의 커밋 참조가 최신 상태로 갱신되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->