### PR TITLE
[coupon] 캐시 write back 디비 싱크 구현

### DIFF
--- a/coupon/src/main/java/table/eat/now/coupon/coupon/application/scheduler/CouponScheduler.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/application/scheduler/CouponScheduler.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import table.eat.now.coupon.coupon.application.aop.annotation.DistributedLock;
 import table.eat.now.coupon.coupon.application.usecase.PrepareCouponIssuanceUsecase;
 import table.eat.now.coupon.coupon.application.usecase.PrepareDailyCouponCacheUsecase;
+import table.eat.now.coupon.coupon.application.usecase.SyncCouponCacheToDbUsecase;
 
 @Slf4j
 @Component
@@ -14,6 +15,7 @@ import table.eat.now.coupon.coupon.application.usecase.PrepareDailyCouponCacheUs
 public class CouponScheduler {
   private final PrepareCouponIssuanceUsecase prepareCouponIssuanceUsecase;
   private final PrepareDailyCouponCacheUsecase prepareDailyCouponCacheUsecase;
+  private final SyncCouponCacheToDbUsecase syncCouponCacheToDbUsecase;
 
   @DistributedLock(subPrefix = "schedule:hourlycaching", waitTime = 0L, leaseTime = 60)
   @Scheduled(cron="0 0 * * * *")
@@ -27,5 +29,11 @@ public class CouponScheduler {
   @Scheduled(cron="0 0 0/23 * * *")
   public void prepareDailyCouponCache() {
     prepareDailyCouponCacheUsecase.execute();
+  }
+
+  @DistributedLock(subPrefix = "schedule:sync:caching:db", waitTime = 0L, leaseTime = 60)
+  @Scheduled(cron="0 * * * * *")
+  public void syncCouponCacheToDb() {
+    syncCouponCacheToDbUsecase.execute();
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/application/scheduler/config/SchedulingConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/application/scheduler/config/SchedulingConfig.java
@@ -1,9 +1,0 @@
-package table.eat.now.coupon.coupon.application.scheduler.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
-
-@Configuration
-@EnableScheduling
-public class SchedulingConfig {
-}

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/application/service/CouponServiceImpl.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/application/service/CouponServiceImpl.java
@@ -70,7 +70,7 @@ public class CouponServiceImpl implements CouponService {
     try {
       coupon = getValidCouponBy(couponUuid);
       coupon.modify(command.toDomainCommand());
-      couponStore.save(coupon);
+      coupon = couponStore.save(coupon);
 
     } catch (StaleObjectStateException e) {
       throw CustomException.from(CouponErrorCode.IS_OUTDATED_DATA);

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/application/usecase/SyncCouponCacheToDbUsecase.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/application/usecase/SyncCouponCacheToDbUsecase.java
@@ -1,0 +1,37 @@
+package table.eat.now.coupon.coupon.application.usecase;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import table.eat.now.coupon.coupon.application.utils.TimeProvider;
+import table.eat.now.coupon.coupon.domain.entity.Coupon;
+import table.eat.now.coupon.coupon.domain.reader.CouponReader;
+import table.eat.now.coupon.coupon.domain.store.CouponStore;
+
+@RequiredArgsConstructor
+@Service
+public class SyncCouponCacheToDbUsecase {
+
+  public static final Integer THRESHOLD_MINUTES = 5;
+  private final CouponReader couponReader;
+  private final CouponStore couponStore;
+
+  @Transactional
+  public void execute() {
+
+    LocalDateTime min5Ago = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES).minusMinutes(THRESHOLD_MINUTES);
+    long threshold = TimeProvider.getEpochMillis(min5Ago);
+    Set<String> expiredCouponCacheKeys = couponReader.getDirtyCouponKeysForSync(threshold);
+    couponStore.deleteDirtyCouponKeysByScore(threshold);
+
+    List<Coupon> couponCaches = couponReader.getValidCouponCachesBy(expiredCouponCacheKeys.stream().toList());
+
+    for (Coupon coupon : couponCaches) {
+      couponStore.updateIssuedCount(coupon.getCouponUuid(), coupon.getIssuedCount(), coupon.getVersion());
+    }
+  }
+}

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/domain/entity/Coupon.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/domain/entity/Coupon.java
@@ -22,9 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import table.eat.now.common.domain.BaseEntity;
-import table.eat.now.coupon.coupon.domain.command.CouponIssuance;
 import table.eat.now.coupon.coupon.domain.command.UpdateCoupon;
-import table.eat.now.coupon.coupon.domain.info.CouponProfile;
 
 @Table(name="p_coupon")
 @Getter
@@ -160,12 +158,4 @@ public class Coupon extends BaseEntity {
     return this.period.isIssuableIn(today);
   }
 
-  public CouponIssuance toIssuance(Long userId, Long timestamp) {
-    return CouponIssuance.builder()
-        .couponProfile(CouponProfile.parse(this))
-        .userId(userId)
-        .timestamp(timestamp)
-        .couponUuid(this.couponUuid)
-        .build();
-  }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/domain/reader/CouponReader.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/domain/reader/CouponReader.java
@@ -27,4 +27,8 @@ public interface CouponReader {
   List<Coupon> getIssuableCouponsCacheIn(CouponLabel label);
 
   boolean isAlreadyIssued(String couponUuid, Long userId);
+
+  Set<String> getDirtyCouponKeysForSync(long threshold);
+
+  List<Coupon> getValidCouponCachesBy(List<String> couponKeys);
 }

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/domain/store/CouponStore.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/domain/store/CouponStore.java
@@ -29,4 +29,8 @@ public interface CouponStore {
   boolean markAsIssued(String couponUuid, Long userId);
 
   Long increaseCouponCount(String couponUuid);
+
+  void updateIssuedCount(String couponUuid, Integer issuedCount, Long version);
+
+  void deleteDirtyCouponKeysByScore(long threshold);
 }

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/CouponReaderImpl.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/CouponReaderImpl.java
@@ -75,4 +75,14 @@ public class CouponReaderImpl implements CouponReader {
   public boolean isAlreadyIssued(String couponUuid, Long userId) {
     return redisCouponCacheManager.isAlreadyIssued(couponUuid, userId);
   }
+
+  @Override
+  public Set<String> getDirtyCouponKeysForSync(long threshold) {
+    return redisCouponCacheManager.getDirtyCouponKeysForSync(threshold);
+  }
+
+  @Override
+  public List<Coupon> getValidCouponCachesBy(List<String> couponKeys) {
+    return redisCouponCacheManager.getValidCouponsCacheBy(couponKeys);
+  }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/CouponStoreImpl.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/CouponStoreImpl.java
@@ -1,5 +1,7 @@
 package table.eat.now.coupon.coupon.infrastructure.persistence;
 
+import static table.eat.now.coupon.coupon.infrastructure.persistence.redis.constant.CouponCacheConstant.DIRTY_COUPON_ZSET;
+
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +52,16 @@ public class CouponStoreImpl implements CouponStore {
   @Override
   public Long increaseCouponCount(String couponUuid) {
     return redisCacheManager.increaseCouponCount(couponUuid);
+  }
+
+  @Override
+  public void updateIssuedCount(String couponUuid, Integer issuedCount, Long version) {
+    jpaRepository.updateIssuedCount(couponUuid, issuedCount, version);
+  }
+
+  @Override
+  public void deleteDirtyCouponKeysByScore(long threshold) {
+    redisCacheManager.deleteZSetMembersByScore(DIRTY_COUPON_ZSET, threshold);
   }
 
   @Override

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/jpa/JpaCouponRepository.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/jpa/JpaCouponRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import table.eat.now.coupon.coupon.domain.entity.Coupon;
 
@@ -20,8 +21,13 @@ public interface JpaCouponRepository
   List<Coupon> findByCouponUuidsInAndDeletedAtIsNullFetchJoin(Set<String> couponUuids);
 
   @Query("select c from Coupon c join fetch c.policy "
-      + "where c.period.issueStartAt < :toAt and c.period.issueEndAt > :fromAt "
+      + "where c.period.issueStartAt >= :fromAt and c.period.issueStartAt < :toAt "
       + "and c.label in ('HOT', 'PROMOTION')"
       + "and c.deletedAt is null")
   List<Coupon> findCouponsByIssueStartAtBtwAndHotPromo(LocalDateTime fromAt, LocalDateTime toAt);
+
+  @Modifying
+  @Query("update Coupon c set c.issuedCount = :issuedCount, c.version = c.version + 1 "
+      + "where c.couponUuid = :couponUuid and c.version <= :version")
+  void updateIssuedCount(String couponUuid, Integer issuedCount, Long version);
 }

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/redis/config/CouponRedisConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/redis/config/CouponRedisConfig.java
@@ -37,12 +37,13 @@ public class CouponRedisConfig {
     //objectMapperForRedis.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     Jackson2JsonRedisSerializer<Object> serializer =
         new Jackson2JsonRedisSerializer<>(objectMapperForRedis, Object.class);
+    StringRedisSerializer stringSerializer = new StringRedisSerializer();
 
     RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
     redisTemplate.setConnectionFactory(redisConnectionFactory);
-    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setKeySerializer(stringSerializer);
     redisTemplate.setValueSerializer(serializer);
-    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+    redisTemplate.setHashKeySerializer(stringSerializer);
     redisTemplate.setHashValueSerializer(serializer);
 
     return redisTemplate;

--- a/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/redis/constant/CouponCacheConstant.java
+++ b/coupon/src/main/java/table/eat/now/coupon/coupon/infrastructure/persistence/redis/constant/CouponCacheConstant.java
@@ -5,7 +5,7 @@ public class CouponCacheConstant {
     throw new IllegalStateException("Constant class");
   }
 
-  public static final String DIRTY_COUPON_SET = "coupon:dirty";
+  public static final String DIRTY_COUPON_ZSET = "coupon:dirty";
 
   public static final String COUPON_CACHE = "coupon:";
   public static final String COUPON_USER_SET = "coupon:user:";

--- a/coupon/src/main/java/table/eat/now/coupon/global/metric/KafkaLagMetricProvider.java
+++ b/coupon/src/main/java/table/eat/now/coupon/global/metric/KafkaLagMetricProvider.java
@@ -2,9 +2,12 @@ package table.eat.now.coupon.global.metric;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.OffsetSpec;
@@ -12,13 +15,37 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class KafkaLagMetricProvider {
 
   private final AdminClient adminClient;
+  private final MetricProvider metricProvider;
+  private final Map<String, AtomicLong> lagMetrics = new ConcurrentHashMap<>();
 
-  public Map<TopicPartition, Long> getConsumerLag(String groupId)
+  public void publishConsumerLagToMetrics(String groupId) {
+
+    Map<TopicPartition, Long> consumerLag = null;
+    try {
+      consumerLag = this.getConsumerLag(groupId);
+
+      consumerLag.forEach((topicPartition, lag) -> {
+        String metricId = String.format("%s:%s:%d", groupId, topicPartition.topic(), topicPartition.partition());
+        AtomicLong atomicLag = lagMetrics.computeIfAbsent(metricId, id -> {
+          AtomicLong value = new AtomicLong(lag);
+          metricProvider.getLagGauge(groupId, topicPartition, value);
+          return value;
+        });
+        atomicLag.set(lag);
+      });
+    }
+    catch (Exception e) {
+      log.error("컨슈머 랙 지표 획득 실패:: groupId:{}", groupId, e);
+    }
+  }
+
+  private Map<TopicPartition, Long> getConsumerLag(String groupId)
       throws ExecutionException, InterruptedException {
 
     Map<TopicPartition, OffsetAndMetadata> consumerOffsets =

--- a/coupon/src/main/java/table/eat/now/coupon/global/scheduler/KafkaLagMeasureScheduler.java
+++ b/coupon/src/main/java/table/eat/now/coupon/global/scheduler/KafkaLagMeasureScheduler.java
@@ -1,51 +1,24 @@
 package table.eat.now.coupon.global.scheduler;
 
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.common.TopicPartition;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import table.eat.now.coupon.global.metric.KafkaLagMetricProvider;
-import table.eat.now.coupon.global.metric.MetricProvider;
 import table.eat.now.coupon.user_coupon.infrastructure.messaging.kafka.config.UserCouponConsumerConfig;
 
-@Slf4j
+
 @RequiredArgsConstructor
 @Component
 public class KafkaLagMeasureScheduler {
   private final KafkaLagMetricProvider kafkaLagMetricProvider;
-  private final MetricProvider metricProvider;
-  private final Map<String, AtomicLong> lagMetrics = new ConcurrentHashMap<>();
   private static final List<String> GROUP_IDS = List.of(
-      UserCouponConsumerConfig.GROUP, UserCouponConsumerConfig.GROUP_1, "for-test");
+      UserCouponConsumerConfig.GROUP,
+      UserCouponConsumerConfig.GROUP_1,
+      "for-test");
 
   @Scheduled(fixedRate = 5000)
   public void updateConsumerLag() {
-    GROUP_IDS.forEach(this::publishConsumerLagToMetrics);
-  }
-
-  private void publishConsumerLagToMetrics(String groupId) {
-
-    Map<TopicPartition, Long> consumerLag = null;
-    try {
-      consumerLag = kafkaLagMetricProvider.getConsumerLag(groupId);
-
-      consumerLag.forEach((topicPartition, lag) -> {
-        String metricId = String.format("%s:%s:%d", groupId, topicPartition.topic(), topicPartition.partition());
-        AtomicLong atomicLag = lagMetrics.computeIfAbsent(metricId, id -> {
-          AtomicLong value = new AtomicLong(lag);
-          metricProvider.getLagGauge(groupId, topicPartition, value);
-          return value;
-        });
-        atomicLag.set(lag);
-      });
-    }
-    catch (Exception e) {
-      log.error("컨슈머 랙 지표 획득 실패:: groupId:{}", groupId, e);
-    }
+    GROUP_IDS.forEach(kafkaLagMetricProvider::publishConsumerLagToMetrics);
   }
 }

--- a/coupon/src/main/java/table/eat/now/coupon/global/scheduler/config/SchedulingConfig.java
+++ b/coupon/src/main/java/table/eat/now/coupon/global/scheduler/config/SchedulingConfig.java
@@ -1,0 +1,20 @@
+package table.eat.now.coupon.global.scheduler.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+  @Bean
+  public TaskScheduler taskScheduler() {
+    ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+    threadPoolTaskScheduler.setPoolSize(4);
+    threadPoolTaskScheduler.setThreadNamePrefix("scheduler-");
+    return threadPoolTaskScheduler;
+  }
+}

--- a/coupon/src/main/resources/redis/coupon/limited_nondup.lua
+++ b/coupon/src/main/resources/redis/coupon/limited_nondup.lua
@@ -1,7 +1,7 @@
 local userSetKey = KEYS[1]    -- 쿠폰 발급 유저 집합 키
 local couponKey = KEYS[2]   -- 쿠폰 캐시 키
 local idempotencyKey = KEYS[3]  -- 이벤트별 idempotency 키
-local dirtyCouponSetKey = KEYS[4] -- 쿠폰 캐시 변경 감지 집합 키
+local dirtyCouponZSetKey = KEYS[4] -- 쿠폰 캐시 변경 감지 집합 키
 
 local userId = ARGV[1]
 local currentTimestamp = tonumber(ARGV[2])
@@ -35,7 +35,7 @@ end
 -- 4. 발급 완료 처리
 redis.call('HINCRBY', couponKey, 'issuedCount', 1)
 redis.call('SADD', userSetKey, userId)
-redis.call('ZADD', dirtyCouponSetKey, currentTimestamp, couponKey)
+redis.call('ZADD', dirtyCouponZSetKey, 'NX', currentTimestamp, couponKey)
 redis.call('SET', idempotencyKey, 1, 'EX', 86400)  -- idempotency 키 설정 (3600 *24 1일 TTL)
 
 return 1  -- 발급 성공

--- a/coupon/src/main/resources/redis/coupon/limited_nondup_test.lua
+++ b/coupon/src/main/resources/redis/coupon/limited_nondup_test.lua
@@ -1,0 +1,20 @@
+local userSetKey = KEYS[1]    -- 쿠폰 발급 유저 집합 키
+local couponCountKey = KEYS[2]   -- 쿠폰 캐시 키
+local userId = ARGV[1]
+
+-- 2. 유저 중복 체크
+if redis.call('SISMEMBER', userSetKey, userId) == 1 then
+    return -1  -- 중복 발급 시도
+end
+
+-- 3. 재고 체크
+local remainder = tonumber(redis.call('DECRBY', couponCountKey, 1))
+
+if remainder < 0 then
+    return -2  -- 재고 없음
+end
+
+-- 4. 발급 완료 처리
+redis.call('SADD', userSetKey, userId)
+
+return 1  -- 발급 성공

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/application/scheduler/CouponSchedulerTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/application/scheduler/CouponSchedulerTest.java
@@ -19,6 +19,7 @@ import table.eat.now.common.exception.CustomException;
 import table.eat.now.coupon.coupon.application.exception.CouponErrorCode;
 import table.eat.now.coupon.coupon.application.usecase.PrepareCouponIssuanceUsecase;
 import table.eat.now.coupon.coupon.application.usecase.PrepareDailyCouponCacheUsecase;
+import table.eat.now.coupon.coupon.application.usecase.SyncCouponCacheToDbUsecase;
 import table.eat.now.coupon.helper.IntegrationTestSupport;
 
 class CouponSchedulerTest extends IntegrationTestSupport {
@@ -31,6 +32,9 @@ class CouponSchedulerTest extends IntegrationTestSupport {
 
   @MockitoBean
   private PrepareDailyCouponCacheUsecase prepareDailyCouponCacheUsecase;
+
+  @MockitoBean
+  private SyncCouponCacheToDbUsecase syncCouponCacheToDbUsecase;
 
   @BeforeEach
   void setUp() {
@@ -87,5 +91,18 @@ class CouponSchedulerTest extends IntegrationTestSupport {
 
     // then
     verify(prepareDailyCouponCacheUsecase, times(1)).execute();
+  }
+
+  @DisplayName("쿠폰 캐시 디비 싱크 스케쥴러 메소드 호출시 내부 로직이 잘 동작하는지 확인 - 성공")
+  @Test
+  void syncCouponCacheToDb() {
+    // given
+    doNothing().when(syncCouponCacheToDbUsecase).execute();
+
+    // when
+    couponScheduler.syncCouponCacheToDb();
+
+    // then
+    verify(syncCouponCacheToDbUsecase, times(1)).execute();
   }
 }

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/application/usecase/PrepareDailyCouponCacheUsecaseTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/application/usecase/PrepareDailyCouponCacheUsecaseTest.java
@@ -36,7 +36,7 @@ class PrepareDailyCouponCacheUsecaseTest extends IntegrationTestSupport {
   void setUp() {
     coupons = CouponFixture.createCoupons(20);
     coupons.forEach(coupon -> {
-      ReflectionTestUtils.setField(coupon.getPeriod(), "issueStartAt", LocalDateTime.now().minusDays(1));
+      ReflectionTestUtils.setField(coupon.getPeriod(), "issueStartAt", LocalDateTime.now().plusDays(1));
       ReflectionTestUtils.setField(coupon, "label", CouponLabel.HOT);
     });
     couponStore.saveAll(coupons);

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/application/usecase/SyncCouponCacheToDbUsecaseTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/application/usecase/SyncCouponCacheToDbUsecaseTest.java
@@ -1,0 +1,83 @@
+package table.eat.now.coupon.coupon.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static table.eat.now.coupon.coupon.infrastructure.persistence.redis.constant.CouponCacheConstant.COUPON_CACHE;
+import static table.eat.now.coupon.coupon.infrastructure.persistence.redis.constant.CouponCacheConstant.DIRTY_COUPON_ZSET;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+import table.eat.now.coupon.coupon.application.utils.TimeProvider;
+import table.eat.now.coupon.coupon.domain.command.CouponIssuance;
+import table.eat.now.coupon.coupon.domain.entity.Coupon;
+import table.eat.now.coupon.coupon.domain.info.CouponProfile;
+import table.eat.now.coupon.coupon.domain.reader.CouponReader;
+import table.eat.now.coupon.coupon.domain.store.CouponStore;
+import table.eat.now.coupon.coupon.fixture.CouponFixture;
+import table.eat.now.coupon.coupon.infrastructure.persistence.jpa.JpaCouponRepository;
+import table.eat.now.coupon.helper.IntegrationTestSupport;
+
+class SyncCouponCacheToDbUsecaseTest extends IntegrationTestSupport {
+
+  @Autowired
+  private SyncCouponCacheToDbUsecase syncCouponCacheToDbUsecase;
+
+  @Autowired
+  private CouponReader couponReader;
+  @Autowired
+  private CouponStore couponStore;
+  @Autowired
+  private JpaCouponRepository jpaCouponRepository;
+
+  private Coupon coupon;
+
+  @BeforeEach
+  void setUp() {
+    // 핫 쿠폰
+    coupon = CouponFixture.createHotCoupon(
+        1, "FIXED_DISCOUNT", 2, false, 2000, null, null);
+    ReflectionTestUtils.setField(coupon.getPeriod(), "issueStartAt", LocalDateTime.now().minusDays(1));
+    couponStore.save(coupon);
+
+    Duration cacheDuration = TimeProvider.getDuration(coupon.calcExpireAt(), 60);
+    couponStore.insertCouponCache(coupon.getCouponUuid(), coupon, cacheDuration);
+  }
+
+  @DisplayName("변경 감지된 쿠폰 캐시: 디비 싱크 수행 검증 - 성공")
+  @Transactional
+  @Test
+  void execute() {
+    // given
+    couponStore.requestIssue(CouponIssuance.builder()
+        .couponUuid(coupon.getCouponUuid())
+        .timestamp(TimeProvider.getEpochMillis(LocalDateTime.now()))
+        .couponProfile(CouponProfile.parse(coupon))
+        .userId(1L)
+        .build());
+
+    Double result = stringRedisTemplate.opsForZSet().incrementScore(
+        DIRTY_COUPON_ZSET,
+        COUPON_CACHE + coupon.getCouponUuid(),
+        -6 * 60_000L);
+
+    // when
+    syncCouponCacheToDbUsecase.execute();
+
+    // then
+    entityManager.clear();
+    Coupon updated = jpaCouponRepository.findByCouponUuidAndDeletedAtIsNullFetchJoin(
+            coupon.getCouponUuid())
+        .orElseThrow(() -> new RuntimeException("coupon not found"));
+
+    assertThat(updated.getIssuedCount()).isEqualTo(1);
+
+    Double score = stringRedisTemplate.opsForZSet()
+        .score(DIRTY_COUPON_ZSET, COUPON_CACHE + coupon.getCouponUuid());
+    assertThat(score).isNull();
+  }
+}

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/fixture/CouponFixture.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/fixture/CouponFixture.java
@@ -24,22 +24,6 @@ public class CouponFixture {
         .toList();
   }
 
-  private static Coupon createCouponBase(
-      int i, String type, String label, LocalDateTime issueEndAt,
-      Integer count, boolean allowDuplicate,
-      Integer amount, Integer percent, Integer maxDiscountAmount
-  ) {
-    Coupon coupon = Coupon.of("test 쿠폰 " + i, type, label,
-        LocalDateTime.now().plusDays(2+i).truncatedTo(ChronoUnit.DAYS),
-        issueEndAt,
-        LocalDateTime.now().plusDays(12+i).truncatedTo(ChronoUnit.DAYS),
-        7, count, allowDuplicate);
-    DiscountPolicy policy = DiscountPolicy.of(
-        10000, amount, percent, maxDiscountAmount);
-    coupon.registerPolicy(policy);
-    return coupon;
-  }
-
   public static Coupon createCoupon(
       int i, String type, String label, Integer count, boolean allowDuplicate,
       Integer amount, Integer percent, Integer maxDiscountAmount
@@ -52,12 +36,12 @@ public class CouponFixture {
   }
 
   public static Coupon createHotCoupon(
-      int i, String type, String label, Integer count, boolean allowDuplicate,
+      int i, String type, Integer count, boolean allowDuplicate,
       Integer amount, Integer percent, Integer maxDiscountAmount
   ) {
 
     return createCouponBase(
-        i, type, label,
+        i, type, "HOT",
         LocalDateTime.now().plusDays(2+i).plusMinutes(59).truncatedTo(ChronoUnit.DAYS),
         count, allowDuplicate, amount, percent, maxDiscountAmount);
   }
@@ -115,5 +99,21 @@ public class CouponFixture {
         )
         .toList();
     return couponInfos;
+  }
+
+  private static Coupon createCouponBase(
+      int i, String type, String label, LocalDateTime issueEndAt,
+      Integer count, boolean allowDuplicate,
+      Integer amount, Integer percent, Integer maxDiscountAmount
+  ) {
+    Coupon coupon = Coupon.of("test 쿠폰 " + i, type, label,
+        LocalDateTime.now().plusDays(2+i).truncatedTo(ChronoUnit.DAYS),
+        issueEndAt,
+        LocalDateTime.now().plusDays(12+i).truncatedTo(ChronoUnit.DAYS),
+        7, count, allowDuplicate);
+    DiscountPolicy policy = DiscountPolicy.of(
+        10000, amount, percent, maxDiscountAmount);
+    coupon.registerPolicy(policy);
+    return coupon;
   }
 }

--- a/coupon/src/test/java/table/eat/now/coupon/coupon/infrastructure/persistence/redis/RedisCouponIssueSpeedTest.java
+++ b/coupon/src/test/java/table/eat/now/coupon/coupon/infrastructure/persistence/redis/RedisCouponIssueSpeedTest.java
@@ -76,7 +76,7 @@ public class RedisCouponIssueSpeedTest extends IntegrationTestSupport {
     couponStore.setCouponSetWithTtl(coupon.getCouponUuid(), duration);
     couponStore.insertCouponCache(coupon.getCouponUuid(), coupon, cacheDuration);
 
-    sha = this.saveLua();
+    sha = this.saveLuaAngGetSha();
     simpleCouponIssueRedisScript = loadScript("redis/coupon/limited_nondup_test.lua", Long.class);
   }
 
@@ -227,7 +227,7 @@ public class RedisCouponIssueSpeedTest extends IntegrationTestSupport {
     }
   }
 
-  private String saveLua() throws IOException {
+  private String saveLuaAngGetSha() throws IOException {
 
     String path = "redis/coupon/limited_nondup_test.lua";
 
@@ -241,7 +241,7 @@ public class RedisCouponIssueSpeedTest extends IntegrationTestSupport {
     );
   }
 
-  private static <T> RedisScript<T> loadScript(String path, Class<T> resultType) {
+  private <T> RedisScript<T> loadScript(String path, Class<T> resultType) {
     DefaultRedisScript<T> script = new DefaultRedisScript<>();
     script.setScriptSource(new ResourceScriptSource(new ClassPathResource(path)));
     script.setResultType(resultType);

--- a/coupon/src/test/java/table/eat/now/coupon/helper/IntegrationTestSupport.java
+++ b/coupon/src/test/java/table/eat/now/coupon/helper/IntegrationTestSupport.java
@@ -1,5 +1,6 @@
 package table.eat.now.coupon.helper;
 
+import jakarta.persistence.EntityManager;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
@@ -31,6 +33,12 @@ public abstract class IntegrationTestSupport {
 
   @Autowired
   protected RedisTemplate<String, Object> redisTemplate;
+
+  @Autowired
+  protected StringRedisTemplate stringRedisTemplate;
+
+  @Autowired
+  protected EntityManager entityManager;
 
   @MockitoBean
   protected UserCouponSpringEventListener userCouponSpringEventListener;

--- a/coupon/src/test/java/table/eat/now/coupon/testdata/CouponTestDataSaver.java
+++ b/coupon/src/test/java/table/eat/now/coupon/testdata/CouponTestDataSaver.java
@@ -3,7 +3,6 @@ package table.eat.now.coupon.testdata;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,9 +13,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.util.ResourceUtils;
 import table.eat.now.coupon.coupon.application.utils.TimeProvider;
 import table.eat.now.coupon.coupon.domain.command.CouponCachingAndIndexing;
 import table.eat.now.coupon.coupon.domain.entity.Coupon;
@@ -49,7 +48,7 @@ public class CouponTestDataSaver extends IntegrationDataCreationSupport {
       int size = 10;
       List<Coupon> coupons = IntStream.range(0, size)
           .mapToObj(i -> CouponFixture.createHotCoupon(
-              i, "FIXED_DISCOUNT", "HOT", 1000000000, false,
+              i, "FIXED_DISCOUNT", 1000000000, false,
               10000, null, null)
           )
           .toList();
@@ -94,11 +93,9 @@ public class CouponTestDataSaver extends IntegrationDataCreationSupport {
   void saveLua() throws IOException {
 
     String path = "redis/coupon/limited_nondup.lua";
+    ClassPathResource resource = new ClassPathResource(path);
+    String luaScript = Files.readString(resource.getFile().toPath(), StandardCharsets.UTF_8);
 
-    String luaScript = new String(
-        Files.readAllBytes(Paths.get(ResourceUtils.getFile("classpath:" + path).toURI())),
-        StandardCharsets.UTF_8
-    );
     String sha = redisTemplate.execute((RedisCallback<String>) connection ->
       connection.scriptingCommands().scriptLoad(luaScript.getBytes(StandardCharsets.UTF_8))
     );


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #264

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 캐시 write back 디비 싱크 구현 및 테스트 코드
 
## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 쿠폰 캐시 데이터를 주기적으로 데이터베이스와 동기화하는 기능이 추가되었습니다.
  - 쿠폰 캐시 동기화 관련 스케줄러가 1분마다 실행됩니다.

- **버그 수정**
  - 쿠폰 발급 수량 및 버전 동기화 로직이 개선되었습니다.

- **개선사항**
  - 쿠폰 캐시 및 동기화 관련 성능과 일관성이 향상되었습니다.
  - 스케줄러 스레드풀 및 네이밍 설정이 추가되어 스케줄러 안정성이 강화되었습니다.
  - Kafka 컨슈머 지연 측정 및 메트릭 등록 방식이 개선되었습니다.

- **테스트**
  - 쿠폰 캐시 동기화, 쿠폰 업데이트 및 Redis 캐시 연동 관련 테스트가 추가 및 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->